### PR TITLE
#168 Add e2e tests for home page

### DIFF
--- a/apps/web/e2e/pages/home.spec.ts
+++ b/apps/web/e2e/pages/home.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+});
+
+test.describe("Home page", () => {
+    test("should display latest inputs section", async ({ page }) => {
+        // Find latest inputs section
+        const latestInputsSection = page.getByTestId("latest-inputs");
+
+        // Wait for the section to be visible
+        await expect(latestInputsSection).toBeVisible();
+
+        // Verify section title
+        await expect(
+            latestInputsSection.getByText("Latest inputs"),
+        ).toBeVisible();
+
+        // Verify that table with correct columns is visible
+        await expect(
+            latestInputsSection
+                .getByRole("row", { name: "Address Age" })
+                .first(),
+        ).toBeVisible();
+
+        // Find view all inputs link
+        const viewAllLink = latestInputsSection.getByText("View all inputs");
+        await expect(viewAllLink).toBeVisible();
+
+        // Click the link
+        await viewAllLink.click();
+
+        // Verify navigation to inputs page
+        await page.waitForURL("/inputs");
+    });
+
+    test("should display latest applications section", async ({ page }) => {
+        // Find latest applications section
+        const latestApplicationsSection = page.getByTestId(
+            "latest-applications",
+        );
+
+        // Wait for the section to be visible
+        await expect(latestApplicationsSection).toBeVisible();
+
+        // Verify section title
+        await expect(
+            latestApplicationsSection.getByText("Latest applications"),
+        ).toBeVisible();
+
+        // Verify that table with correct columns is visible
+        await expect(
+            latestApplicationsSection
+                .getByRole("row", { name: "Address Age" })
+                .first(),
+        ).toBeVisible();
+
+        // Find view all inputs link
+        const viewAllLink = latestApplicationsSection.getByText(
+            "View all applications",
+        );
+        await expect(viewAllLink).toBeVisible();
+
+        // Click the link
+        await viewAllLink.click();
+
+        // Verify navigation to inputs page
+        await page.waitForURL("/applications");
+    });
+
+    test("should display inputs summary", async ({ page }) => {
+        // Find entries summary section
+        const entriesSummarySection = page.getByTestId("entries-summary");
+
+        // Wait for the section to be visible
+        await expect(entriesSummarySection).toBeVisible();
+
+        // Verify section title
+        await expect(entriesSummarySection.getByText("Inputs")).toBeVisible();
+    });
+
+    test("should display applications summary", async ({ page }) => {
+        // Find entries summary section
+        const entriesSummarySection = page.getByTestId("entries-summary");
+
+        // Wait for the section to be visible
+        await expect(entriesSummarySection).toBeVisible();
+
+        // Verify section title
+        await expect(
+            entriesSummarySection.getByText("Applications"),
+        ).toBeVisible();
+    });
+});

--- a/apps/web/e2e/pages/home.spec.ts
+++ b/apps/web/e2e/pages/home.spec.ts
@@ -4,92 +4,82 @@ test.beforeEach(async ({ page }) => {
     await page.goto("/");
 });
 
-test.describe("Home page", () => {
-    test("should display latest inputs section", async ({ page }) => {
-        // Find latest inputs section
-        const latestInputsSection = page.getByTestId("latest-inputs");
+test("should display latest inputs section", async ({ page }) => {
+    // Find latest inputs section
+    const latestInputsSection = page.getByTestId("latest-inputs");
 
-        // Wait for the section to be visible
-        await expect(latestInputsSection).toBeVisible();
+    // Wait for the section to be visible
+    await expect(latestInputsSection).toBeVisible();
 
-        // Verify section title
-        await expect(
-            latestInputsSection.getByText("Latest inputs"),
-        ).toBeVisible();
+    // Verify section title
+    await expect(latestInputsSection.getByText("Latest inputs")).toBeVisible();
 
-        // Verify that table with correct columns is visible
-        await expect(
-            latestInputsSection
-                .getByRole("row", { name: "Address Age" })
-                .first(),
-        ).toBeVisible();
+    // Verify that table with correct columns is visible
+    await expect(
+        latestInputsSection.getByRole("row", { name: "Address Age" }).first(),
+    ).toBeVisible();
 
-        // Find view all inputs link
-        const viewAllLink = latestInputsSection.getByText("View all inputs");
-        await expect(viewAllLink).toBeVisible();
+    // Find "View all inputs" link
+    const viewAllLink = latestInputsSection.getByText("View all inputs");
+    await expect(viewAllLink).toBeVisible();
 
-        // Click the link
-        await viewAllLink.click();
+    // Click the link
+    await viewAllLink.click();
 
-        // Verify navigation to inputs page
-        await page.waitForURL("/inputs");
-    });
+    // Verify navigation to inputs page
+    await page.waitForURL("/inputs");
+});
 
-    test("should display latest applications section", async ({ page }) => {
-        // Find latest applications section
-        const latestApplicationsSection = page.getByTestId(
-            "latest-applications",
-        );
+test("should display latest applications section", async ({ page }) => {
+    // Find latest applications section
+    const latestApplicationsSection = page.getByTestId("latest-applications");
 
-        // Wait for the section to be visible
-        await expect(latestApplicationsSection).toBeVisible();
+    // Wait for the section to be visible
+    await expect(latestApplicationsSection).toBeVisible();
 
-        // Verify section title
-        await expect(
-            latestApplicationsSection.getByText("Latest applications"),
-        ).toBeVisible();
+    // Verify section title
+    await expect(
+        latestApplicationsSection.getByText("Latest applications"),
+    ).toBeVisible();
 
-        // Verify that table with correct columns is visible
-        await expect(
-            latestApplicationsSection
-                .getByRole("row", { name: "Address Age" })
-                .first(),
-        ).toBeVisible();
+    // Verify that table with correct columns is visible
+    await expect(
+        latestApplicationsSection
+            .getByRole("row", { name: "Address Age" })
+            .first(),
+    ).toBeVisible();
 
-        // Find view all inputs link
-        const viewAllLink = latestApplicationsSection.getByText(
-            "View all applications",
-        );
-        await expect(viewAllLink).toBeVisible();
+    // Find "View all applications" link
+    const viewAllLink = latestApplicationsSection.getByText(
+        "View all applications",
+    );
+    await expect(viewAllLink).toBeVisible();
 
-        // Click the link
-        await viewAllLink.click();
+    // Click the link
+    await viewAllLink.click();
 
-        // Verify navigation to inputs page
-        await page.waitForURL("/applications");
-    });
+    // Verify navigation to applications page
+    await page.waitForURL("/applications");
+});
 
-    test("should display inputs summary", async ({ page }) => {
-        // Find entries summary section
-        const entriesSummarySection = page.getByTestId("entries-summary");
+test("should display inputs summary", async ({ page }) => {
+    // Find entries summary section
+    const entriesSummarySection = page.getByTestId("entries-summary");
 
-        // Wait for the section to be visible
-        await expect(entriesSummarySection).toBeVisible();
+    // Wait for the section to be visible
+    await expect(entriesSummarySection).toBeVisible();
 
-        // Verify section title
-        await expect(entriesSummarySection.getByText("Inputs")).toBeVisible();
-    });
+    // Verify section title
+    await expect(entriesSummarySection.getByText("Inputs")).toBeVisible();
+});
 
-    test("should display applications summary", async ({ page }) => {
-        // Find entries summary section
-        const entriesSummarySection = page.getByTestId("entries-summary");
+test("should display applications summary", async ({ page }) => {
+    // Find entries summary section
+    const entriesSummarySection = page.getByTestId("entries-summary");
 
-        // Wait for the section to be visible
-        await expect(entriesSummarySection).toBeVisible();
+    // Wait for the section to be visible
+    await expect(entriesSummarySection).toBeVisible();
 
-        // Verify section title
-        await expect(
-            entriesSummarySection.getByText("Applications"),
-        ).toBeVisible();
-    });
+    // Verify section title
+    await expect(entriesSummarySection.getByText("Applications")).toBeVisible();
 });

--- a/apps/web/src/components/entriesSummary.tsx
+++ b/apps/web/src/components/entriesSummary.tsx
@@ -21,11 +21,13 @@ const EntriesSummary: FC = () => {
         : 0;
 
     return (
-        <Summary
-            inputs={stats?.inputsConnection?.totalCount ?? 0}
-            applications={stats?.applicationsConnection?.totalCount ?? 0}
-            applicationsOwned={applicationsOwnedCount}
-        />
+        <div data-testid="entries-summary">
+            <Summary
+                inputs={stats?.inputsConnection?.totalCount ?? 0}
+                applications={stats?.applicationsConnection?.totalCount ?? 0}
+                applicationsOwned={applicationsOwnedCount}
+            />
+        </div>
     );
 };
 

--- a/apps/web/src/components/entriesSummary.tsx
+++ b/apps/web/src/components/entriesSummary.tsx
@@ -21,13 +21,12 @@ const EntriesSummary: FC = () => {
         : 0;
 
     return (
-        <div data-testid="entries-summary">
-            <Summary
-                inputs={stats?.inputsConnection?.totalCount ?? 0}
-                applications={stats?.applicationsConnection?.totalCount ?? 0}
-                applicationsOwned={applicationsOwnedCount}
-            />
-        </div>
+        <Summary
+            inputs={stats?.inputsConnection?.totalCount ?? 0}
+            applications={stats?.applicationsConnection?.totalCount ?? 0}
+            applicationsOwned={applicationsOwnedCount}
+            data-testid="entries-summary"
+        />
     );
 };
 

--- a/apps/web/src/components/latestEntries.tsx
+++ b/apps/web/src/components/latestEntries.tsx
@@ -110,7 +110,11 @@ const LatestEntries: FC = () => {
 
     return (
         <Grid gutter="md">
-            <Grid.Col span={{ base: 12, md: 6 }} my="md">
+            <Grid.Col
+                span={{ base: 12, md: 6 }}
+                my="md"
+                data-testid="latest-inputs"
+            >
                 <LatestEntriesCard
                     title="Latest inputs"
                     Icon={TbInbox}
@@ -122,7 +126,11 @@ const LatestEntries: FC = () => {
                 />
             </Grid.Col>
 
-            <Grid.Col span={{ base: 12, md: 6 }} my="md">
+            <Grid.Col
+                span={{ base: 12, md: 6 }}
+                my="md"
+                data-testid="latest-applications"
+            >
                 <LatestEntriesCard
                     title="Latest applications"
                     Icon={TbApps}

--- a/packages/ui/src/Summary.tsx
+++ b/packages/ui/src/Summary.tsx
@@ -1,24 +1,25 @@
 "use client";
-import { Grid } from "@mantine/core";
+import { Grid, GridProps } from "@mantine/core";
 import { FC } from "react";
 import { TbApps, TbInbox } from "react-icons/tb";
 import { useAccount } from "wagmi";
 import { SummaryCard } from "./SummaryCard";
 
-export type SummaryProps = {
+export interface SummaryProps extends GridProps {
     inputs: number;
     applications: number;
     applicationsOwned: number;
-};
+}
 
 export const Summary: FC<SummaryProps> = ({
     inputs,
     applications,
     applicationsOwned,
+    ...restProps
 }: SummaryProps) => {
     const { isConnected } = useAccount();
     return (
-        <Grid gutter="md">
+        <Grid gutter="md" {...restProps}>
             <Grid.Col span={{ base: 12, md: isConnected ? 4 : 6 }} my="md">
                 <SummaryCard title="Inputs" icon={TbInbox} value={inputs} />
             </Grid.Col>


### PR DESCRIPTION
I added e2e tests for the home page covering the summary cards for inputs and applications as well as the latest inputs and applications tables.