### PR TITLE
Feat: Application summary page access

### DIFF
--- a/apps/web/src/components/applications/applicationRow.tsx
+++ b/apps/web/src/components/applications/applicationRow.tsx
@@ -1,7 +1,12 @@
-import { ActionIcon, Table, Tooltip } from "@mantine/core";
+import { ActionIcon, Group, Table, Tooltip } from "@mantine/core";
 import Link from "next/link";
 import { FC } from "react";
-import { TbInbox, TbPlugConnected, TbPlugConnectedX } from "react-icons/tb";
+import {
+    TbInbox,
+    TbPlugConnected,
+    TbPlugConnectedX,
+    TbStack2,
+} from "react-icons/tb";
 import { Address as AddressType } from "viem";
 import { Application } from "../../graphql/explorer/types";
 import { useConnectionConfig } from "../../providers/connectionConfig/hooks";
@@ -40,39 +45,49 @@ const ApplicationRow: FC<ApplicationRowProps> = (props) => {
             </Table.Td>
             <Table.Td>{connection?.url ?? "N/A"}</Table.Td>
             <Table.Td>
-                <Tooltip label="Inputs">
-                    <Link
-                        href={`/applications/${appId}/inputs`}
-                        data-testid="applications-link"
-                    >
-                        <ActionIcon variant="default">
-                            <TbInbox />
-                        </ActionIcon>
-                    </Link>
-                </Tooltip>
-                {hasConnection(appId) ? (
-                    <Tooltip label="Remove connection">
-                        <ActionIcon
-                            data-testid="remove-connection"
-                            variant="default"
-                            ml={4}
-                            onClick={() => removeConnection(appId)}
+                <Group gap="xs">
+                    <Tooltip label="Summary">
+                        <Link
+                            href={`/applications/${appId}`}
+                            data-testid="applications-summary-link"
                         >
-                            <TbPlugConnectedX />
-                        </ActionIcon>
+                            <ActionIcon variant="default">
+                                <TbStack2 />
+                            </ActionIcon>
+                        </Link>
                     </Tooltip>
-                ) : (
-                    <Tooltip label="Add a connection">
-                        <ActionIcon
-                            data-testid="add-connection"
-                            variant="default"
-                            ml={4}
-                            onClick={() => showConnectionModal(appId)}
+                    <Tooltip label="Inputs">
+                        <Link
+                            href={`/applications/${appId}/inputs`}
+                            data-testid="applications-link"
                         >
-                            <TbPlugConnected />
-                        </ActionIcon>
+                            <ActionIcon variant="default">
+                                <TbInbox />
+                            </ActionIcon>
+                        </Link>
                     </Tooltip>
-                )}
+                    {hasConnection(appId) ? (
+                        <Tooltip label="Remove connection">
+                            <ActionIcon
+                                data-testid="remove-connection"
+                                variant="default"
+                                onClick={() => removeConnection(appId)}
+                            >
+                                <TbPlugConnectedX />
+                            </ActionIcon>
+                        </Tooltip>
+                    ) : (
+                        <Tooltip label="Add a connection">
+                            <ActionIcon
+                                data-testid="add-connection"
+                                variant="default"
+                                onClick={() => showConnectionModal(appId)}
+                            >
+                                <TbPlugConnected />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                </Group>
             </Table.Td>
         </Table.Tr>
     );

--- a/apps/web/src/components/applications/applications.tsx
+++ b/apps/web/src/components/applications/applications.tsx
@@ -96,7 +96,7 @@ const AllApplications: FC = () => {
 
 export const Applications = () => {
     return (
-        <Tabs defaultValue="all-apps">
+        <Tabs defaultValue="all-apps" keepMounted={false}>
             <Tabs.List>
                 <Tabs.Tab value="all-apps">All Apps</Tabs.Tab>
                 <Tabs.Tab value="my-apps">My Apps</Tabs.Tab>

--- a/apps/web/src/components/applications/userApplicationsRow.tsx
+++ b/apps/web/src/components/applications/userApplicationsRow.tsx
@@ -1,8 +1,13 @@
-import { ActionIcon, Box, Table, Text, Tooltip } from "@mantine/core";
+import { ActionIcon, Box, Group, Table, Text, Tooltip } from "@mantine/core";
 import Link from "next/link";
 import prettyMilliseconds from "pretty-ms";
 import { FC } from "react";
-import { TbInbox, TbPlugConnected, TbPlugConnectedX } from "react-icons/tb";
+import {
+    TbInbox,
+    TbPlugConnected,
+    TbPlugConnectedX,
+    TbStack2,
+} from "react-icons/tb";
 import { Address as AddressType } from "viem";
 import { useConnectionConfig } from "../../providers/connectionConfig/hooks";
 import Address from "../address";
@@ -41,39 +46,51 @@ const UserApplicationsRow: FC<ApplicationRowProps> = (props) => {
                 </Box>
             </Table.Td>
             <Table.Td>
-                <Tooltip label="Inputs">
-                    <Link
-                        href={`/applications/${appId}/inputs`}
-                        data-testid="applications-link"
-                    >
-                        <ActionIcon variant="default">
-                            <TbInbox />
-                        </ActionIcon>
-                    </Link>
-                </Tooltip>
-                {hasConnection(appId) ? (
-                    <Tooltip label="Remove connection">
-                        <ActionIcon
-                            data-testid="remove-connection"
-                            variant="default"
-                            ml={4}
-                            onClick={() => removeConnection(appId)}
+                <Group gap="xs">
+                    <Tooltip label="Summary">
+                        <Link
+                            href={`/applications/${appId}`}
+                            data-testid="applications-summary-link"
                         >
-                            <TbPlugConnectedX />
-                        </ActionIcon>
+                            <ActionIcon variant="default">
+                                <TbStack2 />
+                            </ActionIcon>
+                        </Link>
                     </Tooltip>
-                ) : (
-                    <Tooltip label="Add a connection">
-                        <ActionIcon
-                            data-testid="add-connection"
-                            variant="default"
-                            ml={4}
-                            onClick={() => showConnectionModal(appId)}
+                    <Tooltip label="Inputs">
+                        <Link
+                            href={`/applications/${appId}/inputs`}
+                            data-testid="applications-link"
                         >
-                            <TbPlugConnected />
-                        </ActionIcon>
+                            <ActionIcon variant="default">
+                                <TbInbox />
+                            </ActionIcon>
+                        </Link>
                     </Tooltip>
-                )}
+                    {hasConnection(appId) ? (
+                        <Tooltip label="Remove connection">
+                            <ActionIcon
+                                data-testid="remove-connection"
+                                variant="default"
+                                ml={4}
+                                onClick={() => removeConnection(appId)}
+                            >
+                                <TbPlugConnectedX />
+                            </ActionIcon>
+                        </Tooltip>
+                    ) : (
+                        <Tooltip label="Add a connection">
+                            <ActionIcon
+                                data-testid="add-connection"
+                                variant="default"
+                                ml={4}
+                                onClick={() => showConnectionModal(appId)}
+                            >
+                                <TbPlugConnected />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                </Group>
             </Table.Td>
         </Table.Tr>
     );

--- a/apps/web/test/components/applications/applicationRow.test.tsx
+++ b/apps/web/test/components/applications/applicationRow.test.tsx
@@ -1,12 +1,12 @@
-import { afterEach, beforeEach, describe, it } from "vitest";
-import type { FC } from "react";
+import { Table } from "@mantine/core";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { FC } from "react";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import ApplicationRow, {
     ApplicationRowProps,
 } from "../../../src/components/applications/applicationRow";
-import { withMantineTheme } from "../../utils/WithMantineTheme";
-import { Table } from "@mantine/core";
 import { useConnectionConfig } from "../../../src/providers/connectionConfig/hooks";
+import { withMantineTheme } from "../../utils/WithMantineTheme";
 
 vi.mock("../../../src/providers/connectionConfig/hooks");
 const useConnectionConfigMock = vi.mocked(useConnectionConfig, true);
@@ -109,6 +109,16 @@ describe("ApplicationRow component", () => {
         render(<Component {...defaultProps} />);
 
         expect(screen.getByText(defaultConnection.url)).toBeInTheDocument();
+    });
+
+    it("should display link to the application summary page", () => {
+        render(<Component {...defaultProps} />);
+        const link = screen.getByTestId("applications-summary-link");
+
+        expect(link).toBeInTheDocument();
+        expect(link.getAttribute("href")).toBe(
+            `/applications/${defaultProps.application.id}`,
+        );
     });
 
     it("should display link to application inputs page", () => {

--- a/apps/web/test/components/applications/userApplicationRow.test.tsx
+++ b/apps/web/test/components/applications/userApplicationRow.test.tsx
@@ -95,6 +95,16 @@ describe("ApplicationRow component", () => {
         expect(screen.getByText(defaultConnection.url)).toBeInTheDocument();
     });
 
+    it("should display link to application summary page", () => {
+        render(<Component {...defaultProps} />);
+        const link = screen.getByTestId("applications-summary-link");
+
+        expect(link).toBeInTheDocument();
+        expect(link.getAttribute("href")).toBe(
+            `/applications/${defaultProps.application.id}`,
+        );
+    });
+
     it("should display link to application inputs page", () => {
         render(<Component {...defaultProps} />);
         const link = screen.getByTestId("applications-link");


### PR DESCRIPTION
### Summary
Code changes to add access to an application's summary page from the `/applications` page. Also, include a small change to avoid unintended rewrites in the query parameters done by the component not selected, i.e., the only mounted component is the one under the selected tab.