### PR TITLE
Adding access to Applications page

### DIFF
--- a/apps/web/src/app/applications/page.tsx
+++ b/apps/web/src/app/applications/page.tsx
@@ -5,24 +5,24 @@ import {
     Breadcrumbs,
     Group,
     Loader,
-    Stack,
-    Table,
-    Title,
-    Tooltip,
     Pagination,
     Select,
+    Stack,
+    Table,
     Text,
+    Title,
+    Tooltip,
 } from "@mantine/core";
-import Link from "next/link";
-import { FC, useEffect, useState } from "react";
 import { useScrollIntoView } from "@mantine/hooks";
+import Link from "next/link";
 import { pathOr } from "ramda";
+import { FC, useEffect, useState } from "react";
+import { TbApps, TbInbox } from "react-icons/tb";
+import Address from "../../components/address";
 import {
     ApplicationOrderByInput,
     useApplicationsConnectionQuery,
 } from "../../graphql";
-import { TbApps, TbInbox } from "react-icons/tb";
-import Address from "../../components/address";
 import {
     limitBounds,
     usePaginationParams,
@@ -157,7 +157,7 @@ const ApplicationsPage: FC<ApplicationsPageProps> = (props) => {
                                 limitBounds[30].toString(),
                             ]}
                         />
-                        <Text>inputs</Text>
+                        <Text>Applications</Text>
                     </Group>
                     <Pagination
                         styles={{ root: { alignSelf: "flex-end" } }}

--- a/apps/web/src/app/shell.tsx
+++ b/apps/web/src/app/shell.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { ERC20DepositForm } from "@cartesi/rollups-explorer-ui";
 import {
     AppShell,
     Burger,
@@ -11,13 +12,12 @@ import {
     useMantineTheme,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { ReactNode, FC } from "react";
-import CartesiLogo from "../components/cartesiLogo";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { TbHome, TbMoonStars, TbPigMoney, TbSun } from "react-icons/tb";
 import Link from "next/link";
-import { ERC20DepositForm } from "@cartesi/rollups-explorer-ui";
+import { FC, ReactNode } from "react";
+import { TbApps, TbHome, TbMoonStars, TbPigMoney, TbSun } from "react-icons/tb";
 import { useAccount } from "wagmi";
+import CartesiLogo from "../components/cartesiLogo";
 import { useApplicationsQuery, useTokensQuery } from "../graphql";
 
 const Shell: FC<{ children: ReactNode }> = ({ children }) => {
@@ -67,6 +67,14 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
                                     leftSection={<TbHome />}
                                 >
                                     Home
+                                </Button>
+                            </Link>
+                            <Link href="/applications">
+                                <Button
+                                    variant="subtle"
+                                    leftSection={<TbApps />}
+                                >
+                                    Applications
                                 </Button>
                             </Link>
                             <Button


### PR DESCRIPTION
### Summary
Code changes to give access to the applications page from a link in the header rather than clicking an application followed by a click in the breadcrumb. Also, a change in the label for the number of items loaded in the list of applications from `inputs` to `applications`.


### Screenshots for visual reference

#### Header
![image](https://github.com/cartesi/rollups-explorer/assets/1239768/b5f099fa-d93b-4231-a978-3eefda725e1b)

#### Select label
![image](https://github.com/cartesi/rollups-explorer/assets/1239768/6fe2df4b-8912-4156-a03d-bc191c4eb774)
