### PR TITLE
Add alchemy-provider support.

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -2,3 +2,4 @@
 # CREATE YOUR OWN .env and use the following environment variables with values as fit
 #NEXT_PUBLIC_CHAIN_ID=1
 #NEXT_PUBLIC_EXPLORER_API_URL=YOUR_SQUID_API_HERE
+#NEXT_PUBLIC_ALCHEMY_API_KEY=YOUR_ALCHEMY_API_KEY

--- a/apps/web/src/providers/walletProvider.tsx
+++ b/apps/web/src/providers/walletProvider.tsx
@@ -15,21 +15,32 @@ import {
     ledgerWallet,
     trustWallet,
 } from "@rainbow-me/rainbowkit/wallets";
-import { configureChains, createConfig, WagmiConfig } from "wagmi";
-import { foundry, mainnet, sepolia } from "wagmi/chains";
-import { publicProvider } from "wagmi/providers/public";
-import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 import Image from "next/image";
+import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
+import {
+    ChainProviderFn,
+    WagmiConfig,
+    configureChains,
+    createConfig,
+} from "wagmi";
+import { foundry, mainnet, sepolia } from "wagmi/chains";
+import { alchemyProvider } from "wagmi/providers/alchemy";
+import { publicProvider } from "wagmi/providers/public";
 
 // select chain based on env var
 const chainId = parseInt(process.env.NEXT_PUBLIC_CHAIN_ID || "31337");
+const alchemyApiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
 const chain =
     [foundry, mainnet, sepolia].find((c) => c.id == chainId) || foundry;
+
+const providers: ChainProviderFn<typeof chain>[] = alchemyApiKey
+    ? [alchemyProvider({ apiKey: alchemyApiKey }), publicProvider()]
+    : [publicProvider()];
 
 // only 1 chain is enabled, based on env var
 const { chains, publicClient, webSocketPublicClient } = configureChains(
     [chain],
-    [publicProvider()],
+    providers,
 );
 
 const projectId = "a6265c875f8a7513ac7c52362abf434b";

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
     "globalEnv": [
         "BASE_PATH",
         "NEXT_PUBLIC_CHAIN_ID",
-        "NEXT_PUBLIC_EXPLORER_API_URL"
+        "NEXT_PUBLIC_EXPLORER_API_URL",
+        "NEXT_PUBLIC_ALCHEMY_API_KEY"
     ],
     "pipeline": {
         "build": {


### PR DESCRIPTION
### Summary
Code changes to support alchemy provider. When the `NEXT_PUBLIC_ALCHEMY_API_KEY` is available the `alchemyProvider()` builder function will be available. That does not remove the `publicProvider` from the list is just an addition. 