### PR TITLE
67. Add responsiveness to the tables

### DIFF
--- a/apps/web/src/app/applications/[address]/page.tsx
+++ b/apps/web/src/app/applications/[address]/page.tsx
@@ -1,10 +1,10 @@
 import { Group, Stack, Title } from "@mantine/core";
-import { FC } from "react";
 import { Metadata } from "next";
+import { FC } from "react";
 import { TbInbox } from "react-icons/tb";
 import Address from "../../../components/address";
-import Inputs from "../../../components/inputs";
 import Breadcrumbs from "../../../components/breadcrumbs";
+import Inputs from "../../../components/inputs";
 
 export type ApplicationPageProps = {
     params: { address: string };

--- a/apps/web/src/components/inputRow.tsx
+++ b/apps/web/src/components/inputRow.tsx
@@ -9,8 +9,6 @@ import {
     Paper,
     Table,
     Text,
-    useMantineColorScheme,
-    useMantineTheme,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import prettyMilliseconds from "pretty-ms";
@@ -50,8 +48,6 @@ const InputRow: FC<InputRowProps> = ({
     timeType,
     keepDataColVisible,
 }) => {
-    const theme = useMantineTheme();
-    const { colorScheme } = useMantineColorScheme();
     const [opened, { toggle }] = useDisclosure(false);
     const from = input.msgSender as AddressType;
     const to = input.application.id as AddressType;
@@ -141,14 +137,11 @@ const InputRow: FC<InputRowProps> = ({
                     top={0}
                     right={0}
                     p={0}
-                    bg={theme.white}
                 >
                     <Paper
                         shadow={keepDataColVisible ? undefined : "xl"}
-                        style={{
-                            borderRadius: 0,
-                            padding: `var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-xs))`,
-                        }}
+                        radius={0}
+                        p="var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-xs))"
                     >
                         <ActionIcon variant="default" onClick={toggle}>
                             {opened ? <TbX /> : <TbFileText />}

--- a/apps/web/src/components/inputRow.tsx
+++ b/apps/web/src/components/inputRow.tsx
@@ -1,6 +1,17 @@
 "use client";
 import { erc20PortalAddress, etherPortalAddress } from "@cartesi/rollups-wagmi";
-import { ActionIcon, Badge, Collapse, Group, Table, Text } from "@mantine/core";
+import {
+    ActionIcon,
+    Badge,
+    Box,
+    Collapse,
+    Group,
+    Paper,
+    Table,
+    Text,
+    useMantineColorScheme,
+    useMantineTheme,
+} from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import prettyMilliseconds from "pretty-ms";
 import { FC } from "react";
@@ -13,6 +24,7 @@ import InputDetailsView from "./inputDetailsView";
 export type InputRowProps = {
     input: InputItemFragment;
     timeType: string;
+    keepDataColVisible: boolean;
 };
 
 export type MethodResolver = (
@@ -33,7 +45,14 @@ const methodResolver: MethodResolver = (input) => {
     return undefined;
 };
 
-const InputRow: FC<InputRowProps> = ({ input, timeType }) => {
+const InputRow: FC<InputRowProps> = ({
+    input,
+    timeType,
+    keepDataColVisible,
+}) => {
+    const theme = useMantineTheme();
+    const { colorScheme } = useMantineColorScheme();
+    const bgColor = colorScheme === "dark" ? theme.colors.dark[7] : theme.white;
     const [opened, { toggle }] = useDisclosure(false);
     const from = input.msgSender as AddressType;
     const to = input.application.id as AddressType;
@@ -61,55 +80,81 @@ const InputRow: FC<InputRowProps> = ({ input, timeType }) => {
             <Table.Tr>
                 <Table.Td>
                     {input.erc20Deposit ? (
-                        <Group>
-                            <Address
-                                value={input.erc20Deposit.from as AddressType}
-                                icon
-                                shorten
-                            />
-                            <TbArrowRight />
-                            <Address value={from} icon shorten />
-                        </Group>
+                        <Box style={{ minWidth: "max-content" }}>
+                            <Group>
+                                <Address
+                                    value={
+                                        input.erc20Deposit.from as AddressType
+                                    }
+                                    icon
+                                    shorten
+                                />
+                                <TbArrowRight />
+                                <Address value={from} icon shorten />
+                            </Group>
+                        </Box>
                     ) : (
                         <Address value={from} icon shorten />
                     )}
                 </Table.Td>
                 <Table.Td>
-                    <Group justify="right">
-                        {erc20Deposit(input)}
-                        <TbArrowRight />
-                    </Group>
+                    <Box style={{ minWidth: "max-content" }}>
+                        <Group justify="right">
+                            {erc20Deposit(input)}
+                            <TbArrowRight />
+                        </Group>
+                    </Box>
                 </Table.Td>
                 <Table.Td>
-                    <Address
-                        value={to}
-                        icon
-                        href={`/applications/${to}`}
-                        shorten
-                    />
+                    <Box style={{ minWidth: "320px" }}>
+                        <Address
+                            value={to}
+                            icon
+                            href={`/applications/${to}`}
+                            shorten
+                        />
+                    </Box>
                 </Table.Td>
                 <Table.Td>{method}</Table.Td>
                 <Table.Td>
                     <Text>{input.index}</Text>
                 </Table.Td>
                 <Table.Td>
-                    <Text>
-                        {timeType === "age"
-                            ? `${prettyMilliseconds(
-                                  Date.now() - input.timestamp * 1000,
-                                  {
-                                      unitCount: 2,
-                                      secondsDecimalDigits: 0,
-                                      verbose: true,
-                                  },
-                              )} ago`
-                            : new Date(input.timestamp * 1000).toISOString()}
-                    </Text>
+                    <Box style={{ minWidth: "max-content" }}>
+                        <Text>
+                            {timeType === "age"
+                                ? `${prettyMilliseconds(
+                                      Date.now() - input.timestamp * 1000,
+                                      {
+                                          unitCount: 2,
+                                          secondsDecimalDigits: 0,
+                                          verbose: true,
+                                      },
+                                  )} ago`
+                                : new Date(
+                                      input.timestamp * 1000,
+                                  ).toISOString()}
+                        </Text>
+                    </Box>
                 </Table.Td>
-                <Table.Td>
-                    <ActionIcon variant="default" onClick={toggle}>
-                        {opened ? <TbX /> : <TbFileText />}
-                    </ActionIcon>
+                <Table.Td
+                    pos={keepDataColVisible ? "initial" : "sticky"}
+                    top={0}
+                    right={0}
+                    bg={bgColor}
+                    p={keepDataColVisible ? theme.spacing.xs : 0}
+                >
+                    {keepDataColVisible ? (
+                        <ActionIcon variant="default" onClick={toggle}>
+                            {opened ? <TbX /> : <TbFileText />}
+                        </ActionIcon>
+                    ) : (
+                        <Paper shadow="xl" p={"lg"}>
+                            <ActionIcon variant="default" onClick={toggle}>
+                                {opened ? <TbX /> : <TbFileText />}
+                            </ActionIcon>
+                        </Paper>
+                    )}
                 </Table.Td>
             </Table.Tr>
             <Table.Tr></Table.Tr>

--- a/apps/web/src/components/inputRow.tsx
+++ b/apps/web/src/components/inputRow.tsx
@@ -52,7 +52,6 @@ const InputRow: FC<InputRowProps> = ({
 }) => {
     const theme = useMantineTheme();
     const { colorScheme } = useMantineColorScheme();
-    const bgColor = colorScheme === "dark" ? theme.colors.dark[7] : theme.white;
     const [opened, { toggle }] = useDisclosure(false);
     const from = input.msgSender as AddressType;
     const to = input.application.id as AddressType;
@@ -141,20 +140,20 @@ const InputRow: FC<InputRowProps> = ({
                     pos={keepDataColVisible ? "initial" : "sticky"}
                     top={0}
                     right={0}
-                    bg={bgColor}
-                    p={keepDataColVisible ? theme.spacing.xs : 0}
+                    p={0}
+                    bg={theme.white}
                 >
-                    {keepDataColVisible ? (
+                    <Paper
+                        shadow={keepDataColVisible ? undefined : "xl"}
+                        style={{
+                            borderRadius: 0,
+                            padding: `var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-xs))`,
+                        }}
+                    >
                         <ActionIcon variant="default" onClick={toggle}>
                             {opened ? <TbX /> : <TbFileText />}
                         </ActionIcon>
-                    ) : (
-                        <Paper shadow="xl" p={"lg"}>
-                            <ActionIcon variant="default" onClick={toggle}>
-                                {opened ? <TbX /> : <TbFileText />}
-                            </ActionIcon>
-                        </Paper>
-                    )}
+                    </Paper>
                 </Table.Td>
             </Table.Tr>
             <Table.Tr></Table.Tr>

--- a/apps/web/src/components/inputRow.tsx
+++ b/apps/web/src/components/inputRow.tsx
@@ -79,8 +79,8 @@ const InputRow: FC<InputRowProps> = ({
         <>
             <Table.Tr>
                 <Table.Td>
-                    {input.erc20Deposit ? (
-                        <Box style={{ minWidth: "max-content" }}>
+                    <Box style={{ minWidth: "max-content" }}>
+                        {input.erc20Deposit ? (
                             <Group>
                                 <Address
                                     value={
@@ -92,10 +92,10 @@ const InputRow: FC<InputRowProps> = ({
                                 <TbArrowRight />
                                 <Address value={from} icon shorten />
                             </Group>
-                        </Box>
-                    ) : (
-                        <Address value={from} icon shorten />
-                    )}
+                        ) : (
+                            <Address value={from} icon shorten />
+                        )}
+                    </Box>
                 </Table.Td>
                 <Table.Td>
                     <Box style={{ minWidth: "max-content" }}>
@@ -106,7 +106,7 @@ const InputRow: FC<InputRowProps> = ({
                     </Box>
                 </Table.Td>
                 <Table.Td>
-                    <Box style={{ minWidth: "320px" }}>
+                    <Box style={{ minWidth: "max-content" }}>
                         <Address
                             value={to}
                             icon

--- a/apps/web/src/components/inputsTable.tsx
+++ b/apps/web/src/components/inputsTable.tsx
@@ -3,13 +3,14 @@ import {
     Button,
     Loader,
     Table,
+    Transition,
     useMantineColorScheme,
     useMantineTheme,
 } from "@mantine/core";
-import { useIntersection } from "@mantine/hooks";
 import { FC, useCallback, useRef, useState } from "react";
 import InputRow from "../components/inputRow";
 import type { InputItemFragment } from "../graphql";
+import { useElementVisibility } from "../hooks/useElementVisibility";
 import { TableResponsiveWrapper } from "./tableResponsiveWrapper";
 
 export interface InputsTableProps {
@@ -31,12 +32,9 @@ const InputsTable: FC<InputsTableProps> = ({
         setTimeType((timeType) => (timeType === "age" ? "timestamp" : "age"));
     }, []);
     const tableRowRef = useRef<HTMLDivElement>(null);
-    const { ref, entry } = useIntersection({
-        root: tableRowRef.current,
-        rootMargin: "20px",
-        threshold: 0.5,
+    const { childrenRef, isVisible } = useElementVisibility({
+        element: tableRowRef,
     });
-    const isVisible = (entry?.intersectionRatio ?? 10) < 0.5;
 
     return (
         <TableResponsiveWrapper ref={tableRowRef}>
@@ -57,13 +55,29 @@ const InputsTable: FC<InputsTableProps> = ({
                                 {timeType === "age" ? "Age" : "Timestamp (UTC)"}
                             </Button>
                         </Table.Th>
-                        <Table.Th ref={ref}>Data</Table.Th>
-                        <Table.Th>
-                            <Button>
-                                {timeType === "age" ? "Age" : "Timestamp (UTC)"}
-                            </Button>
-                        </Table.Th>
-                        <Table.Th>Data</Table.Th>
+                        <Table.Th ref={childrenRef}>Data</Table.Th>
+                        <Transition
+                            mounted={isVisible}
+                            transition="scale-x"
+                            duration={500}
+                            timingFunction="ease-out"
+                        >
+                            {(styles) => (
+                                <th
+                                    style={{
+                                        ...styles,
+                                        position: "sticky",
+                                        top: 0,
+                                        right: 0,
+                                        backgroundColor: bgColor,
+                                        padding:
+                                            "var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-lg))",
+                                    }}
+                                >
+                                    Data
+                                </th>
+                            )}
+                        </Transition>
                     </Table.Tr>
                 </Table.Thead>
                 <Table.Tbody>

--- a/apps/web/src/components/inputsTable.tsx
+++ b/apps/web/src/components/inputsTable.tsx
@@ -1,8 +1,16 @@
 "use client";
-import { Button, Loader, Table } from "@mantine/core";
-import { FC, useCallback, useState } from "react";
+import {
+    Button,
+    Loader,
+    Table,
+    useMantineColorScheme,
+    useMantineTheme,
+} from "@mantine/core";
+import { useIntersection } from "@mantine/hooks";
+import { FC, useCallback, useRef, useState } from "react";
 import InputRow from "../components/inputRow";
 import type { InputItemFragment } from "../graphql";
+import { TableResponsiveWrapper } from "./tableResponsiveWrapper";
 
 export interface InputsTableProps {
     inputs: InputItemFragment[];
@@ -16,57 +24,75 @@ const InputsTable: FC<InputsTableProps> = ({
     totalCount,
 }) => {
     const [timeType, setTimeType] = useState("age");
-
+    const theme = useMantineTheme();
+    const { colorScheme } = useMantineColorScheme();
+    const bgColor = colorScheme === "dark" ? theme.colors.dark[7] : theme.white;
     const onChangeTimeColumnType = useCallback(() => {
         setTimeType((timeType) => (timeType === "age" ? "timestamp" : "age"));
     }, []);
+    const tableRowRef = useRef<HTMLDivElement>(null);
+    const { ref, entry } = useIntersection({
+        root: tableRowRef.current,
+        rootMargin: "20px",
+        threshold: 0.5,
+    });
+    const isVisible = (entry?.intersectionRatio ?? 10) < 0.5;
 
     return (
-        <Table>
-            <Table.Thead>
-                <Table.Tr>
-                    <Table.Th>From</Table.Th>
-                    <Table.Th></Table.Th>
-                    <Table.Th>To</Table.Th>
-                    <Table.Th>Method</Table.Th>
-                    <Table.Th>Index</Table.Th>
-                    <Table.Th>
-                        <Button
-                            variant="transparent"
-                            px={0}
-                            onClick={onChangeTimeColumnType}
-                        >
-                            {timeType === "age" ? "Age" : "Timestamp (UTC)"}
-                        </Button>
-                    </Table.Th>
-                    <Table.Th>Data</Table.Th>
-                </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-                {fetching ? (
+        <TableResponsiveWrapper ref={tableRowRef}>
+            <Table width={"100%"} style={{ borderCollapse: "collapse" }}>
+                <Table.Thead>
                     <Table.Tr>
-                        <Table.Td align="center" colSpan={7}>
-                            <Loader data-testid="inputs-table-spinner" />
-                        </Table.Td>
+                        <Table.Th>From</Table.Th>
+                        <Table.Th></Table.Th>
+                        <Table.Th>To</Table.Th>
+                        <Table.Th>Method</Table.Th>
+                        <Table.Th>Index</Table.Th>
+                        <Table.Th>
+                            <Button
+                                variant="transparent"
+                                px={0}
+                                onClick={onChangeTimeColumnType}
+                            >
+                                {timeType === "age" ? "Age" : "Timestamp (UTC)"}
+                            </Button>
+                        </Table.Th>
+                        <Table.Th ref={ref}>Data</Table.Th>
+                        <Table.Th>
+                            <Button>
+                                {timeType === "age" ? "Age" : "Timestamp (UTC)"}
+                            </Button>
+                        </Table.Th>
+                        <Table.Th>Data</Table.Th>
                     </Table.Tr>
-                ) : (
-                    totalCount === 0 && (
+                </Table.Thead>
+                <Table.Tbody>
+                    {fetching ? (
                         <Table.Tr>
-                            <Table.Td colSpan={3} align="center">
-                                No inputs
+                            <Table.Td align="center" colSpan={7}>
+                                <Loader data-testid="inputs-table-spinner" />
                             </Table.Td>
                         </Table.Tr>
-                    )
-                )}
-                {inputs.map((input) => (
-                    <InputRow
-                        key={input.id}
-                        input={input}
-                        timeType={timeType}
-                    />
-                ))}
-            </Table.Tbody>
-        </Table>
+                    ) : (
+                        totalCount === 0 && (
+                            <Table.Tr>
+                                <Table.Td colSpan={3} align="center">
+                                    No inputs
+                                </Table.Td>
+                            </Table.Tr>
+                        )
+                    )}
+                    {inputs.map((input) => (
+                        <InputRow
+                            key={input.id}
+                            input={input}
+                            timeType={timeType}
+                            keepDataColVisible={!isVisible}
+                        />
+                    ))}
+                </Table.Tbody>
+            </Table>
+        </TableResponsiveWrapper>
     );
 };
 

--- a/apps/web/src/components/tableResponsiveWrapper.tsx
+++ b/apps/web/src/components/tableResponsiveWrapper.tsx
@@ -1,0 +1,26 @@
+import { Box, Flex } from "@mantine/core";
+import { forwardRef } from "react";
+type TableResponsiveWrapperProps = {
+    children: React.ReactNode;
+};
+
+type Ref = HTMLDivElement;
+const Component = (props: any, ref: any) => {
+    const { children, ...restProps } = props;
+    return (
+        <Flex w="100%" align={"center"} direction={"column"}>
+            <Flex w="100%" align={"center"} direction={"column"}>
+                <Box style={{ position: "relative", width: "100%" }} ref={ref}>
+                    <Box style={{ overflowX: "auto", width: "100%" }}>
+                        {children}
+                    </Box>
+                </Box>
+            </Flex>
+        </Flex>
+    );
+};
+
+export const TableResponsiveWrapper = forwardRef<
+    Ref,
+    TableResponsiveWrapperProps
+>(Component);

--- a/apps/web/src/hooks/useElementVisibility.tsx
+++ b/apps/web/src/hooks/useElementVisibility.tsx
@@ -1,0 +1,17 @@
+import { useIntersection } from "@mantine/hooks";
+type UseElementVisibilityParamsProps<T extends Element> = {
+    element: React.RefObject<T>;
+    threshold?: number;
+};
+
+export const useElementVisibility = <T extends Element>({
+    element,
+    threshold = 0.5,
+}: UseElementVisibilityParamsProps<T>) => {
+    const { ref: childrenRef, entry } = useIntersection({
+        root: element.current,
+        threshold,
+    });
+    const isVisible = (entry?.intersectionRatio ?? 1) < threshold;
+    return { childrenRef, isVisible };
+};

--- a/apps/web/src/hooks/useElementVisibility.tsx
+++ b/apps/web/src/hooks/useElementVisibility.tsx
@@ -1,4 +1,5 @@
 import { useIntersection } from "@mantine/hooks";
+import { useMemo } from "react";
 type UseElementVisibilityParamsProps<T extends Element> = {
     element: React.RefObject<T>;
     threshold?: number;
@@ -13,5 +14,8 @@ export const useElementVisibility = <T extends Element>({
         threshold,
     });
     const isVisible = (entry?.intersectionRatio ?? 1) < threshold;
-    return { childrenRef, isVisible };
+    return useMemo(
+        () => ({ childrenRef, isVisible }),
+        [childrenRef, isVisible],
+    );
 };

--- a/apps/web/test/components/inputsTable.test.tsx
+++ b/apps/web/test/components/inputsTable.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it } from "vitest";
 import InputsTable, {
     InputsTableProps,
 } from "../../src/components/inputsTable";
@@ -26,7 +26,14 @@ const defaultProps: InputsTableProps = {
     fetching: false,
     totalCount: 1,
 };
+const IntersectionObserverMock = vi.fn(() => ({
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    takeRecords: vi.fn(),
+    unobserve: vi.fn(),
+}));
 
+vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
 describe("InputsTable component", () => {
     it("should display time column with age label", () => {
         render(<Component {...defaultProps} />);

--- a/apps/web/test/hooks/useElementVisibility.test.tsx
+++ b/apps/web/test/hooks/useElementVisibility.test.tsx
@@ -1,0 +1,60 @@
+import { useIntersection } from "@mantine/hooks";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useElementVisibility } from "../../src/hooks/useElementVisibility";
+
+// Mock @mantine/hooks
+vi.mock("@mantine/hooks", async () => {
+    const actual = await vi.importActual("@mantine/hooks");
+    return {
+        ...(actual as any),
+        useIntersection: vi.fn(),
+    };
+});
+
+const mockUseIntersection = vi.mocked(useIntersection);
+describe("useElementVisibility", () => {
+    it("should return isVisible as true when intersection ratio is below threshold", () => {
+        const element = { current: document.createElement("div") };
+        mockUseIntersection.mockReturnValue({
+            ref: vi.fn(),
+            entry: {
+                boundingClientRect: new DOMRect(),
+                intersectionRatio: 0.4,
+                intersectionRect: new DOMRect(),
+                isIntersecting: true,
+                rootBounds: new DOMRect(),
+                target: document.createElement("div"),
+                time: Date.now(),
+            },
+        });
+
+        const { result } = renderHook(() =>
+            useElementVisibility({ element, threshold: 0.5 }),
+        );
+
+        expect(result.current.isVisible).toBe(true);
+    });
+
+    it("should return isVisible as false when intersection ratio is above threshold", () => {
+        const element = { current: document.createElement("div") };
+        mockUseIntersection.mockReturnValue({
+            ref: vi.fn(),
+            entry: {
+                boundingClientRect: new DOMRect(),
+                intersectionRatio: 0.6,
+                intersectionRect: new DOMRect(),
+                isIntersecting: true,
+                rootBounds: new DOMRect(),
+                target: document.createElement("div"),
+                time: Date.now(),
+            },
+        });
+
+        const { result } = renderHook(() =>
+            useElementVisibility({ element, threshold: 0.5 }),
+        );
+
+        expect(result.current.isVisible).toBe(false);
+    });
+});


### PR DESCRIPTION
This PR introduces:

1. **Responsive Table Wrapper Component:** A new component to make tables have overflow between screen sizes.
2. **Wrapper Integration:** Applied the wrapper to our InputsTable component for enhanced responsiveness.
3. **`use-intersection` from Mantine:** Implemented this hook for better display visibility of our tables.

These changes aim to improve UI responsiveness and user experience.

Closing #67 