### PR TITLE
#149 Upgrade @cartesi/rollups package

### DIFF
--- a/packages/rollups-wagmi/package.json
+++ b/packages/rollups-wagmi/package.json
@@ -29,7 +29,7 @@
         "wagmi": "^2"
     },
     "devDependencies": {
-        "@cartesi/rollups": "^1.0",
+        "@cartesi/rollups": "^1.2.0",
         "@cartesi/tsconfig": "*",
         "@sunodo/wagmi-plugin-hardhat-deploy": "^0.3",
         "@types/react": "^18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,18 +1250,18 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cartesi/rollups@^1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@cartesi/rollups/-/rollups-1.1.0.tgz#706935c827f96f20abee5b73c428e7cde8e2f1b8"
-  integrity sha512-JRe56V8jIQkRaVmmj1wwG+iQ9Xhsn1B38+L/zZHUvyvSW4mAsyXlm2kPWhaK4rP83I9UgKzBrV42e2yAc3S+8A==
+"@cartesi/rollups@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@cartesi/rollups/-/rollups-1.2.0.tgz#522a5e0c6c4b32a643f00dbcfc06d12b2b2f7a7f"
+  integrity sha512-oLm/JYuRpUD6bg8UKFZjdSJRZ1CWOd5SM6xnjvRKMisGZcJzULYHuuzZMSMONpnFVQhFXrwJF4q0tzcOAK4oDw==
   dependencies:
-    "@cartesi/util" "6.0.0"
+    "@cartesi/util" "6.1.0"
     "@openzeppelin/contracts" "4.9.2"
 
-"@cartesi/util@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@cartesi/util/-/util-6.0.0.tgz#e24d39859a369e14d19b8348d53bf3b0857ff42f"
-  integrity sha512-n5+jFRI60HOp6xOd0IDtQU/2eh/u2uojxB1xVoTHi9Qu8EXWLeCT3s3+2bsBevk1duDFtAiqQeTT8g7dcj9+7g==
+"@cartesi/util@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@cartesi/util/-/util-6.1.0.tgz#45f4a55b09b89e8dab506b5c31e6c2424fad0711"
+  integrity sha512-j92nSoMHCyu6h7nZgn+MeXjkp8oa1Cy6qaImyxVXmPN2Rcqzl/TkWm/RkhbODU9rh4U3OuUteYqKRjefI3/XIQ==
 
 "@changesets/apply-release-plan@^7.0.0":
   version "7.0.0"


### PR DESCRIPTION
I upgraded `@cartesi/rollups` package to `1.2`. The wagmi code generated worked as expected afterwards. I also tested all transaction forms and they worked ok so no regressions found.