### PR TITLE
#153 Add application summary

### DIFF
--- a/apps/web/src/app/applications/[address]/inputs/page.tsx
+++ b/apps/web/src/app/applications/[address]/inputs/page.tsx
@@ -2,7 +2,7 @@ import { Group, Stack, Title } from "@mantine/core";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { FC } from "react";
-import { TbInbox } from "react-icons/tb";
+import { TbStack2 } from "react-icons/tb";
 import { Address as AddressType } from "viem";
 import Address from "../../../../components/address";
 import Breadcrumbs from "../../../../components/breadcrumbs";

--- a/apps/web/src/app/applications/[address]/inputs/page.tsx
+++ b/apps/web/src/app/applications/[address]/inputs/page.tsx
@@ -2,7 +2,7 @@ import { Group, Stack, Text, Title } from "@mantine/core";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { FC } from "react";
-import { TbStack2 } from "react-icons/tb";
+import { TbInbox } from "react-icons/tb";
 import { Address as AddressType } from "viem";
 import Address from "../../../../components/address";
 import Breadcrumbs from "../../../../components/breadcrumbs";
@@ -69,7 +69,7 @@ const ApplicationInputsPage: FC<ApplicationInputsPageProps> = async ({
             </Breadcrumbs>
 
             <Group>
-                <TbStack2 size={40} />
+                <TbInbox size={40} />
                 <Title order={2}>Inputs</Title>
             </Group>
 

--- a/apps/web/src/app/applications/[address]/inputs/page.tsx
+++ b/apps/web/src/app/applications/[address]/inputs/page.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack, Title } from "@mantine/core";
+import { Group, Stack, Text, Title } from "@mantine/core";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { FC } from "react";
@@ -61,11 +61,15 @@ const ApplicationInputsPage: FC<ApplicationInputsPageProps> = async ({
                     },
                 ]}
             >
-                <Address value={params.address as AddressType} icon />
+                <Address
+                    value={params.address as AddressType}
+                    href={`/applications/${params.address}`}
+                />
+                <Text>Inputs</Text>
             </Breadcrumbs>
 
             <Group>
-                <TbInbox size={40} />
+                <TbStack2 size={40} />
                 <Title order={2}>Inputs</Title>
             </Group>
 

--- a/apps/web/src/app/applications/[address]/page.tsx
+++ b/apps/web/src/app/applications/[address]/page.tsx
@@ -1,0 +1,75 @@
+import { Group, Stack, Title } from "@mantine/core";
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { FC } from "react";
+import { TbStack2 } from "react-icons/tb";
+import { Address as AddressType } from "viem";
+import Address from "../../../components/address";
+import Breadcrumbs from "../../../components/breadcrumbs";
+import ApplicationSummary from "../../../components/applications/applicationSummary";
+import {
+    ApplicationByIdDocument,
+    ApplicationByIdQuery,
+    ApplicationByIdQueryVariables,
+} from "../../../graphql/explorer/operations";
+import { getUrqlServerClient } from "../../../lib/urql";
+
+export async function generateMetadata({
+    params,
+}: ApplicationPageProps): Promise<Metadata> {
+    return {
+        title: `Application ${params.address}`,
+    };
+}
+
+async function getApplication(address: string) {
+    const client = getUrqlServerClient();
+    const result = await client.query<
+        ApplicationByIdQuery,
+        ApplicationByIdQueryVariables
+    >(ApplicationByIdDocument, {
+        id: address.toLowerCase(),
+    });
+
+    return result.data?.applicationById;
+}
+
+export type ApplicationPageProps = {
+    params: { address: string };
+};
+
+const ApplicationPage: FC<ApplicationPageProps> = async ({ params }) => {
+    const application = await getApplication(params.address);
+
+    if (!application) {
+        notFound();
+    }
+
+    return (
+        <Stack>
+            <Breadcrumbs
+                breadcrumbs={[
+                    {
+                        href: "/",
+                        label: "Home",
+                    },
+                    {
+                        href: "/applications",
+                        label: "Applications",
+                    },
+                ]}
+            >
+                <Address value={params.address as AddressType} icon />
+            </Breadcrumbs>
+
+            <Group>
+                <TbStack2 size={40} />
+                <Title order={2}>Summary</Title>
+            </Group>
+
+            <ApplicationSummary applicationId={params.address} />
+        </Stack>
+    );
+};
+
+export default ApplicationPage;

--- a/apps/web/src/components/applications/applicationSummary.tsx
+++ b/apps/web/src/components/applications/applicationSummary.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import {
+    Button,
+    Card,
+    Flex,
+    Grid,
+    Group,
+    Skeleton,
+    Stack,
+    Text,
+    useMantineTheme,
+} from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+import React, { FC, useMemo } from "react";
+import { SummaryCard } from "@cartesi/rollups-explorer-ui";
+import {
+    TbAlertTriangle,
+    TbInbox,
+    TbReportAnalytics,
+    TbTicket,
+} from "react-icons/tb";
+import { useInputsConnectionQuery } from "../../graphql/explorer/hooks/queries";
+import { InputOrderByInput } from "../../graphql/explorer/types";
+import { useConnectionConfig } from "../../providers/connectionConfig/hooks";
+import { Address } from "viem";
+import { useQuery } from "urql";
+import {
+    CheckStatusDocument,
+    CheckStatusQuery,
+    CheckStatusQueryVariables,
+} from "../../graphql/rollups/operations";
+import Link from "next/link";
+import LatestInputsTable from "./latestInputsTable";
+
+interface ConnectionInfoProps {
+    url: string;
+}
+
+const SummarySkeletonCard = () => (
+    <Card shadow="xs" w="100%">
+        <Skeleton animate={false} height={20} circle mb={18} />
+        <Skeleton animate={false} height={8} radius="xl" />
+        <Skeleton animate={false} height={8} mt={6} radius="xl" />
+        <Skeleton animate={false} height={8} mt={6} width="70%" radius="xl" />
+    </Card>
+);
+
+const ConnectionInfo: FC<ConnectionInfoProps> = ({ url }) => {
+    const [result] = useQuery<CheckStatusQuery, CheckStatusQueryVariables>({
+        query: CheckStatusDocument,
+        context: useMemo(
+            () => ({
+                url,
+                requestPolicy: "network-only",
+            }),
+            [url],
+        ),
+    });
+
+    return (
+        <>
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+                <SummaryCard
+                    title="Notices"
+                    value={result.data?.notices.totalCount ?? 0}
+                    icon={TbAlertTriangle}
+                />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+                <SummaryCard
+                    title="Vouchers"
+                    value={result.data?.vouchers.totalCount ?? 0}
+                    icon={TbTicket}
+                />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+                <SummaryCard
+                    title="Reports"
+                    value={result.data?.reports.totalCount ?? 0}
+                    icon={TbReportAnalytics}
+                />
+            </Grid.Col>
+        </>
+    );
+};
+
+export type ApplicationSummaryProps = {
+    applicationId: string;
+};
+
+const ApplicationSummary: FC<ApplicationSummaryProps> = ({ applicationId }) => {
+    const [{ data, fetching }] = useInputsConnectionQuery({
+        variables: {
+            orderBy: InputOrderByInput.TimestampDesc,
+            limit: 6,
+        },
+    });
+    const inputs = data?.inputsConnection.edges.map((edge) => edge.node) ?? [];
+    const { getConnection, hasConnection, showConnectionModal } =
+        useConnectionConfig();
+    const connection = getConnection(applicationId as Address);
+    const isAppConnected = hasConnection(applicationId as Address);
+    const theme = useMantineTheme();
+    const isSmallDevice = useMediaQuery(`(max-width:${theme.breakpoints.sm})`);
+
+    return (
+        <Stack>
+            <Grid gutter="sm">
+                <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+                    <SummaryCard
+                        title="Inputs"
+                        value={data?.inputsConnection?.totalCount ?? 0}
+                        icon={TbInbox}
+                    />
+                </Grid.Col>
+
+                {isAppConnected ? (
+                    <ConnectionInfo url={connection?.url as string} />
+                ) : (
+                    <Grid.Col span={{ base: 12, sm: 6, md: 9 }} mb="sm">
+                        <Flex m={0} p={0} gap="sm" w="100%">
+                            <SummarySkeletonCard />
+                            <SummarySkeletonCard />
+                            <SummarySkeletonCard />
+                        </Flex>
+                    </Grid.Col>
+                )}
+
+                {!isAppConnected && (
+                    <Flex justify="center" w="100%">
+                        <Button
+                            variant="light"
+                            radius="md"
+                            tt="uppercase"
+                            mx={6}
+                            fullWidth={isSmallDevice}
+                            onClick={() =>
+                                showConnectionModal(applicationId as Address)
+                            }
+                        >
+                            Add connection
+                        </Button>
+                    </Flex>
+                )}
+
+                <Card w="100%" h="100%" mt="md" mx={6}>
+                    <Group gap={5} align="center">
+                        <TbInbox size={20} />
+                        <Text c="dimmed" lh={1}>
+                            Latest inputs
+                        </Text>
+                    </Group>
+
+                    <Group gap={5}>
+                        <LatestInputsTable
+                            inputs={inputs}
+                            fetching={fetching}
+                            totalCount={data?.inputsConnection.totalCount ?? 0}
+                        />
+                    </Group>
+
+                    <Group gap={5} mt="auto">
+                        <Button
+                            component={Link}
+                            href={`/applications/${applicationId}/inputs`}
+                            variant="light"
+                            fullWidth={isSmallDevice}
+                            mt="md"
+                            mx="auto"
+                            radius="md"
+                            tt="uppercase"
+                        >
+                            View inputs
+                        </Button>
+                    </Group>
+                </Card>
+            </Grid>
+        </Stack>
+    );
+};
+
+export default ApplicationSummary;

--- a/apps/web/src/components/applications/applicationSummary.tsx
+++ b/apps/web/src/components/applications/applicationSummary.tsx
@@ -41,6 +41,9 @@ const ApplicationSummary: FC<ApplicationSummaryProps> = ({ applicationId }) => {
         variables: {
             orderBy: InputOrderByInput.TimestampDesc,
             limit: 6,
+            where: {
+                id_startsWith: applicationId,
+            },
         },
     });
     const inputs = data?.inputsConnection.edges.map((edge) => edge.node) ?? [];

--- a/apps/web/src/components/applications/applicationSummary.tsx
+++ b/apps/web/src/components/applications/applicationSummary.tsx
@@ -128,7 +128,7 @@ const ApplicationSummary: FC<ApplicationSummaryProps> = ({ applicationId }) => {
                 )}
 
                 {!isAppConnected && (
-                    <Flex justify="center" w="100%">
+                    <Flex justify="center" w="100%" mb="1.5rem">
                         <Button
                             variant="light"
                             radius="md"

--- a/apps/web/src/components/applications/applicationSummary.tsx
+++ b/apps/web/src/components/applications/applicationSummary.tsx
@@ -42,7 +42,9 @@ const ApplicationSummary: FC<ApplicationSummaryProps> = ({ applicationId }) => {
             orderBy: InputOrderByInput.TimestampDesc,
             limit: 6,
             where: {
-                id_startsWith: applicationId,
+                application: {
+                    id_eq: applicationId.toLowerCase(),
+                },
             },
         },
     });

--- a/apps/web/src/components/applications/latestInputsTable.tsx
+++ b/apps/web/src/components/applications/latestInputsTable.tsx
@@ -84,35 +84,25 @@ const LatestInputsTable: FC<LatestInputsTableProps> = ({
                 {inputs.map((input) => (
                     <Table.Tr key={`${input.application}-${input.timestamp}`}>
                         <Table.Td>
-                            <Table.Td>
-                                <Box
-                                    display="flex"
-                                    w="max-content"
-                                    style={{
-                                        alignItems: "center",
-                                        justifyContent: "center",
-                                    }}
-                                >
-                                    {input.erc20Deposit ? (
-                                        <Group>
-                                            <Address
-                                                value={
-                                                    input.erc20Deposit
-                                                        .from as AddressType
-                                                }
-                                                icon
-                                                shorten
-                                            />
-                                            <TbArrowRight />
-                                            <Address
-                                                value={
-                                                    input.msgSender as AddressType
-                                                }
-                                                icon
-                                                shorten
-                                            />
-                                        </Group>
-                                    ) : (
+                            <Box
+                                display="flex"
+                                w="max-content"
+                                style={{
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                }}
+                            >
+                                {input.erc20Deposit ? (
+                                    <Group>
+                                        <Address
+                                            value={
+                                                input.erc20Deposit
+                                                    .from as AddressType
+                                            }
+                                            icon
+                                            shorten
+                                        />
+                                        <TbArrowRight />
                                         <Address
                                             value={
                                                 input.msgSender as AddressType
@@ -120,9 +110,15 @@ const LatestInputsTable: FC<LatestInputsTableProps> = ({
                                             icon
                                             shorten
                                         />
-                                    )}
-                                </Box>
-                            </Table.Td>
+                                    </Group>
+                                ) : (
+                                    <Address
+                                        value={input.msgSender as AddressType}
+                                        icon
+                                        shorten
+                                    />
+                                )}
+                            </Box>
                         </Table.Td>
                         <Table.Td>
                             <Badge

--- a/apps/web/src/components/applications/latestInputsTable.tsx
+++ b/apps/web/src/components/applications/latestInputsTable.tsx
@@ -1,0 +1,158 @@
+"use client";
+import { Badge, Box, Button, Group, Loader, Table, Text } from "@mantine/core";
+import type { Address as AddressType } from "abitype/dist/types/abi";
+import prettyMilliseconds from "pretty-ms";
+import { FC, useCallback, useState } from "react";
+import Address from "../address";
+import { getAddress } from "viem";
+import { erc20PortalAddress, etherPortalAddress } from "@cartesi/rollups-wagmi";
+import { MethodResolver } from "../inputs/inputRow";
+import { InputItemFragment } from "../../graphql/explorer/operations";
+import { TbArrowRight } from "react-icons/tb";
+
+export interface Entry {
+    appId: AddressType;
+    timestamp: number;
+    href: string;
+}
+
+export interface LatestInputsTableProps {
+    inputs: InputItemFragment[];
+    fetching: boolean;
+    totalCount: number;
+}
+
+const etherDepositResolver: MethodResolver = (input) =>
+    getAddress(input.msgSender) === etherPortalAddress && "depositEther";
+
+const erc20PortalResolver: MethodResolver = (input) =>
+    getAddress(input.msgSender) === erc20PortalAddress && "depositERC20Tokens";
+
+const resolvers: MethodResolver[] = [etherDepositResolver, erc20PortalResolver];
+const methodResolver: MethodResolver = (input) => {
+    for (const resolver of resolvers) {
+        const method = resolver(input);
+        if (method) return method;
+    }
+    return undefined;
+};
+
+const LatestInputsTable: FC<LatestInputsTableProps> = ({
+    inputs,
+    fetching,
+    totalCount,
+}) => {
+    const [timeType, setTimeType] = useState("age");
+
+    const onChangeTimeColumnType = useCallback(() => {
+        setTimeType((timeType) => (timeType === "age" ? "timestamp" : "age"));
+    }, []);
+
+    return (
+        <Table>
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th>From</Table.Th>
+                    <Table.Th>Method</Table.Th>
+                    <Table.Th>
+                        <Button
+                            variant="transparent"
+                            px={0}
+                            onClick={onChangeTimeColumnType}
+                        >
+                            {timeType === "age" ? "Age" : "Timestamp (UTC)"}
+                        </Button>
+                    </Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+                {fetching ? (
+                    <Table.Tr>
+                        <Table.Td align="center" colSpan={2}>
+                            <Loader data-testid="inputs-table-spinner" />
+                        </Table.Td>
+                    </Table.Tr>
+                ) : (
+                    totalCount === 0 && (
+                        <Table.Tr>
+                            <Table.Td colSpan={3} align="center" fw={700}>
+                                No inputs
+                            </Table.Td>
+                        </Table.Tr>
+                    )
+                )}
+                {inputs.map((input) => (
+                    <Table.Tr key={`${input.application}-${input.timestamp}`}>
+                        <Table.Td>
+                            <Table.Td>
+                                <Box
+                                    display="flex"
+                                    w="max-content"
+                                    style={{
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                    }}
+                                >
+                                    {input.erc20Deposit ? (
+                                        <Group>
+                                            <Address
+                                                value={
+                                                    input.erc20Deposit
+                                                        .from as AddressType
+                                                }
+                                                icon
+                                                shorten
+                                            />
+                                            <TbArrowRight />
+                                            <Address
+                                                value={
+                                                    input.msgSender as AddressType
+                                                }
+                                                icon
+                                                shorten
+                                            />
+                                        </Group>
+                                    ) : (
+                                        <Address
+                                            value={
+                                                input.msgSender as AddressType
+                                            }
+                                            icon
+                                            shorten
+                                        />
+                                    )}
+                                </Box>
+                            </Table.Td>
+                        </Table.Td>
+                        <Table.Td>
+                            <Badge
+                                variant="default"
+                                style={{ textTransform: "none" }}
+                            >
+                                {methodResolver(input) ?? "?"}
+                            </Badge>
+                        </Table.Td>
+                        <Table.Td>
+                            <Text>
+                                {timeType === "age"
+                                    ? `${prettyMilliseconds(
+                                          Date.now() - input.timestamp * 1000,
+                                          {
+                                              unitCount: 2,
+                                              secondsDecimalDigits: 0,
+                                              verbose: true,
+                                          },
+                                      )} ago`
+                                    : new Date(
+                                          input.timestamp * 1000,
+                                      ).toISOString()}
+                            </Text>
+                        </Table.Td>
+                    </Table.Tr>
+                ))}
+            </Table.Tbody>
+        </Table>
+    );
+};
+
+export default LatestInputsTable;

--- a/apps/web/src/components/connection/connectionSummary.tsx
+++ b/apps/web/src/components/connection/connectionSummary.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Grid } from "@mantine/core";
+import React, { FC, useMemo } from "react";
+import { SummaryCard } from "@cartesi/rollups-explorer-ui";
+import { TbAlertTriangle, TbReportAnalytics, TbTicket } from "react-icons/tb";
+import { useQuery } from "urql";
+import {
+    CheckStatusDocument,
+    CheckStatusQuery,
+    CheckStatusQueryVariables,
+} from "../../graphql/rollups/operations";
+
+export interface ConnectionSummaryProps {
+    url: string;
+}
+
+export const ConnectionSummary: FC<ConnectionSummaryProps> = ({ url }) => {
+    const [result] = useQuery<CheckStatusQuery, CheckStatusQueryVariables>({
+        query: CheckStatusDocument,
+        context: useMemo(
+            () => ({
+                url,
+                requestPolicy: "network-only",
+            }),
+            [url],
+        ),
+    });
+
+    return (
+        <>
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+                <SummaryCard
+                    title="Notices"
+                    value={result.data?.notices.totalCount ?? 0}
+                    icon={TbAlertTriangle}
+                />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+                <SummaryCard
+                    title="Vouchers"
+                    value={result.data?.vouchers.totalCount ?? 0}
+                    icon={TbTicket}
+                />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+                <SummaryCard
+                    title="Reports"
+                    value={result.data?.reports.totalCount ?? 0}
+                    icon={TbReportAnalytics}
+                />
+            </Grid.Col>
+        </>
+    );
+};
+
+export default ConnectionSummary;

--- a/apps/web/src/components/latestEntries.tsx
+++ b/apps/web/src/components/latestEntries.tsx
@@ -105,7 +105,7 @@ const LatestEntries: FC = () => {
         applicationsData?.applicationsConnection.edges.map((edge) => ({
             appId: edge.node.id as AddressType,
             timestamp: Number(edge.node.timestamp),
-            href: `/applications/${edge.node.id}/inputs`,
+            href: `/applications/${edge.node.id}`,
         })) ?? [];
 
     return (

--- a/apps/web/test/components/applications/applicationSummary.test.tsx
+++ b/apps/web/test/components/applications/applicationSummary.test.tsx
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { withMantineTheme } from "../../utils/WithMantineTheme";
+import ApplicationSummary from "../../../src/components/applications/applicationSummary";
+import { useConnectionConfig } from "../../../src/providers/connectionConfig/hooks";
+import { useInputsConnectionQuery } from "../../../src/graphql/explorer/hooks/queries";
+import { inputsConnectionMock } from "./mocks";
+
+vi.mock("../../../src/providers/connectionConfig/hooks");
+const useConnectionConfigMock = vi.mocked(useConnectionConfig, true);
+
+vi.mock("../../../src/graphql/explorer/hooks/queries");
+const useInputsConnectionQueryMock = vi.mocked(useInputsConnectionQuery, true);
+
+const Component = withMantineTheme(ApplicationSummary);
+
+const defaultProps = {
+    applicationId: "0x07044f5d4ae00666bbb946cf1cbcff8e2d29c878",
+};
+
+const connectionConfig = {
+    hasConnection: vi.fn(),
+    addConnection: vi.fn(),
+    removeConnection: vi.fn(),
+    getConnection: vi.fn(),
+    hideConnectionModal: vi.fn(),
+    showConnectionModal: vi.fn(),
+    listConnections: vi.fn(),
+};
+
+describe("ApplicationSummary component", () => {
+    beforeEach(() => {
+        useConnectionConfigMock.mockReturnValue(connectionConfig);
+        useInputsConnectionQueryMock.mockReturnValue([
+            {
+                data: inputsConnectionMock,
+                fetching: false,
+            },
+        ] as any);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        cleanup();
+    });
+
+    it("should display summary card for inputs", () => {
+        render(<Component {...defaultProps} />);
+        expect(screen.getByText("Inputs")).toBeInTheDocument();
+    });
+
+    it("should display correct number of inputs", () => {
+        render(<Component {...defaultProps} />);
+        expect(
+            screen.getByText(inputsConnectionMock.inputsConnection.totalCount),
+        ).toBeInTheDocument();
+    });
+
+    it("should display skeleton cards when no connection is available", () => {
+        useConnectionConfigMock.mockReturnValue({
+            ...connectionConfig,
+            hasConnection: () => false,
+        });
+        render(<Component {...defaultProps} />);
+        expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+    });
+
+    it("should display Add connection button when no connection is available", () => {
+        useConnectionConfigMock.mockReturnValue({
+            ...connectionConfig,
+            hasConnection: () => false,
+        });
+        render(<Component {...defaultProps} />);
+        expect(screen.getByText("Add connection")).toBeInTheDocument();
+    });
+
+    it("should invoke showConnectionModal when Add connection button is clicked", () => {
+        const showConnectionModalMock = vi.fn();
+        useConnectionConfigMock.mockReturnValue({
+            ...connectionConfig,
+            showConnectionModal: showConnectionModalMock,
+        });
+        render(<Component {...defaultProps} />);
+
+        const button = screen
+            .getByText("Add connection")
+            .closest("button") as HTMLButtonElement;
+
+        fireEvent.click(button);
+
+        expect(showConnectionModalMock).toHaveBeenCalledWith(
+            defaultProps.applicationId,
+        );
+    });
+
+    it("should display Latest inputs section", () => {
+        render(<Component {...defaultProps} />);
+        expect(screen.getByText("Latest inputs")).toBeInTheDocument();
+    });
+
+    it("should display View inputs link when there are some inputs", () => {
+        render(<Component {...defaultProps} />);
+        const buttonLabel = screen.getByText("View inputs");
+        expect(buttonLabel).toBeInTheDocument();
+
+        const anchor = buttonLabel.closest("a") as HTMLAnchorElement;
+        expect(anchor.getAttribute("href")).toBe(
+            `/applications/${defaultProps.applicationId}/inputs`,
+        );
+    });
+
+    it("should not display View inputs link when there are no inputs", () => {
+        render(<Component {...defaultProps} />);
+        useInputsConnectionQueryMock.mockReturnValue([
+            {
+                data: {
+                    ...inputsConnectionMock,
+                    inputsConnection: {
+                        ...inputsConnectionMock.inputsConnection,
+                        totalCount: 0,
+                        edges: [],
+                    },
+                },
+                fetching: false,
+            },
+        ] as any);
+        expect(screen.getByText("View inputs")).toBeInTheDocument();
+    });
+});

--- a/apps/web/test/components/applications/applicationSummary.test.tsx
+++ b/apps/web/test/components/applications/applicationSummary.test.tsx
@@ -5,6 +5,7 @@ import ApplicationSummary from "../../../src/components/applications/application
 import { useConnectionConfig } from "../../../src/providers/connectionConfig/hooks";
 import { useInputsConnectionQuery } from "../../../src/graphql/explorer/hooks/queries";
 import { inputsConnectionMock } from "./mocks";
+import { InputOrderByInput } from "../../../src/graphql/explorer/types";
 
 vi.mock("../../../src/providers/connectionConfig/hooks");
 const useConnectionConfigMock = vi.mocked(useConnectionConfig, true);
@@ -42,6 +43,32 @@ describe("ApplicationSummary component", () => {
     afterEach(() => {
         vi.clearAllMocks();
         cleanup();
+    });
+
+    it("should filter applications based on application id", () => {
+        const implementationMock = vi.fn(
+            () =>
+                [
+                    {
+                        data: inputsConnectionMock,
+                        fetching: false,
+                    },
+                ] as any,
+        );
+        useInputsConnectionQueryMock.mockImplementation(implementationMock);
+        render(<Component {...defaultProps} />);
+
+        expect(implementationMock).toHaveBeenCalledWith({
+            variables: {
+                orderBy: InputOrderByInput.TimestampDesc,
+                limit: 6,
+                where: {
+                    application: {
+                        id_eq: defaultProps.applicationId.toLowerCase(),
+                    },
+                },
+            },
+        });
     });
 
     it("should display summary card for inputs", () => {

--- a/apps/web/test/components/applications/latestInputsTable.test.tsx
+++ b/apps/web/test/components/applications/latestInputsTable.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it } from "vitest";
+import LatestInputsTable from "../../../src/components/applications/latestInputsTable";
+import { withMantineTheme } from "../../utils/WithMantineTheme";
+import prettyMilliseconds from "pretty-ms";
+
+const Component = withMantineTheme(LatestInputsTable);
+
+const defaultProps = {
+    inputs: [
+        {
+            id: "0xdb84080e7d2b4654a7e384de851a6cf7281643de-1",
+            application: {
+                id: "0xdb84080e7d2b4654a7e384de851a6cf7281643de",
+            },
+            index: 1,
+            payload: "0x68656c6c6f2032",
+            msgSender: "0x8a12cf75000cd2e73ab16469826838d5f137f444",
+            timestamp: 1700593992,
+            transactionHash:
+                "0x4ad73b8f46dc16bc27d75b3f8f584e8785a8cb6fdf97a6c2a5a5dcfbda3e75c0",
+            erc20Deposit: null,
+        },
+    ],
+    fetching: false,
+    totalCount: 1,
+};
+
+describe("LatestInputsTable component", () => {
+    it("should display time column with age label", () => {
+        render(<Component {...defaultProps} />);
+        expect(screen.getByText("Age")).toBeInTheDocument();
+    });
+
+    it("should display time column with timestamp label", () => {
+        render(<Component {...defaultProps} />);
+
+        const timeTypeButton = screen.getByText("Age");
+        fireEvent.click(timeTypeButton);
+
+        expect(screen.getByText("Timestamp (UTC)")).toBeInTheDocument();
+    });
+
+    it("should display spinner when fetching data", () => {
+        render(<Component {...defaultProps} fetching />);
+        expect(screen.getByTestId("inputs-table-spinner")).toBeInTheDocument();
+    });
+
+    it("should display correct label when no inputs are fetched", () => {
+        render(<Component inputs={[]} fetching={false} totalCount={0} />);
+        expect(screen.getByText("No inputs")).toBeInTheDocument();
+    });
+
+    it("should display correct age", () => {
+        render(<Component {...defaultProps} />);
+
+        const [entry] = defaultProps.inputs;
+        const age = `${prettyMilliseconds(Date.now() - entry.timestamp * 1000, {
+            unitCount: 2,
+            secondsDecimalDigits: 0,
+            verbose: true,
+        })} ago`;
+        expect(screen.getByText(age)).toBeInTheDocument();
+    });
+
+    it("should display correct timestamp in UTC format", () => {
+        render(<Component {...defaultProps} />);
+
+        const timeTypeButton = screen.getByText("Age");
+        fireEvent.click(timeTypeButton);
+
+        const [entry] = defaultProps.inputs;
+        const timestamp = new Date(entry.timestamp * 1000).toISOString();
+        expect(screen.getByText(timestamp)).toBeInTheDocument();
+    });
+});

--- a/apps/web/test/components/applications/mocks.ts
+++ b/apps/web/test/components/applications/mocks.ts
@@ -1,0 +1,129 @@
+export const inputsConnectionMock = {
+    inputsConnection: {
+        totalCount: 2470,
+        pageInfo: {
+            hasNextPage: true,
+            hasPreviousPage: false,
+            startCursor: "1",
+            endCursor: "6",
+            __typename: "PageInfo",
+        },
+        edges: [
+            {
+                node: {
+                    id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d-108",
+                    application: {
+                        id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
+                        __typename: "Application",
+                    },
+                    index: 108,
+                    payload:
+                        "0x227b5c226d6574686f645c223a5c226164645061727469636970616e745c222c5c22646174615c223a7b5c2267616d6549645c223a5c2264386330346137622d653230372d346466622d613164322d6336346539643039633965355c222c5c22706c61796572416464726573735c223a5c223078336131343639313535323762643135323830323662356331343333353039386466663237303063615c227d7d22",
+                    msgSender: "0x3a146915527bd1528026b5c14335098dff2700ca",
+                    timestamp: "1713958884",
+                    transactionHash:
+                        "0x1ce43d42d6660b12cbe6896d89bdc6a9469bd2d1bde16ae5aae590e25c76b299",
+                    erc20Deposit: null,
+                    __typename: "Input",
+                },
+                __typename: "InputEdge",
+            },
+            {
+                node: {
+                    id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d-107",
+                    application: {
+                        id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
+                        __typename: "Application",
+                    },
+                    index: 107,
+                    payload:
+                        "0x227b5c226d6574686f645c223a5c226164645061727469636970616e745c222c5c22646174615c223a7b5c2267616d6549645c223a5c2263386337303330652d313434622d343136342d616633372d3164343662646361656135355c222c5c22706c61796572416464726573735c223a5c223078336131343639313535323762643135323830323662356331343333353039386466663237303063615c227d7d22",
+                    msgSender: "0x3a146915527bd1528026b5c14335098dff2700ca",
+                    timestamp: "1713958572",
+                    transactionHash:
+                        "0x346a33128606a55c03fb56ce3abf0eb210aa96348ced26c819f71a6bef3027d7",
+                    erc20Deposit: null,
+                    __typename: "Input",
+                },
+                __typename: "InputEdge",
+            },
+            {
+                node: {
+                    id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d-106",
+                    application: {
+                        id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
+                        __typename: "Application",
+                    },
+                    index: 106,
+                    payload:
+                        "0x227b5c226d6574686f645c223a5c226164645061727469636970616e745c222c5c22646174615c223a7b5c2267616d6549645c223a5c2263386337303330652d313434622d343136342d616633372d3164343662646361656135355c222c5c22706c61796572416464726573735c223a5c223078336131343639313535323762643135323830323662356331343333353039386466663237303063615c227d7d22",
+                    msgSender: "0x3a146915527bd1528026b5c14335098dff2700ca",
+                    timestamp: "1713958548",
+                    transactionHash:
+                        "0x61d279d4e190a872ce4e49877d7e4f94bda46442d92cb7b9af2756e46391a2ee",
+                    erc20Deposit: null,
+                    __typename: "Input",
+                },
+                __typename: "InputEdge",
+            },
+            {
+                node: {
+                    id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d-105",
+                    application: {
+                        id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
+                        __typename: "Application",
+                    },
+                    index: 105,
+                    payload:
+                        "0x227b5c226d6574686f645c223a5c2263726561746547616d655c222c5c22646174615c223a7b5c2263726561746f725c223a5c223078336131343639313535323762643135323830323662356331343333353039386466663237303063615c222c5c22616374697665506c617965725c223a5c225c222c5c2267616d654e616d655c223a5c2254657374204d61726375735c222c5c22636f6d6d697450686173655c223a66616c73652c5c2272657665616c50686173655c223a66616c73652c5c227061727469636970616e74735c223a5b5d2c5c2267616d6553657474696e67735c223a7b5c226e756d626572734f665475726e5c223a322c5c2277696e6e696e6753636f72655c223a362c5c226d6f64655c223a5c2273636f72655c222c5c226170706172617475735c223a5c22646963655c222c5c226265745c223a66616c73652c5c226d6178506c617965725c223a31302c5c226c696d69744e756d6265724f66506c617965725c223a747275657d2c5c227374617475735c223a5c224e65775c222c5c22726f6c6c4f7574636f6d655c223a302c5c2277696e6e65725c223a5c225c222c5c2262657474696e67416d6f756e745c223a5c22302e30325c222c5c2262657474696e6746756e645c223a302c5c22706169644f75745c223a66616c73657d7d22",
+                    msgSender: "0x3a146915527bd1528026b5c14335098dff2700ca",
+                    timestamp: "1713958500",
+                    transactionHash:
+                        "0x30a07db7f20a2546f10f36bede6096489f5e71be61198161fdd6171da2538f72",
+                    erc20Deposit: null,
+                    __typename: "Input",
+                },
+                __typename: "InputEdge",
+            },
+            {
+                node: {
+                    id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d-104",
+                    application: {
+                        id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
+                        __typename: "Application",
+                    },
+                    index: 104,
+                    payload:
+                        "0x227b5c226d6574686f645c223a5c226164645061727469636970616e745c222c5c22646174615c223a7b5c2267616d6549645c223a5c2263386337303330652d313434622d343136342d616633372d3164343662646361656135355c222c5c22706c61796572416464726573735c223a5c223078336131343639313535323762643135323830323662356331343333353039386466663237303063615c227d7d22",
+                    msgSender: "0x3a146915527bd1528026b5c14335098dff2700ca",
+                    timestamp: "1713958332",
+                    transactionHash:
+                        "0x0916b54f462aab3b6199ce81fdef365e39c2c367f3546f9234c32b0fb85c0075",
+                    erc20Deposit: null,
+                    __typename: "Input",
+                },
+                __typename: "InputEdge",
+            },
+            {
+                node: {
+                    id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d-103",
+                    application: {
+                        id: "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
+                        __typename: "Application",
+                    },
+                    index: 103,
+                    payload:
+                        "0x227b5c226d6574686f645c223a5c2263726561746547616d655c222c5c22646174615c223a7b5c2263726561746f725c223a5c223078336131343639313535323762643135323830323662356331343333353039386466663237303063615c222c5c22616374697665506c617965725c223a5c225c222c5c2267616d654e616d655c223a5c224d617263757320546573745c222c5c22636f6d6d697450686173655c223a66616c73652c5c2272657665616c50686173655c223a66616c73652c5c227061727469636970616e74735c223a5b5d2c5c2267616d6553657474696e67735c223a7b5c226e756d626572734f665475726e5c223a322c5c2277696e6e696e6753636f72655c223a35302c5c226d6f64655c223a5c2273636f72655c222c5c226170706172617475735c223a5c22646963655c222c5c226265745c223a66616c73652c5c226d6178506c617965725c223a31302c5c226c696d69744e756d6265724f66506c617965725c223a747275657d2c5c227374617475735c223a5c224e65775c222c5c22726f6c6c4f7574636f6d655c223a302c5c2277696e6e65725c223a5c225c222c5c2262657474696e67416d6f756e745c223a5c22302e30325c222c5c2262657474696e6746756e645c223a302c5c22706169644f75745c223a66616c73657d7d22",
+                    msgSender: "0x3a146915527bd1528026b5c14335098dff2700ca",
+                    timestamp: "1713958248",
+                    transactionHash:
+                        "0x72bdbf522b1aeb33ec5972b372b74daf10120a4ff83fa3e3136f6c39ae850f68",
+                    erc20Deposit: null,
+                    __typename: "Input",
+                },
+                __typename: "InputEdge",
+            },
+        ],
+        __typename: "InputsConnection",
+    },
+};

--- a/apps/web/test/components/connection/connectionSummary.test.tsx
+++ b/apps/web/test/components/connection/connectionSummary.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { withMantineTheme } from "../../utils/WithMantineTheme";
+import ConnectionSummary, {
+    ConnectionSummaryProps,
+} from "../../../src/components/connection/connectionSummary";
+import { useQuery } from "urql";
+import { connectionSummaryResult } from "./mocks";
+import { FC } from "react";
+import { Grid } from "@mantine/core";
+
+vi.mock("urql");
+const useQueryMock = vi.mocked(useQuery, true);
+
+const GridComponent: FC<ConnectionSummaryProps> = (props) => (
+    <Grid>
+        <ConnectionSummary {...props} />
+    </Grid>
+);
+
+const Component = withMantineTheme(GridComponent);
+
+const defaultProps = {
+    url: "http://localhost:3000/graphql",
+};
+
+describe("ConnectionSummary component", () => {
+    beforeEach(() => {
+        useQueryMock.mockReturnValue([
+            {
+                data: connectionSummaryResult.data,
+                fetching: false,
+            },
+        ] as any);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        cleanup();
+    });
+
+    it("should display summary card for notices", () => {
+        render(<Component {...defaultProps} />);
+        expect(screen.getByText("Notices")).toBeInTheDocument();
+        expect(
+            screen.getByText(connectionSummaryResult.data.notices.totalCount),
+        ).toBeInTheDocument();
+    });
+
+    it("should display summary card for vouchers", () => {
+        render(<Component {...defaultProps} />);
+        expect(screen.getByText("Vouchers")).toBeInTheDocument();
+        expect(
+            screen.getByText(connectionSummaryResult.data.vouchers.totalCount),
+        ).toBeInTheDocument();
+    });
+
+    it("should display summary card for reports", () => {
+        render(<Component {...defaultProps} />);
+        expect(screen.getByText("Reports")).toBeInTheDocument();
+        expect(
+            screen.getByText(connectionSummaryResult.data.reports.totalCount),
+        ).toBeInTheDocument();
+    });
+});

--- a/apps/web/test/components/connection/mocks.ts
+++ b/apps/web/test/components/connection/mocks.ts
@@ -1,0 +1,184 @@
+export const connectionSummaryResult = {
+    fetching: false,
+    stale: false,
+    data: {
+        inputs: {
+            totalCount: 806,
+            __typename: "InputConnection",
+        },
+        vouchers: {
+            totalCount: 1,
+            __typename: "VoucherConnection",
+        },
+        reports: {
+            totalCount: 806,
+            __typename: "ReportConnection",
+        },
+        notices: {
+            totalCount: 0,
+            __typename: "NoticeConnection",
+        },
+    },
+    operation: {
+        key: -2192240688,
+        query: {
+            kind: "Document",
+            definitions: [
+                {
+                    kind: "OperationDefinition",
+                    operation: "query",
+                    name: {
+                        kind: "Name",
+                        value: "checkStatus",
+                    },
+                    variableDefinitions: [],
+                    directives: [],
+                    selectionSet: {
+                        kind: "SelectionSet",
+                        selections: [
+                            {
+                                kind: "Field",
+                                name: {
+                                    kind: "Name",
+                                    value: "inputs",
+                                },
+                                arguments: [],
+                                directives: [],
+                                selectionSet: {
+                                    kind: "SelectionSet",
+                                    selections: [
+                                        {
+                                            kind: "Field",
+                                            name: {
+                                                kind: "Name",
+                                                value: "totalCount",
+                                            },
+                                            arguments: [],
+                                            directives: [],
+                                        },
+                                        {
+                                            kind: "Field",
+                                            name: {
+                                                kind: "Name",
+                                                value: "__typename",
+                                            },
+                                            _generated: true,
+                                        },
+                                    ],
+                                },
+                            },
+                            {
+                                kind: "Field",
+                                name: {
+                                    kind: "Name",
+                                    value: "vouchers",
+                                },
+                                arguments: [],
+                                directives: [],
+                                selectionSet: {
+                                    kind: "SelectionSet",
+                                    selections: [
+                                        {
+                                            kind: "Field",
+                                            name: {
+                                                kind: "Name",
+                                                value: "totalCount",
+                                            },
+                                            arguments: [],
+                                            directives: [],
+                                        },
+                                        {
+                                            kind: "Field",
+                                            name: {
+                                                kind: "Name",
+                                                value: "__typename",
+                                            },
+                                            _generated: true,
+                                        },
+                                    ],
+                                },
+                            },
+                            {
+                                kind: "Field",
+                                name: {
+                                    kind: "Name",
+                                    value: "reports",
+                                },
+                                arguments: [],
+                                directives: [],
+                                selectionSet: {
+                                    kind: "SelectionSet",
+                                    selections: [
+                                        {
+                                            kind: "Field",
+                                            name: {
+                                                kind: "Name",
+                                                value: "totalCount",
+                                            },
+                                            arguments: [],
+                                            directives: [],
+                                        },
+                                        {
+                                            kind: "Field",
+                                            name: {
+                                                kind: "Name",
+                                                value: "__typename",
+                                            },
+                                            _generated: true,
+                                        },
+                                    ],
+                                },
+                            },
+                            {
+                                kind: "Field",
+                                name: {
+                                    kind: "Name",
+                                    value: "notices",
+                                },
+                                arguments: [],
+                                directives: [],
+                                selectionSet: {
+                                    kind: "SelectionSet",
+                                    selections: [
+                                        {
+                                            kind: "Field",
+                                            name: {
+                                                kind: "Name",
+                                                value: "totalCount",
+                                            },
+                                            arguments: [],
+                                            directives: [],
+                                        },
+                                        {
+                                            kind: "Field",
+                                            name: {
+                                                kind: "Name",
+                                                value: "__typename",
+                                            },
+                                            _generated: true,
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+            loc: {
+                start: 0,
+                end: 155,
+            },
+        },
+        variables: {},
+        kind: "query",
+        context: {
+            url: "https://honeypot.sepolia.rollups.staging.cartesi.io/graphql",
+            requestPolicy: "network-only",
+            suspense: false,
+            meta: {
+                cacheOutcome: "miss",
+            },
+        },
+    },
+    hasNext: false,
+};


### PR DESCRIPTION
I tweaked `/applications/{address}` route to display the application summary information with 4 cards for inputs, notices, vouchers and reports. Below the cards, I added the 6 latest inputs table.