### PR TITLE
Chore: Add playwright setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/cartesi/rollups-explorer/badge.svg?branch=feature/97-upload-test-coverage-to-coveralls)](https://coveralls.io/github/cartesi/rollups-explorer?branch=feature/97-upload-test-coverage-to-coveralls)
 
-This is a monorepo holding up two web applications. One is called [web](./apps//web/) and is the UI for the rollups explorer and the second is called [workshop](./apps/workshop/) that is a storybook to support fast development iteration and showcase. The repository also holds a few packages more on these below.
-
-## What's inside?
-
-This monorepo uses [Yarn v1](https://classic.yarnpkg.com/) as a package manager and is controlled by [turborepo](https://turbo.build/repo).
+This is a monorepo managed by [turborepo](https://turbo.build/repo) using [Yarn v1](https://classic.yarnpkg.com/) as the package manager. It holds two web apps and a few packages. A nextJS app called [web](./apps//web/) that is the rollups-explorer UI. The second is a Storybook app called [workshop](./apps/workshop/) to support showcase and quick development of components. The backend for the rollups-explorer can be found [here](https://github.com/cartesi/rollups-explorer-api)
 
 ## Formatter + Linter
 
@@ -51,7 +47,33 @@ yarn run dev --filter=web --filter=@cartesi/rollups-explorer-ui
 
 ## Testing
 
-We are using [Vitest framework](https://vitest.dev/) combined with [testing-library](https://testing-library.com/docs/react-testing-library/intro/) for react in both `packages/ui` and `apps/web`.
+The project is using [Vitest framework](https://vitest.dev/) combined with [testing-library](https://testing-library.com/docs/react-testing-library/intro/) for react in both `packages/ui` and `apps/web` for unit testing.
+
+### E2E Testing
+
+The project is using [Playwright](https://playwright.dev/docs/intro) to run the E2E checks against the rollups-explorer UI. You can run the commands inside the [web](./apps//web/) app.
+
+> [!IMPORTANT]  
+> Make sure you have your app running in dev mode or a built version
+
+For single run, execute the following:
+
+```
+yarn test:e2e
+```
+
+To run in a interactive way with watch mode run the following command (Preferred)
+
+```
+yarn run test:e2e:ui
+```
+
+Below is a table with env vars and its default value that is used by the Playwright config, that can be found inside the `apps/web`
+
+|  Env variable  |         Default         |
+| :------------: | :---------------------: |
+| `E2E_BASE_URL` | `http://localhost:3000` |
+|      `CI`      |       `undefined`       |
 
 ## Build
 

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -47,3 +47,7 @@ yarn-error.log*
 # generated files
 src/contracts.ts
 src/graphql
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/apps/web/additional.d.ts
+++ b/apps/web/additional.d.ts
@@ -17,5 +17,10 @@ declare namespace NodeJS {
          * Internal calls may need a different URI to become reachable.
          */
         INTERNAL_EXPLORER_API_URL: string;
+
+        /**
+         * CI=true is common set in most CI providers. e.g. Github, TravisCI
+         */
+        CI?: "true" | "false";
     }
 }

--- a/apps/web/additional.d.ts
+++ b/apps/web/additional.d.ts
@@ -21,6 +21,12 @@ declare namespace NodeJS {
         /**
          * CI=true is common set in most CI providers. e.g. Github, TravisCI
          */
-        CI?: "true" | "false";
+        CI?: "true";
+
+        /**
+         * Base url to be used inside the e2e tests when calling e.g. page.goto("/applications")
+         * Default used in its absence is http://localhost:3000
+         */
+        E2E_BASE_URL?: string;
     }
 }

--- a/apps/web/e2e/config.ts
+++ b/apps/web/e2e/config.ts
@@ -1,0 +1,5 @@
+const e2eConfig = {
+    baseURL: "http://localhost:3000",
+} as const;
+
+export default e2eConfig;

--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -1,10 +1,7 @@
 import { expect, test } from "@playwright/test";
-import e2eConfig from "./config";
-
-const { baseURL } = e2eConfig;
 
 test.beforeEach(async ({ page }) => {
-    await page.goto(baseURL);
+    await page.goto("/");
 });
 
 test("should have page title", async ({ page }) => {
@@ -21,34 +18,18 @@ test("should have a left menu with links", async ({ page }) => {
 
 test("should have a visible and disabled send transaction", async ({
     page,
-    isMobile,
 }) => {
-    let sendTransaction;
-    if (isMobile) {
-        const burgerBtn = page.getByTestId("burger-menu-btn");
-        await expect(burgerBtn).toBeVisible();
-        await burgerBtn.click();
-        sendTransaction = await page.getByTestId("menu-item-send-transaction");
-        await expect(sendTransaction).toHaveAttribute("data-disabled", "true");
-    } else {
-        sendTransaction = await page.getByRole("button", {
-            name: "Send Transaction",
-        });
-        await expect(sendTransaction).toBeDisabled();
-    }
+    const sendTransaction = await page.getByRole("button", {
+        name: "Send Transaction",
+    });
+    await expect(sendTransaction).toBeDisabled();
 
     await expect(sendTransaction).toBeVisible();
 });
 
 test("should have an enabled button to connect to a wallet", async ({
     page,
-    isMobile,
 }) => {
-    if (isMobile) {
-        const burgerBtn = page.getByTestId("burger-menu-btn");
-        await expect(burgerBtn).toBeVisible();
-        await burgerBtn.click();
-    }
     const connectWallet = page.getByRole("button", {
         name: "Connect Wallet",
     });
@@ -65,4 +46,35 @@ test("should have a switch for dark and light mode", async ({ page }) => {
     switchBtn.click();
 
     await expect(switchBtn).toHaveText("Dark Mode");
+});
+
+test.describe("mobile", () => {
+    test("should have a visible and disabled send transaction", async ({
+        page,
+    }) => {
+        const burgerBtn = page.getByTestId("burger-menu-btn");
+        await expect(burgerBtn).toBeVisible();
+        await burgerBtn.click();
+        const sendTransaction = await page.getByTestId(
+            "menu-item-send-transaction",
+        );
+        await expect(sendTransaction).toHaveAttribute("data-disabled", "true");
+
+        await expect(sendTransaction).toBeVisible();
+    });
+
+    test("should have an enabled button to connect to a wallet", async ({
+        page,
+    }) => {
+        const burgerBtn = page.getByTestId("burger-menu-btn");
+        await expect(burgerBtn).toBeVisible();
+        await burgerBtn.click();
+
+        const connectWallet = page.getByRole("button", {
+            name: "Connect Wallet",
+        });
+
+        await expect(connectWallet).toBeVisible();
+        await expect(connectWallet).toBeEnabled();
+    });
 });

--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import e2eConfig from "./config";
+
+const { baseURL } = e2eConfig;
+
+test.beforeEach(async ({ page }) => {
+    await page.goto(baseURL);
+});
+
+test("should have page title", async ({ page }) => {
+    await expect(page).toHaveTitle(/Blockchain Explorer \| CartesiScan/);
+});
+
+test("should have a left menu with links", async ({ page }) => {
+    await expect(page.getByTestId("home-link")).toHaveText("Home");
+    await expect(page.getByTestId("applications-link")).toHaveText(
+        "Applications",
+    );
+    await expect(page.getByTestId("inputs-link")).toHaveText("Inputs");
+});
+
+test("should have a visible and disabled send transaction", async ({
+    page,
+    isMobile,
+}) => {
+    let sendTransaction;
+    if (isMobile) {
+        const burgerBtn = page.getByTestId("burger-menu-btn");
+        await expect(burgerBtn).toBeVisible();
+        await burgerBtn.click();
+        sendTransaction = await page.getByTestId("menu-item-send-transaction");
+        await expect(sendTransaction).toHaveAttribute("data-disabled", "true");
+    } else {
+        sendTransaction = await page.getByRole("button", {
+            name: "Send Transaction",
+        });
+        await expect(sendTransaction).toBeDisabled();
+    }
+
+    await expect(sendTransaction).toBeVisible();
+});
+
+test("should have an enabled button to connect to a wallet", async ({
+    page,
+    isMobile,
+}) => {
+    if (isMobile) {
+        const burgerBtn = page.getByTestId("burger-menu-btn");
+        await expect(burgerBtn).toBeVisible();
+        await burgerBtn.click();
+    }
+    const connectWallet = page.getByRole("button", {
+        name: "Connect Wallet",
+    });
+
+    await expect(connectWallet).toBeVisible();
+    await expect(connectWallet).toBeEnabled();
+});
+
+test("should have a switch for dark and light mode", async ({ page }) => {
+    const switchBtn = page.getByTestId("theme-mode-switch");
+
+    await expect(switchBtn).toHaveText("Light Mode");
+
+    switchBtn.click();
+
+    await expect(switchBtn).toHaveText("Dark Mode");
+});

--- a/apps/web/e2e/menu.spec.ts
+++ b/apps/web/e2e/menu.spec.ts
@@ -1,22 +1,13 @@
 import { expect, test } from "@playwright/test";
-import e2eConfig from "./config";
-
-const { baseURL } = e2eConfig;
 
 test.beforeEach(async ({ page }) => {
-    await page.goto(baseURL);
+    await page.goto("/");
 });
 
 test.describe("Navigations", () => {
-    test("can navigate to applications page", async ({ page, isMobile }) => {
-        if (isMobile) {
-            const burgerBtn = page.getByTestId("burger-menu-btn");
-            await expect(burgerBtn).toBeVisible();
-            await burgerBtn.click();
-        }
-
+    test("can navigate to applications page", async ({ page }) => {
         await page.getByTestId("applications-link").click();
-        await page.waitForURL(`${baseURL}/applications`);
+        await page.waitForURL(`/applications`);
 
         await expect(
             page.getByRole("heading", { name: "Applications" }),
@@ -29,15 +20,9 @@ test.describe("Navigations", () => {
         await expect(page.getByRole("row")).toHaveCount(11);
     });
 
-    test("can navigate to inputs page", async ({ page, isMobile }) => {
-        if (isMobile) {
-            const burgerBtn = page.getByTestId("burger-menu-btn");
-            await expect(burgerBtn).toBeVisible();
-            await burgerBtn.click();
-        }
-
+    test("can navigate to inputs page", async ({ page }) => {
         await page.getByTestId("inputs-link").click();
-        await page.waitForURL(`${baseURL}/inputs`);
+        await page.waitForURL(`/inputs`);
 
         await expect(
             page.getByPlaceholder("Search by Address / Txn Hash / Index"),
@@ -53,5 +38,52 @@ test.describe("Navigations", () => {
 
         // For each input row it actually inserts 3 <tr>
         await expect(page.getByRole("row")).toHaveCount(31);
+    });
+
+    test.describe("mobile", () => {
+        test("can navigate to applications page", async ({ page }) => {
+            const burgerBtn = page.getByTestId("burger-menu-btn");
+            await expect(burgerBtn).toBeVisible();
+            await burgerBtn.click();
+
+            await page.getByTestId("applications-link").click();
+            await page.waitForURL(`/applications`);
+
+            await expect(
+                page.getByRole("heading", { name: "Applications" }),
+            ).toBeVisible();
+
+            await expect(
+                page.getByRole("row", { name: "Id Owner URL" }),
+            ).toBeVisible();
+
+            await expect(page.getByRole("row")).toHaveCount(11);
+        });
+
+        test("can navigate to inputs page", async ({ page }) => {
+            const burgerBtn = page.getByTestId("burger-menu-btn");
+            await expect(burgerBtn).toBeVisible();
+            await burgerBtn.click();
+
+            await page.getByTestId("inputs-link").click();
+            await page.waitForURL(`/inputs`);
+
+            await expect(
+                page.getByPlaceholder("Search by Address / Txn Hash / Index"),
+            ).toBeVisible();
+
+            await expect(
+                page.getByRole("heading", { name: "Inputs" }),
+            ).toBeVisible();
+
+            await expect(
+                page.getByRole("row", {
+                    name: "From To Method Index Age Data",
+                }),
+            ).toBeVisible();
+
+            // For each input row it actually inserts 3 <tr>
+            await expect(page.getByRole("row")).toHaveCount(31);
+        });
     });
 });

--- a/apps/web/e2e/menu.spec.ts
+++ b/apps/web/e2e/menu.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import e2eConfig from "./config";
+
+const { baseURL } = e2eConfig;
+
+test.beforeEach(async ({ page }) => {
+    await page.goto(baseURL);
+});
+
+test.describe("Navigations", () => {
+    test("can navigate to applications page", async ({ page, isMobile }) => {
+        if (isMobile) {
+            const burgerBtn = page.getByTestId("burger-menu-btn");
+            await expect(burgerBtn).toBeVisible();
+            await burgerBtn.click();
+        }
+
+        await page.getByTestId("applications-link").click();
+        await page.waitForURL(`${baseURL}/applications`);
+
+        await expect(
+            page.getByRole("heading", { name: "Applications" }),
+        ).toBeVisible();
+
+        await expect(
+            page.getByRole("row", { name: "Id Owner URL" }),
+        ).toBeVisible();
+
+        await expect(page.getByRole("row")).toHaveCount(11);
+    });
+
+    test("can navigate to inputs page", async ({ page, isMobile }) => {
+        if (isMobile) {
+            const burgerBtn = page.getByTestId("burger-menu-btn");
+            await expect(burgerBtn).toBeVisible();
+            await burgerBtn.click();
+        }
+
+        await page.getByTestId("inputs-link").click();
+        await page.waitForURL(`${baseURL}/inputs`);
+
+        await expect(
+            page.getByPlaceholder("Search by Address / Txn Hash / Index"),
+        ).toBeVisible();
+
+        await expect(
+            page.getByRole("heading", { name: "Inputs" }),
+        ).toBeVisible();
+
+        await expect(
+            page.getByRole("row", { name: "From To Method Index Age Data" }),
+        ).toBeVisible();
+
+        // For each input row it actually inserts 3 <tr>
+        await expect(page.getByRole("row")).toHaveCount(31);
+    });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,10 @@
         "lint": "next lint",
         "test": "vitest run",
         "test:watch": "vitest",
-        "test:ci": "vitest run --coverage"
+        "test:ci": "vitest run --coverage",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui",
+        "test:e2e:local": "run-s build test:e2e"
     },
     "dependencies": {
         "@cartesi/rollups-explorer-ui": "*",
@@ -51,6 +54,7 @@
         "@graphql-codegen/typescript-operations": "^4",
         "@graphql-codegen/typescript-urql": "^4",
         "@graphql-typed-document-node/core": "^3",
+        "@playwright/test": "^1.43.1",
         "@sunodo/wagmi-plugin-hardhat-deploy": "^0.2",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^14.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,8 +13,7 @@
         "test:watch": "vitest",
         "test:ci": "vitest run --coverage",
         "test:e2e": "playwright test",
-        "test:e2e:ui": "playwright test --ui",
-        "test:e2e:local": "run-s build test:e2e"
+        "test:e2e:ui": "playwright test --ui"
     },
     "dependencies": {
         "@cartesi/rollups-explorer-ui": "*",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
+const BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -24,8 +20,7 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        // baseURL: 'http://127.0.0.1:3000',
-
+        baseURL: BASE_URL,
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: "on-first-retry",
     },
@@ -34,21 +29,25 @@ export default defineConfig({
     projects: [
         {
             name: "chromium",
-            use: { ...devices["Desktop Chrome"] },
+            grepInvert: /mobile/,
+            use: { ...devices[""] },
         },
 
         {
             name: "firefox",
+            grepInvert: /mobile/,
             use: { ...devices["Desktop Firefox"] },
         },
 
         {
             name: "webkit",
+            grepInvert: /mobile/,
             use: { ...devices["Desktop Safari"] },
         },
 
         {
             name: "Mobile Safari",
+            grep: /mobile/,
             use: { ...devices["iPhone 12"] },
         },
     ],

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,62 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+    testDir: "./e2e",
+    /* Run tests in files in parallel */
+    fullyParallel: true,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 1 : undefined,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: [["list"], ["html", { outputFolder: "playwright-report" }]],
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+        /* Base URL to use in actions like `await page.goto('/')`. */
+        // baseURL: 'http://127.0.0.1:3000',
+
+        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+        trace: "on-first-retry",
+    },
+
+    /* Configure projects for major browsers */
+    projects: [
+        {
+            name: "chromium",
+            use: { ...devices["Desktop Chrome"] },
+        },
+
+        {
+            name: "firefox",
+            use: { ...devices["Desktop Firefox"] },
+        },
+
+        {
+            name: "webkit",
+            use: { ...devices["Desktop Safari"] },
+        },
+
+        {
+            name: "Mobile Safari",
+            use: { ...devices["iPhone 12"] },
+        },
+    ],
+
+    /* Run your local dev server before starting the tests */
+    // webServer: {
+    //     command: "yarn run start",
+    //     url: "http://127.0.0.1:3000",
+    //     reuseExistingServer: !process.env.CI,
+    // },
+});

--- a/apps/web/src/components/layout/shell.tsx
+++ b/apps/web/src/components/layout/shell.tsx
@@ -8,6 +8,7 @@ import {
     NavLink,
     Stack,
     Switch,
+    VisuallyHidden,
     useMantineColorScheme,
     useMantineTheme,
 } from "@mantine/core";
@@ -82,6 +83,7 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
             <AppShell.Header data-testid="header">
                 <Group h="100%" px="md">
                     <Burger
+                        data-testid="burger-menu-btn"
                         opened={opened}
                         onClick={toggle}
                         hiddenFrom="sm"
@@ -108,17 +110,33 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
                                 />
                             )}
                             <Switch
+                                wrapperProps={{
+                                    "data-testid": "theme-mode-switch",
+                                }}
                                 checked={colorScheme === "dark"}
                                 onChange={() => toggleColorScheme()}
                                 size="md"
                                 onLabel={
-                                    <TbSun color={theme.white} size="1rem" />
+                                    <>
+                                        <VisuallyHidden>
+                                            Light Mode
+                                        </VisuallyHidden>
+                                        <TbSun
+                                            color={theme.white}
+                                            size="1rem"
+                                        />
+                                    </>
                                 }
                                 offLabel={
-                                    <TbMoonStars
-                                        color={theme.colors.gray[6]}
-                                        size="1rem"
-                                    />
+                                    <>
+                                        <VisuallyHidden>
+                                            Dark Mode
+                                        </VisuallyHidden>
+                                        <TbMoonStars
+                                            color={theme.colors.gray[6]}
+                                            size="1rem"
+                                        />
+                                    </>
                                 }
                             />
                         </Group>
@@ -161,6 +179,8 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
                     />
 
                     <NavLink
+                        component="button"
+                        data-testid="menu-item-send-transaction"
                         label="Send Transaction"
                         leftSection={<TbArrowsDownUp />}
                         disabled={!isConnected}

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,8 @@
         "NEXT_PUBLIC_CHAIN_ID",
         "NEXT_PUBLIC_EXPLORER_API_URL",
         "NEXT_PUBLIC_ALCHEMY_API_KEY",
-        "CI"
+        "CI",
+        "E2E_BASE_URL"
     ],
     "pipeline": {
         "build": {

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,8 @@
         "BASE_PATH",
         "NEXT_PUBLIC_CHAIN_ID",
         "NEXT_PUBLIC_EXPLORER_API_URL",
-        "NEXT_PUBLIC_ALCHEMY_API_KEY"
+        "NEXT_PUBLIC_ALCHEMY_API_KEY",
+        "CI"
     ],
     "pipeline": {
         "build": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3362,6 +3362,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.43.1":
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.43.1.tgz#16728a59eb8ce0f60472f98d8886d6cab0fa3e42"
+  integrity sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==
+  dependencies:
+    playwright "1.43.1"
+
 "@radix-ui/react-compose-refs@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
@@ -8507,6 +8514,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -11759,6 +11771,20 @@ pkg-types@^1.0.3:
     jsonc-parser "^3.2.0"
     mlly "^1.2.0"
     pathe "^1.1.0"
+
+playwright-core@1.43.1:
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.43.1.tgz#0eafef9994c69c02a1a3825a4343e56c99c03b02"
+  integrity sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==
+
+playwright@1.43.1:
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.43.1.tgz#8ad08984ac66c9ef3d0db035be54dd7ec9f1c7d9"
+  integrity sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==
+  dependencies:
+    playwright-core "1.43.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 pngjs@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
### Summary
Code changes to add E2E capability to the `apps/web`. The setup is to run the [Playwright](https://playwright.dev/) locally. Github action integration will come later. 

Changes: 
* I added setup for the rollups-explorer ui.
* I added a few cases for initial reference. e.g. how to navigate between pages
* I added cases for desktop and mobile checks separately. That means desktop devices will not run test cases under the title `mobile`. 
* I updated the main `README` with a section including information about the **E2E testing**.