### PR TITLE
chore: Replace Subsquid API address.

### DIFF
--- a/apps/web/.env.mainnet
+++ b/apps/web/.env.mainnet
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_CHAIN_ID=1
-NEXT_PUBLIC_EXPLORER_API_URL="https://squid.subsquid.io/cartesi-rollups-mainnet/graphql"
+NEXT_PUBLIC_EXPLORER_API_URL="https://mainnet.api.cartesiscan.io/graphql"

--- a/apps/web/.env.sepolia
+++ b/apps/web/.env.sepolia
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_CHAIN_ID=11155111
-NEXT_PUBLIC_EXPLORER_API_URL="https://squid.subsquid.io/cartesi-rollups-sepolia/graphql"
+NEXT_PUBLIC_EXPLORER_API_URL="https://sepolia.api.cartesiscan.io/graphql"

--- a/apps/web/codegen.ts
+++ b/apps/web/codegen.ts
@@ -1,8 +1,6 @@
 import type { CodegenConfig } from "@graphql-codegen/cli";
 
-const schema = "https://squid.subsquid.io/cartesi-rollups-mainnet/graphql";
-// const schema = "https://squid.subsquid.io/cartesi-rollups-sepolia/graphql";
-// const schema = "http://127.0.0.1:4350/graphql";
+const schema = "https://mainnet.api.cartesiscan.io/graphql";
 
 const plugins = [
     {


### PR DESCRIPTION
### Summary
Replace the Subsquid service domain address in favour of our domain. We are not using the Subsquid aquarium service at the moment. So, at this point, any calls to that endpoint will fail.