### PR TITLE
Feature: Close menu after clicking link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
-        "source.fixAll": true,
-        "source.organizeImports": true
+        "source.fixAll": "explicit",
+        "source.organizeImports": "explicit"
     },
     "typescript.tsdk": "node_modules/typescript/lib",
     "[terraform]": {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,10 +1,10 @@
+import { ColorSchemeScript } from "@mantine/core";
 import "@mantine/core/styles.css";
 import "@mantine/notifications/styles.css";
-import type { FC, ReactNode } from "react";
 import { Metadata } from "next";
-import { ColorSchemeScript } from "@mantine/core";
+import dynamic from "next/dynamic";
+import type { FC, ReactNode } from "react";
 import { Providers } from "../providers/providers";
-import Shell from "../components/layout/shell";
 
 export const metadata: Metadata = {
     title: {
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     },
 };
 
+const Shell = dynamic(() => import("../components/layout/shell"), {
+    ssr: false,
+});
 interface LayoutProps {
     children: ReactNode;
 }

--- a/apps/web/src/components/layout/shell.tsx
+++ b/apps/web/src/components/layout/shell.tsx
@@ -52,6 +52,7 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
     const { isConnected } = useAccount();
     const { colorScheme, toggleColorScheme } = useMantineColorScheme();
     const themeDefaultProps = theme.components?.AppShell?.defaultProps ?? {};
+
     return (
         <AppShell
             header={themeDefaultProps.header}
@@ -137,12 +138,14 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
                         label="Home"
                         href="/"
                         leftSection={<TbHome />}
+                        onClick={toggle}
                         data-testid="home-link"
                     />
 
                     <NavLink
                         component={Link}
                         label="Applications"
+                        onClick={toggle}
                         href="/applications"
                         leftSection={<TbApps />}
                         data-testid="applications-link"
@@ -151,6 +154,7 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
                     <NavLink
                         component={Link}
                         label="Inputs"
+                        onClick={toggle}
                         href="/inputs"
                         leftSection={<TbInbox />}
                         data-testid="inputs-link"
@@ -160,7 +164,6 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
                         label="Send Transaction"
                         leftSection={<TbArrowsDownUp />}
                         disabled={!isConnected}
-                        opened={isConnected && transaction}
                         onClick={toggleTransaction}
                         hiddenFrom="sm"
                     />


### PR DESCRIPTION
### Summary
Code changes to close the mobile menu when clicking one of the links [`inputs`, `applications`, `home`] so the user have a feedback that the navigation happen. Also, changes to fix a bug that causes the send-transaction to not be enabled when entering the application with a wallet connected (only in dark-mode gif below). Ps: that also affected the menu for small devices, the send-tx would continue to be disabled even though there is an account connected.



### Results
<details>
<summary><h3>Before Fix</h3> </summary>

![send-tx-disabled-on-dark-mode](https://github.com/cartesi/rollups-explorer/assets/1239768/a022c045-14f4-45a0-9024-ba5314bc7c32)

</details>

<details>
<summary><h3>After Fix</h3> </summary>

![fix-send-tx-on-dark-mode](https://github.com/cartesi/rollups-explorer/assets/1239768/ba16bb35-9223-4380-90cd-0644fa542dbe)

</details>




