### PR TITLE
Fix: Mock type for @cartesi/rollups-wagmi on InputDetailsView test file

### DIFF
--- a/apps/web/test/components/inputs/inputDetailsView.test.tsx
+++ b/apps/web/test/components/inputs/inputDetailsView.test.tsx
@@ -1,3 +1,4 @@
+import * as RollupsWagmi from "@cartesi/rollups-wagmi";
 import {
     cleanup,
     fireEvent,
@@ -7,8 +8,8 @@ import {
 } from "@testing-library/react";
 import { useQuery } from "urql";
 import { Address } from "viem";
-import { useAccount, useWaitForTransaction } from "wagmi";
 import { afterEach, beforeEach, describe, it } from "vitest";
+import { useAccount, useWaitForTransaction } from "wagmi";
 import InputDetailsView from "../../../src/components/inputs/inputDetailsView";
 import { useConnectionConfig } from "../../../src/providers/connectionConfig/hooks";
 import withMantineTheme from "../../utils/WithMantineTheme";
@@ -23,7 +24,12 @@ import { queryMockImplBuilder } from "../../utils/useQueryMock";
 vi.mock("../../../src/providers/connectionConfig/hooks");
 vi.mock("urql");
 vi.mock("@cartesi/rollups-wagmi", async () => {
+    const actual = await vi.importActual<typeof RollupsWagmi>(
+        "@cartesi/rollups-wagmi",
+    );
+
     return {
+        ...actual,
         useCartesiDAppWasVoucherExecuted: () => ({
             data: {},
         }),


### PR DESCRIPTION
### Summary
Fixing build failure due to a missing mock on Vitest after merging voucher execution PR. It was a bit behind compared with the main, and the addition of ERC-721 was not a problem until the merge & squash was done. No real damage on Vercel deployments, only the Github action that failed.