### PR TITLE
Chore: Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature.md
+++ b/.github/ISSUE_TEMPLATE/1-feature.md
@@ -1,0 +1,26 @@
+---
+name: ✨ Feature request
+about: Template for requesting new features
+title: ""
+labels: ["Type: Feature", "Status: Needs triage"]
+assignees: ""
+---
+
+## 📄 Context
+
+What is the problem that you are trying to solve?
+Why is this problem relevant?
+
+## ✔️ Solution
+
+(This section and the ones below are optional.)
+What are the possible solutions?
+If there are multiple, what are the benefits and drawbacks of each one?
+
+## 📈 Subtasks
+
+- [ ] If there is a solution, what are the subtasks for completing this issue?
+
+## 🎯 Definition of Done
+
+- [ ] If there is a solution, what are the final deliverables?

--- a/.github/ISSUE_TEMPLATE/2-bug.md
+++ b/.github/ISSUE_TEMPLATE/2-bug.md
@@ -1,0 +1,31 @@
+---
+name: 🐛 Bug Report
+about: Template for bug report
+title: ""
+labels: ["Type: Bug", "Status: Needs triage"]
+assignees: ""
+---
+
+## 🙂 Expected behavior
+
+What is expected to happen?
+
+## 🫠 Actual behavior
+
+What is happening instead?
+
+## 🧪 Minimal test case
+
+Please describe a minimal test case that demonstrates the bug.
+If possible, this should be an automated test.
+
+## 🌎 Environment
+
+What is the network that the bug happens? e.g Mainnet / Sepolia / Local
+What is the Rollups and/or Rollups-squid version?
+
+## ✔️ Possible solutions
+
+(This section is optional.)
+Any hint on how to solve the issue?
+What parts of the code will be affected?

--- a/.github/ISSUE_TEMPLATE/3-documentation.md
+++ b/.github/ISSUE_TEMPLATE/3-documentation.md
@@ -1,0 +1,27 @@
+---
+name: "📖 Documentation issue"
+about: Help improve our docs.
+labels: ["Type: Documentation"]
+---
+
+### Documentation issue
+
+<!-- (Update "[ ]" to "[x]" to check a box) -->
+
+- [ ] Reporting a typo
+- [ ] Reporting a documentation bug
+- [ ] Documentation improvement
+- [ ] Documentation feedback
+
+<!--
+  If your issue is not regarding the documentation, please choose an issue type:
+  https://github.com/cartesi/rollups-explorer/issues/new/choose
+-->
+
+### Is there a specific documentation page you are reporting?
+
+Enter the URL or documentation section here.
+
+### Additional context or description
+
+Provide any additional details here as needed.

--- a/.github/ISSUE_TEMPLATE/4-technical-debt.md
+++ b/.github/ISSUE_TEMPLATE/4-technical-debt.md
@@ -1,0 +1,28 @@
+---
+name: 🏗️ Technical Debt
+about: Template for proposing solutions to technical debts
+title: ""
+labels: ["Type: Refactor"]
+assignees: ""
+---
+
+## 📄 Context
+
+What is the problem that you are trying to solve?
+Why is this problem relevant?
+How this problem afects the feature roadmap?
+Is it a blocker to implement a new feature?
+What parts of the architecture and/or code are affected?
+
+## ✔️ Solution
+
+What are the possible solutions?
+If there are multiple, what are the benefits and drawbacks of each one?
+
+## 📈 Subtasks
+
+- [ ] What are the subtasks for completing this issue?
+
+## 🎯 Definition of Done
+
+- [ ] What are the final deliverables?

--- a/.github/ISSUE_TEMPLATE/5-update-dependencies.md
+++ b/.github/ISSUE_TEMPLATE/5-update-dependencies.md
@@ -1,0 +1,20 @@
+---
+name: ⬆️ Update Dependencies
+about: Template for updating dependencies
+title: ""
+labels: ["Type: Chore"]
+assignees: ""
+---
+
+## 📄 Context
+
+Please provide a clean and concise description of what dependency/dependencies will be updated and the expected impacts.
+What are the dependency or dependencies to be updated?
+What are the parts of the code that will be affected by this action?
+Why is that update relevant?
+
+## 📈 Subtasks
+
+- [ ] If an update requires major work, create the corresponding issue.
+- [ ] Make sure dependencies are updated in the lock file (package-lock.json).
+- [ ] Verify whether everything is working as expected.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 🤔 Questions and Help
+      url: https://discord.gg/cartesi
+      about: This issue tracker is not for support questions. Please refer to the discord Cartesi Development Community server for help and discussion.

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,12 @@
 {
-    "tabWidth": 4
+    "tabWidth": 4,
+    "overrides": [
+        {
+            "files": "*.md",
+            "options": {
+                "tabWidth": 1,
+                "bracketSpacing": false
+            }
+        }
+    ]
 }


### PR DESCRIPTION
### Summary
Including a set of issue templates and config to be used in the repository. Also, override the prettier tab config for Markdown files.