### PR TITLE
Fix: Missing ui module on build

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,8 @@
     "sideEffects": false,
     "license": "Apache-2.0",
     "files": [
-        "dist/**"
+        "dist",
+        "src"
     ],
     "scripts": {
         "build": "tsup",

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,7 @@
             "outputs": [
                 ".next/**",
                 "!.next/cache/**",
-                "dist",
+                "dist/**",
                 "storybook-static/**"
             ]
         },


### PR DESCRIPTION
### Summary
I added the src to the files map beside the dist folder. It has been hard to replicate this intermittent error locally of not finding the module. I made it happen only once, but I forced my hand on the /ui/dist folder. 

Next build locally shared this link for possible causes: https://nextjs.org/docs/messages/module-not-found

After I added the mapping and pushed it, the Vercel build passed on the first try different from other PRs. It may be a false positive, if so, the next step would be to change the name of the ui script build to something else and separate the turbo task instead of relying only upon the "^" symbol.

The worst-case scenario would be if that is related to how PNPM works with the links it creates. Since the first thing that happens is `pnpm install` the node_modules will be created, and the @cartesi/rollups-explorer-ui inside as well, but the dist does not exist yet, then, when the `pnpm run build` goes through, my assumption is that these links are not being refreshed somehow.