### PR TITLE
#171 Make applications tables responsive

### DIFF
--- a/apps/web/src/components/applications/applicationRow.tsx
+++ b/apps/web/src/components/applications/applicationRow.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Table, Tooltip } from "@mantine/core";
+import { ActionIcon, Box, Group, Paper, Table, Tooltip } from "@mantine/core";
 import Link from "next/link";
 import { FC } from "react";
 import {
@@ -14,10 +14,11 @@ import Address from "../address";
 
 export interface ApplicationRowProps {
     application: Omit<Application, "inputs">;
+    keepDataColVisible: boolean;
 }
 
 const ApplicationRow: FC<ApplicationRowProps> = (props) => {
-    const { application } = props;
+    const { application, keepDataColVisible } = props;
     const {
         getConnection,
         hasConnection,
@@ -30,64 +31,115 @@ const ApplicationRow: FC<ApplicationRowProps> = (props) => {
     return (
         <Table.Tr key={application.id}>
             <Table.Td>
-                <Address value={appId} icon shorten />
+                <Box
+                    display="flex"
+                    w="max-content"
+                    style={{
+                        alignItems: "center",
+                        justifyContent: "center",
+                    }}
+                >
+                    <Address value={appId} icon shorten />
+                </Box>
             </Table.Td>
             <Table.Td>
-                {application.owner ? (
-                    <Address
-                        value={application.owner as AddressType}
-                        icon
-                        shorten
-                    />
-                ) : (
-                    "N/A"
-                )}
-            </Table.Td>
-            <Table.Td>{connection?.url ?? "N/A"}</Table.Td>
-            <Table.Td>
-                <Group gap="xs">
-                    <Tooltip label="Summary">
-                        <Link
-                            href={`/applications/${appId}`}
-                            data-testid="applications-summary-link"
-                        >
-                            <ActionIcon variant="default">
-                                <TbStack2 />
-                            </ActionIcon>
-                        </Link>
-                    </Tooltip>
-                    <Tooltip label="Inputs">
-                        <Link
-                            href={`/applications/${appId}/inputs`}
-                            data-testid="applications-link"
-                        >
-                            <ActionIcon variant="default">
-                                <TbInbox />
-                            </ActionIcon>
-                        </Link>
-                    </Tooltip>
-                    {hasConnection(appId) ? (
-                        <Tooltip label="Remove connection">
-                            <ActionIcon
-                                data-testid="remove-connection"
-                                variant="default"
-                                onClick={() => removeConnection(appId)}
-                            >
-                                <TbPlugConnectedX />
-                            </ActionIcon>
-                        </Tooltip>
+                <Box
+                    display="flex"
+                    w="max-content"
+                    style={{
+                        alignItems: "center",
+                        justifyContent: "center",
+                    }}
+                >
+                    {application.owner ? (
+                        <Address
+                            value={application.owner as AddressType}
+                            icon
+                            shorten
+                        />
                     ) : (
-                        <Tooltip label="Add a connection">
-                            <ActionIcon
-                                data-testid="add-connection"
-                                variant="default"
-                                onClick={() => showConnectionModal(appId)}
-                            >
-                                <TbPlugConnected />
-                            </ActionIcon>
-                        </Tooltip>
+                        "N/A"
                     )}
-                </Group>
+                </Box>
+            </Table.Td>
+            <Table.Td>
+                <Box
+                    display="flex"
+                    w="max-content"
+                    style={{
+                        alignItems: "center",
+                        justifyContent: "center",
+                    }}
+                >
+                    {connection?.url ?? "N/A"}
+                </Box>
+            </Table.Td>
+            <Table.Td
+                pos={keepDataColVisible ? "initial" : "sticky"}
+                top={0}
+                right={0}
+                p={0}
+            >
+                <Paper
+                    shadow={keepDataColVisible ? undefined : "xl"}
+                    radius={0}
+                    p="var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-xs))"
+                >
+                    <Box
+                        display="flex"
+                        w="max-content"
+                        style={{
+                            alignItems: "center",
+                            justifyContent: "center",
+                        }}
+                    >
+                        <Group gap="xs">
+                            <Tooltip label="Summary">
+                                <Link
+                                    href={`/applications/${appId}`}
+                                    data-testid="applications-summary-link"
+                                >
+                                    <ActionIcon variant="default">
+                                        <TbStack2 />
+                                    </ActionIcon>
+                                </Link>
+                            </Tooltip>
+                            <Tooltip label="Inputs">
+                                <Link
+                                    href={`/applications/${appId}/inputs`}
+                                    data-testid="applications-link"
+                                >
+                                    <ActionIcon variant="default">
+                                        <TbInbox />
+                                    </ActionIcon>
+                                </Link>
+                            </Tooltip>
+                            {hasConnection(appId) ? (
+                                <Tooltip label="Remove connection">
+                                    <ActionIcon
+                                        data-testid="remove-connection"
+                                        variant="default"
+                                        onClick={() => removeConnection(appId)}
+                                    >
+                                        <TbPlugConnectedX />
+                                    </ActionIcon>
+                                </Tooltip>
+                            ) : (
+                                <Tooltip label="Add a connection">
+                                    <ActionIcon
+                                        data-testid="add-connection"
+                                        variant="default"
+                                        onClick={() =>
+                                            showConnectionModal(appId)
+                                        }
+                                    >
+                                        <TbPlugConnected />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </Group>
+                    </Box>
+                </Paper>
             </Table.Td>
         </Table.Tr>
     );

--- a/apps/web/src/components/applications/applicationsTable.tsx
+++ b/apps/web/src/components/applications/applicationsTable.tsx
@@ -1,10 +1,19 @@
 "use client";
 
-import { Loader, Table, Text } from "@mantine/core";
-import { FC } from "react";
+import {
+    Loader,
+    Table,
+    Text,
+    Transition,
+    useMantineColorScheme,
+    useMantineTheme,
+} from "@mantine/core";
+import { FC, useRef } from "react";
 import { ApplicationItemFragment } from "../../graphql/explorer/operations";
 import { Application } from "../../graphql/explorer/types";
 import ApplicationRow from "./applicationRow";
+import { useElementVisibility } from "../../hooks/useElementVisibility";
+import TableResponsiveWrapper from "../tableResponsiveWrapper";
 
 export interface ApplicationsTableProps {
     applications: ApplicationItemFragment[];
@@ -14,40 +23,75 @@ export interface ApplicationsTableProps {
 
 const ApplicationsTable: FC<ApplicationsTableProps> = (props) => {
     const { applications, fetching, totalCount } = props;
+    const tableRowRef = useRef<HTMLDivElement>(null);
+    const theme = useMantineTheme();
+    const { colorScheme } = useMantineColorScheme();
+    const bgColor = colorScheme === "dark" ? theme.colors.dark[7] : theme.white;
+    const { childrenRef, isVisible } = useElementVisibility({
+        element: tableRowRef,
+    });
 
     return (
-        <Table>
-            <Table.Thead>
-                <Table.Tr>
-                    <Table.Th>Id</Table.Th>
-                    <Table.Th>Owner</Table.Th>
-                    <Table.Th>URL</Table.Th>
-                </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-                {fetching ? (
+        <TableResponsiveWrapper ref={tableRowRef}>
+            <Table width={"100%"} style={{ borderCollapse: "collapse" }}>
+                <Table.Thead>
                     <Table.Tr>
-                        <Table.Td align="center" colSpan={3}>
-                            <Loader />
-                        </Table.Td>
+                        <Table.Th>Id</Table.Th>
+                        <Table.Th>Owner</Table.Th>
+                        <Table.Th>URL</Table.Th>
+                        <Table.Th ref={childrenRef}>Data</Table.Th>
+                        <Transition
+                            mounted={isVisible}
+                            transition="scale-x"
+                            duration={500}
+                            timingFunction="ease-out"
+                        >
+                            {(styles) => (
+                                <th
+                                    style={{
+                                        ...styles,
+                                        position: "sticky",
+                                        top: 0,
+                                        right: 0,
+                                        backgroundColor: bgColor,
+                                        padding:
+                                            "var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-lg))",
+                                    }}
+                                >
+                                    Data
+                                </th>
+                            )}
+                        </Transition>
                     </Table.Tr>
-                ) : (
-                    totalCount === 0 && (
+                </Table.Thead>
+                <Table.Tbody>
+                    {fetching ? (
                         <Table.Tr>
-                            <Table.Td colSpan={3} align="center">
-                                <Text fw={700}>No applications</Text>
+                            <Table.Td align="center" colSpan={4}>
+                                <Loader />
                             </Table.Td>
                         </Table.Tr>
-                    )
-                )}
-                {applications.map((application) => (
-                    <ApplicationRow
-                        key={application.id}
-                        application={application as Omit<Application, "inputs">}
-                    />
-                ))}
-            </Table.Tbody>
-        </Table>
+                    ) : (
+                        totalCount === 0 && (
+                            <Table.Tr>
+                                <Table.Td colSpan={4} align="center">
+                                    <Text fw={700}>No applications</Text>
+                                </Table.Td>
+                            </Table.Tr>
+                        )
+                    )}
+                    {applications.map((application) => (
+                        <ApplicationRow
+                            key={application.id}
+                            application={
+                                application as Omit<Application, "inputs">
+                            }
+                            keepDataColVisible={!isVisible}
+                        />
+                    ))}
+                </Table.Tbody>
+            </Table>
+        </TableResponsiveWrapper>
     );
 };
 

--- a/apps/web/src/components/applications/userApplicationsRow.tsx
+++ b/apps/web/src/components/applications/userApplicationsRow.tsx
@@ -1,4 +1,12 @@
-import { ActionIcon, Box, Group, Table, Text, Tooltip } from "@mantine/core";
+import {
+    ActionIcon,
+    Box,
+    Group,
+    Paper,
+    Table,
+    Text,
+    Tooltip,
+} from "@mantine/core";
 import Link from "next/link";
 import prettyMilliseconds from "pretty-ms";
 import { FC } from "react";
@@ -13,8 +21,12 @@ import { useConnectionConfig } from "../../providers/connectionConfig/hooks";
 import Address from "../address";
 import { ApplicationRowProps } from "./applicationRow";
 
-const UserApplicationsRow: FC<ApplicationRowProps> = (props) => {
-    const { application } = props;
+export interface UserApplicationsRowProps extends ApplicationRowProps {
+    timeType: "timestamp" | "age";
+}
+
+const UserApplicationsRow: FC<UserApplicationsRowProps> = (props) => {
+    const { application, keepDataColVisible, timeType } = props;
     const {
         getConnection,
         hasConnection,
@@ -26,71 +38,117 @@ const UserApplicationsRow: FC<ApplicationRowProps> = (props) => {
     return (
         <Table.Tr key={application.id}>
             <Table.Td>
-                <Address value={appId} icon shorten />
+                <Box
+                    display="flex"
+                    w="max-content"
+                    style={{
+                        alignItems: "center",
+                        justifyContent: "center",
+                    }}
+                >
+                    <Address value={appId} icon shorten />
+                </Box>
             </Table.Td>
             <Table.Td>{connection?.url ?? "N/A"}</Table.Td>
             <Table.Td>
-                <Box>
+                <Box
+                    display="flex"
+                    w="max-content"
+                    style={{
+                        alignItems: "center",
+                        justifyContent: "center",
+                    }}
+                >
                     <Text>
-                        {application &&
-                            application?.timestamp &&
-                            `${prettyMilliseconds(
-                                Date.now() - application?.timestamp * 1000,
-                                {
-                                    unitCount: 2,
-                                    secondsDecimalDigits: 0,
-                                    verbose: true,
-                                },
-                            )} ago`}
+                        {application && application?.timestamp && (
+                            <>
+                                {timeType === "age"
+                                    ? `${prettyMilliseconds(
+                                          Date.now() -
+                                              application.timestamp * 1000,
+                                          {
+                                              unitCount: 2,
+                                              secondsDecimalDigits: 0,
+                                              verbose: true,
+                                          },
+                                      )} ago`
+                                    : new Date(
+                                          application.timestamp * 1000,
+                                      ).toISOString()}
+                            </>
+                        )}
                     </Text>
                 </Box>
             </Table.Td>
-            <Table.Td>
-                <Group gap="xs">
-                    <Tooltip label="Summary">
-                        <Link
-                            href={`/applications/${appId}`}
-                            data-testid="applications-summary-link"
-                        >
-                            <ActionIcon variant="default">
-                                <TbStack2 />
-                            </ActionIcon>
-                        </Link>
-                    </Tooltip>
-                    <Tooltip label="Inputs">
-                        <Link
-                            href={`/applications/${appId}/inputs`}
-                            data-testid="applications-link"
-                        >
-                            <ActionIcon variant="default">
-                                <TbInbox />
-                            </ActionIcon>
-                        </Link>
-                    </Tooltip>
-                    {hasConnection(appId) ? (
-                        <Tooltip label="Remove connection">
-                            <ActionIcon
-                                data-testid="remove-connection"
-                                variant="default"
-                                ml={4}
-                                onClick={() => removeConnection(appId)}
-                            >
-                                <TbPlugConnectedX />
-                            </ActionIcon>
-                        </Tooltip>
-                    ) : (
-                        <Tooltip label="Add a connection">
-                            <ActionIcon
-                                data-testid="add-connection"
-                                variant="default"
-                                ml={4}
-                                onClick={() => showConnectionModal(appId)}
-                            >
-                                <TbPlugConnected />
-                            </ActionIcon>
-                        </Tooltip>
-                    )}
-                </Group>
+
+            <Table.Td
+                pos={keepDataColVisible ? "initial" : "sticky"}
+                top={0}
+                right={0}
+                p={0}
+            >
+                <Paper
+                    shadow={keepDataColVisible ? undefined : "xl"}
+                    radius={0}
+                    p="var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-xs))"
+                >
+                    <Box
+                        display="flex"
+                        w="max-content"
+                        style={{
+                            alignItems: "center",
+                            justifyContent: "center",
+                        }}
+                    >
+                        <Group gap="xs">
+                            <Tooltip label="Summary">
+                                <Link
+                                    href={`/applications/${appId}`}
+                                    data-testid="applications-summary-link"
+                                >
+                                    <ActionIcon variant="default">
+                                        <TbStack2 />
+                                    </ActionIcon>
+                                </Link>
+                            </Tooltip>
+                            <Tooltip label="Inputs">
+                                <Link
+                                    href={`/applications/${appId}/inputs`}
+                                    data-testid="applications-link"
+                                >
+                                    <ActionIcon variant="default">
+                                        <TbInbox />
+                                    </ActionIcon>
+                                </Link>
+                            </Tooltip>
+                            {hasConnection(appId) ? (
+                                <Tooltip label="Remove connection">
+                                    <ActionIcon
+                                        data-testid="remove-connection"
+                                        variant="default"
+                                        ml={4}
+                                        onClick={() => removeConnection(appId)}
+                                    >
+                                        <TbPlugConnectedX />
+                                    </ActionIcon>
+                                </Tooltip>
+                            ) : (
+                                <Tooltip label="Add a connection">
+                                    <ActionIcon
+                                        data-testid="add-connection"
+                                        variant="default"
+                                        ml={4}
+                                        onClick={() =>
+                                            showConnectionModal(appId)
+                                        }
+                                    >
+                                        <TbPlugConnected />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </Group>
+                    </Box>
+                </Paper>
             </Table.Td>
         </Table.Tr>
     );

--- a/apps/web/src/components/applications/userApplicationsTable.tsx
+++ b/apps/web/src/components/applications/userApplicationsTable.tsx
@@ -1,8 +1,18 @@
-import { Box, Loader, Table, Text } from "@mantine/core";
-import { FC } from "react";
+import {
+    Button,
+    Loader,
+    Table,
+    Text,
+    Transition,
+    useMantineColorScheme,
+    useMantineTheme,
+} from "@mantine/core";
+import { FC, useCallback, useRef, useState } from "react";
 import { Application } from "../../graphql/explorer/types";
 import { ApplicationsTableProps } from "./applicationsTable";
 import UserApplicationsRow from "./userApplicationsRow";
+import { useElementVisibility } from "../../hooks/useElementVisibility";
+import TableResponsiveWrapper from "../tableResponsiveWrapper";
 
 interface UserApplicationsTableProps extends ApplicationsTableProps {
     noResultsMessage?: string;
@@ -15,27 +25,71 @@ const UserApplicationsTable: FC<UserApplicationsTableProps> = (props) => {
         totalCount,
         noResultsMessage = "No applications",
     } = props;
+    const tableRowRef = useRef<HTMLDivElement>(null);
+    const theme = useMantineTheme();
+    const { colorScheme } = useMantineColorScheme();
+    const bgColor = colorScheme === "dark" ? theme.colors.dark[7] : theme.white;
+    const { childrenRef, isVisible } = useElementVisibility({
+        element: tableRowRef,
+    });
+    const [timeType, setTimeType] = useState<"timestamp" | "age">("age");
+
+    const onChangeTimeColumnType = useCallback(() => {
+        setTimeType((timeType) => (timeType === "age" ? "timestamp" : "age"));
+    }, []);
+
     return (
-        <Box>
-            <Table>
+        <TableResponsiveWrapper ref={tableRowRef}>
+            <Table width={"100%"} style={{ borderCollapse: "collapse" }}>
                 <Table.Thead>
                     <Table.Tr>
                         <Table.Th>Id</Table.Th>
                         <Table.Th>URL</Table.Th>
-                        <Table.Th>Age</Table.Th>
+                        <Table.Th>
+                            <Button
+                                variant="transparent"
+                                px={0}
+                                onClick={onChangeTimeColumnType}
+                            >
+                                {timeType === "age" ? "Age" : "Timestamp (UTC)"}
+                            </Button>
+                        </Table.Th>
+                        <Table.Th ref={childrenRef}>Data</Table.Th>
+                        <Transition
+                            mounted={isVisible}
+                            transition="scale-x"
+                            duration={500}
+                            timingFunction="ease-out"
+                        >
+                            {(styles) => (
+                                <th
+                                    style={{
+                                        ...styles,
+                                        position: "sticky",
+                                        top: 0,
+                                        right: 0,
+                                        backgroundColor: bgColor,
+                                        padding:
+                                            "var(--table-vertical-spacing) var(--table-horizontal-spacing, var(--mantine-spacing-lg))",
+                                    }}
+                                >
+                                    Data
+                                </th>
+                            )}
+                        </Transition>
                     </Table.Tr>
                 </Table.Thead>
                 <Table.Tbody>
                     {fetching ? (
                         <Table.Tr>
-                            <Table.Td align="center" colSpan={3}>
+                            <Table.Td align="center" colSpan={4}>
                                 <Loader />
                             </Table.Td>
                         </Table.Tr>
                     ) : (
                         totalCount === 0 && (
                             <Table.Tr>
-                                <Table.Td colSpan={3} align="center">
+                                <Table.Td colSpan={4} align="center">
                                     <Text fw={700}>{noResultsMessage}</Text>
                                 </Table.Td>
                             </Table.Tr>
@@ -47,11 +101,13 @@ const UserApplicationsTable: FC<UserApplicationsTableProps> = (props) => {
                             application={
                                 application as Omit<Application, "inputs">
                             }
+                            timeType={timeType}
+                            keepDataColVisible={!isVisible}
                         />
                     ))}
                 </Table.Tbody>
             </Table>
-        </Box>
+        </TableResponsiveWrapper>
     );
 };
 

--- a/apps/web/src/components/inputs/inputsTable.tsx
+++ b/apps/web/src/components/inputs/inputsTable.tsx
@@ -11,7 +11,7 @@ import {
 import { FC, useCallback, useRef, useState } from "react";
 import type { InputItemFragment } from "../../graphql/explorer/operations";
 import { useElementVisibility } from "../../hooks/useElementVisibility";
-import { TableResponsiveWrapper } from "../tableResponsiveWrapper";
+import TableResponsiveWrapper from "../tableResponsiveWrapper";
 import InputRow from "./inputRow";
 
 export interface InputsTableProps {

--- a/apps/web/src/components/tableResponsiveWrapper.tsx
+++ b/apps/web/src/components/tableResponsiveWrapper.tsx
@@ -1,16 +1,18 @@
 import { Box, Flex } from "@mantine/core";
-import { forwardRef } from "react";
-type TableResponsiveWrapperProps = {
-    children: React.ReactNode;
-};
+import { forwardRef, ForwardRefRenderFunction, ReactNode } from "react";
 
-type Ref = HTMLDivElement;
-const Component = (props: any, ref: any) => {
-    const { children, ...restProps } = props;
+interface TableResponsiveWrapperProps {
+    children: ReactNode;
+}
+
+const TableResponsiveWrapper: ForwardRefRenderFunction<
+    HTMLDivElement,
+    TableResponsiveWrapperProps
+> = ({ children }, ref) => {
     return (
-        <Flex w="100%" align={"center"} direction={"column"}>
-            <Flex w="100%" align={"center"} direction={"column"}>
-                <Box style={{ position: "relative", width: "100%" }} ref={ref}>
+        <Flex direction="column" align="center" w="100%">
+            <Flex direction="column" align="center" w="100%">
+                <Box ref={ref} style={{ position: "relative", width: "100%" }}>
                     <Box style={{ overflowX: "auto", width: "100%" }}>
                         {children}
                     </Box>
@@ -20,7 +22,4 @@ const Component = (props: any, ref: any) => {
     );
 };
 
-export const TableResponsiveWrapper = forwardRef<
-    Ref,
-    TableResponsiveWrapperProps
->(Component);
+export default forwardRef(TableResponsiveWrapper);

--- a/apps/web/test/components/applications/applicationRow.test.tsx
+++ b/apps/web/test/components/applications/applicationRow.test.tsx
@@ -31,6 +31,7 @@ const defaultProps: ApplicationRowProps = {
             applications: [],
         },
     },
+    keepDataColVisible: true,
 };
 
 const defaultConnection = {
@@ -84,6 +85,7 @@ describe("ApplicationRow component", () => {
 
         render(
             <Component
+                {...defaultProps}
                 application={{
                     ...defaultProps.application,
                     owner: undefined,

--- a/apps/web/test/components/applications/applications.test.tsx
+++ b/apps/web/test/components/applications/applications.test.tsx
@@ -33,6 +33,15 @@ const useApplicationsConnectionQueryMock = vi.mocked(
 
 const Component = withMantineTheme(Applications);
 
+const IntersectionObserverMock = vi.fn(() => ({
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    takeRecords: vi.fn(),
+    unobserve: vi.fn(),
+}));
+
+vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
+
 describe("Applications component", () => {
     beforeEach(() => {
         useAccountMock.mockReturnValue(useAccountData as any);

--- a/apps/web/test/components/applications/userApplicationRow.test.tsx
+++ b/apps/web/test/components/applications/userApplicationRow.test.tsx
@@ -4,13 +4,15 @@ import prettyMilliseconds from "pretty-ms";
 import type { FC } from "react";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { ApplicationRowProps } from "../../../src/components/applications/applicationRow";
-import UserApplicationsRow from "../../../src/components/applications/userApplicationsRow";
+import UserApplicationsRow, {
+    UserApplicationsRowProps,
+} from "../../../src/components/applications/userApplicationsRow";
 import { useConnectionConfig } from "../../../src/providers/connectionConfig/hooks";
 import { withMantineTheme } from "../../utils/WithMantineTheme";
 vi.mock("../../../src/providers/connectionConfig/hooks");
 const useConnectionConfigMock = vi.mocked(useConnectionConfig, true);
 
-const TableComponent: FC<ApplicationRowProps> = (props) => (
+const TableComponent: FC<UserApplicationsRowProps> = (props) => (
     <Table>
         <Table.Tbody>
             <UserApplicationsRow {...props} />
@@ -20,7 +22,7 @@ const TableComponent: FC<ApplicationRowProps> = (props) => (
 
 const Component = withMantineTheme(TableComponent);
 
-const defaultProps: ApplicationRowProps = {
+const defaultProps: UserApplicationsRowProps = {
     application: {
         id: "0x028367fe226cd9e5699f4288d512fe3a4a4a0012",
         owner: "0x74d093f6911ac080897c3145441103dabb869307",
@@ -30,6 +32,8 @@ const defaultProps: ApplicationRowProps = {
             applications: [],
         },
     },
+    keepDataColVisible: false,
+    timeType: "age",
 };
 
 const defaultConnection = {
@@ -37,7 +41,7 @@ const defaultConnection = {
     url: "https://echo-python.sepolia.rollups.staging.cartesi.io/graphql",
 };
 
-describe("ApplicationRow component", () => {
+describe("UserApplicationRow component", () => {
     beforeEach(() => {
         useConnectionConfigMock.mockReturnValue({
             hasConnection: vi.fn(),
@@ -63,7 +67,8 @@ describe("ApplicationRow component", () => {
 
         expect(screen.getByText(shortenedId)).toBeInTheDocument();
     });
-    it("should display the correct timestamp", () => {
+
+    it("should display the correct age", () => {
         render(<Component {...defaultProps} />);
         const { application } = defaultProps;
 
@@ -76,6 +81,14 @@ describe("ApplicationRow component", () => {
             },
         )} ago`;
         expect(screen.getByText(age)).toBeInTheDocument();
+    });
+
+    it("should display the correct timestamp", () => {
+        render(<Component {...defaultProps} timeType="timestamp" />);
+        const { application } = defaultProps;
+
+        const timestamp = new Date(application.timestamp * 1000).toISOString();
+        expect(screen.getByText(timestamp)).toBeInTheDocument();
     });
 
     it("should display N/A when no connection exists", () => {


### PR DESCRIPTION
I made the applications and user applications table responsive. I also made some slight refactoring for a couple of components. Additionally, I made a [task](https://github.com/cartesi/rollups-explorer/issues/178) about extracting this repetitive responsive table logic into a reusable component.