### PR TITLE
Feature: Add support to DappAddressRelay 

### DIFF
--- a/apps/web/src/components/sendTransaction.tsx
+++ b/apps/web/src/components/sendTransaction.tsx
@@ -1,11 +1,12 @@
 "use client";
 import {
-    DepositFormSuccessData,
+    AddressRelayForm,
     ERC1155DepositForm,
     ERC20DepositForm,
     ERC721DepositForm,
     EtherDepositForm,
     RawInputForm,
+    TransactionFormSuccessData,
 } from "@cartesi/rollups-explorer-ui";
 import { Select } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
@@ -67,7 +68,7 @@ const SendTransaction: FC<DepositProps> = ({
     }, []);
 
     const onSuccess = useCallback(
-        ({ receipt, type }: DepositFormSuccessData) => {
+        ({ receipt, type }: TransactionFormSuccessData) => {
             const message = receipt?.transactionHash
                 ? {
                       message: (
@@ -76,9 +77,9 @@ const SendTransaction: FC<DepositProps> = ({
                               type="tx"
                           />
                       ),
-                      title: `${type} transfer completed`,
+                      title: `${type} transaction completed`,
                   }
-                : { message: `${type} transfer completed.` };
+                : { message: `${type} transaction completed.` };
 
             notifications.show({
                 withCloseButton: true,
@@ -97,7 +98,7 @@ const SendTransaction: FC<DepositProps> = ({
         <>
             <Select
                 label="Type"
-                placeholder="Select deposit type"
+                placeholder="Select transaction type"
                 mb={16}
                 allowDeselect={false}
                 data={[
@@ -112,6 +113,12 @@ const SendTransaction: FC<DepositProps> = ({
                                 value: "erc1155Batch",
                                 label: "ERC-1155 Batch Deposit",
                             },
+                        ],
+                    },
+                    {
+                        group: "Relay",
+                        items: [
+                            { value: "relay", label: "Application Address" },
                         ],
                     },
                     {
@@ -171,6 +178,13 @@ const SendTransaction: FC<DepositProps> = ({
                     isLoadingApplications={fetching}
                     onSearchApplications={setApplicationId}
                     onSearchTokens={setMultiTokenId}
+                    onSuccess={onSuccess}
+                />
+            ) : depositType === "relay" ? (
+                <AddressRelayForm
+                    applications={applications}
+                    isLoadingApplications={fetching}
+                    onSearchApplications={setApplicationId}
                     onSuccess={onSuccess}
                 />
             ) : null}

--- a/apps/web/src/lib/methodResolver.ts
+++ b/apps/web/src/lib/methodResolver.ts
@@ -1,5 +1,6 @@
 "use client";
 import {
+    dAppAddressRelayAddress,
     erc1155BatchPortalAddress,
     erc1155SinglePortalAddress,
     erc20PortalAddress,
@@ -31,12 +32,17 @@ const erc1155BatchPortalResolver: MethodResolver = (input) =>
     getAddress(input.msgSender) === erc1155BatchPortalAddress &&
     "depositERC1155BatchTokens";
 
+const dAppAddressRelayResolver: MethodResolver = (input) =>
+    getAddress(input.msgSender) === dAppAddressRelayAddress &&
+    "relayDAppAddress";
+
 const resolvers: MethodResolver[] = [
     etherDepositResolver,
     erc20PortalResolver,
     erc721PortalResolver,
     erc1155SinglePortalResolver,
     erc1155BatchPortalResolver,
+    dAppAddressRelayResolver,
 ];
 
 export const methodResolver: MethodResolver = (input) => {

--- a/apps/web/test/lib/methodResolver.test.ts
+++ b/apps/web/test/lib/methodResolver.test.ts
@@ -1,13 +1,14 @@
-import { describe, it } from "vitest";
 import {
+    dAppAddressRelayAddress,
     erc1155BatchPortalAddress,
     erc1155SinglePortalAddress,
     erc20PortalAddress,
     erc721PortalAddress,
     etherPortalAddress,
 } from "@cartesi/rollups-wagmi";
-import { methodResolver } from "../../src/lib/methodResolver";
+import { describe, it } from "vitest";
 import { InputItemFragment } from "../../src/graphql/explorer/operations";
+import { methodResolver } from "../../src/lib/methodResolver";
 
 const defaultInput: InputItemFragment = {
     id: "0x60a7048c3136293071605a4eaffef49923e981cc-40",
@@ -26,7 +27,7 @@ const defaultInput: InputItemFragment = {
 };
 
 describe("methodResolver", () => {
-    it("should resolve correct method", () => {
+    it("should resolve correct method name", () => {
         let method = methodResolver(defaultInput);
 
         expect(method).toBe(undefined);
@@ -65,5 +66,12 @@ describe("methodResolver", () => {
         });
 
         expect(method).toBe("depositERC1155BatchTokens");
+
+        method = methodResolver({
+            ...defaultInput,
+            msgSender: dAppAddressRelayAddress,
+        });
+
+        expect(method).toEqual("relayDAppAddress");
     });
 });

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache libc6-compat
 RUN apk update
 
 WORKDIR /app
-RUN yarn global add turbo
+RUN yarn global add turbo@1.13.3
 COPY . .
 RUN turbo prune --scope=web --docker
 

--- a/packages/ui/src/AddressRelayForm.tsx
+++ b/packages/ui/src/AddressRelayForm.tsx
@@ -1,0 +1,148 @@
+import {
+    useSimulateDAppAddressRelayRelayDAppAddress,
+    useWriteDAppAddressRelayRelayDAppAddress,
+} from "@cartesi/rollups-wagmi";
+import {
+    Alert,
+    Autocomplete,
+    Button,
+    Collapse,
+    Group,
+    Loader,
+    Stack,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { is } from "ramda";
+import { FC, useEffect } from "react";
+import { TbAlertCircle, TbCheck } from "react-icons/tb";
+import { BaseError, getAddress, isAddress, zeroAddress } from "viem";
+import { useWaitForTransactionReceipt } from "wagmi";
+import { TransactionFormSuccessData } from "./DepositFormTypes";
+import { TransactionProgress } from "./TransactionProgress";
+import { transactionState } from "./TransactionState";
+import useUndeployedApplication from "./hooks/useUndeployedApplication";
+
+export interface AddressRelayFormProps {
+    applications: string[];
+    isLoadingApplications: boolean;
+    onSearchApplications: (applicationId: string) => void;
+    onSuccess?: (receipt: TransactionFormSuccessData) => void;
+}
+
+export const AddressRelayForm: FC<AddressRelayFormProps> = (props) => {
+    const {
+        applications,
+        isLoadingApplications,
+        onSearchApplications,
+        onSuccess,
+    } = props;
+    const form = useForm({
+        validateInputOnChange: true,
+        initialValues: {
+            application: "",
+        },
+        validate: {
+            application: (value) =>
+                value !== "" && isAddress(value)
+                    ? null
+                    : "Invalid application address",
+        },
+        transformValues: (values) => ({
+            address: isAddress(values.application)
+                ? getAddress(values.application)
+                : zeroAddress,
+        }),
+    });
+    const { address } = form.getTransformedValues();
+    const prepare = useSimulateDAppAddressRelayRelayDAppAddress({
+        args: [address],
+        query: {
+            enabled: address !== zeroAddress,
+        },
+    });
+
+    const execute = useWriteDAppAddressRelayRelayDAppAddress();
+    const wait = useWaitForTransactionReceipt({
+        hash: execute.data,
+    });
+
+    const { loading, disabled } = transactionState(
+        prepare,
+        execute,
+        wait,
+        true,
+    );
+    const canSubmit = form.isValid();
+    const isUndeployedApp = useUndeployedApplication(address, applications);
+
+    useEffect(() => {
+        if (wait.isSuccess) {
+            if (is(Function, onSuccess))
+                onSuccess({ receipt: wait.data, type: "ADDRESS-RELAY" });
+            form.reset();
+            execute.reset();
+        }
+    }, [wait.isSuccess, wait.data, form, execute, onSuccess]);
+
+    return (
+        <form data-testid="address-relay-form">
+            <Stack>
+                <Autocomplete
+                    label="Application"
+                    data-testid="application"
+                    description="The application address to relay."
+                    placeholder="0x"
+                    data={applications}
+                    withAsterisk
+                    rightSection={
+                        (prepare.isLoading || isLoadingApplications) && (
+                            <Loader size="xs" />
+                        )
+                    }
+                    {...form.getInputProps("application")}
+                    error={
+                        form.errors.application ||
+                        (prepare.error as BaseError)?.shortMessage
+                    }
+                    onChange={(nextValue) => {
+                        form.setFieldValue("application", nextValue);
+                        onSearchApplications(nextValue);
+                    }}
+                />
+
+                {!form.errors.application && isUndeployedApp && (
+                    <Alert
+                        variant="light"
+                        color="yellow"
+                        icon={<TbAlertCircle />}
+                    >
+                        This is an undeployed application.
+                    </Alert>
+                )}
+
+                <Collapse in={!execute.isIdle || execute.isError}>
+                    <TransactionProgress
+                        prepare={prepare}
+                        execute={execute}
+                        wait={wait}
+                        defaultErrorMessage={execute.error?.message}
+                    />
+                </Collapse>
+
+                <Group justify="right">
+                    <Button
+                        variant="filled"
+                        disabled={disabled || !canSubmit}
+                        leftSection={<TbCheck />}
+                        loading={loading}
+                        onClick={() =>
+                            execute.writeContract(prepare.data!.request)
+                        }
+                    >
+                        Send
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};

--- a/packages/ui/src/DepositFormTypes.ts
+++ b/packages/ui/src/DepositFormTypes.ts
@@ -1,8 +1,14 @@
 import { UseWaitForTransactionReceiptReturnType } from "wagmi";
 
-export type DEPOSIT_TYPE = "ERC-1155" | "ERC-20" | "ERC-721" | "ETHER" | "RAW";
+export type TRANSACTION_TYPE =
+    | "ERC-1155"
+    | "ERC-20"
+    | "ERC-721"
+    | "ETHER"
+    | "RAW"
+    | "ADDRESS-RELAY";
 
-export type DepositFormSuccessData = {
+export type TransactionFormSuccessData = {
     receipt: UseWaitForTransactionReceiptReturnType["data"];
-    type: DEPOSIT_TYPE;
+    type: TRANSACTION_TYPE;
 };

--- a/packages/ui/src/ERC1155DepositForm/types.ts
+++ b/packages/ui/src/ERC1155DepositForm/types.ts
@@ -1,4 +1,4 @@
-import { DepositFormSuccessData } from "../DepositFormTypes";
+import { TransactionFormSuccessData } from "../DepositFormTypes";
 
 export interface ERC1155DepositFormProps {
     mode: "single" | "batch";
@@ -7,5 +7,5 @@ export interface ERC1155DepositFormProps {
     isLoadingApplications: boolean;
     onSearchApplications: (applicationId: string) => void;
     onSearchTokens: (tokenId: string) => void;
-    onSuccess?: (receipt: DepositFormSuccessData) => void;
+    onSuccess?: (receipt: TransactionFormSuccessData) => void;
 }

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,4 +1,5 @@
-export { type DepositFormSuccessData } from "./DepositFormTypes";
+export { AddressRelayForm } from "./AddressRelayForm";
+export { type TransactionFormSuccessData } from "./DepositFormTypes";
 export { ERC1155DepositForm } from "./ERC1155DepositForm";
 export { ERC20DepositForm } from "./ERC20DepositForm";
 export { ERC721DepositForm } from "./ERC721DepositForm";

--- a/packages/ui/test/AddressRelayForm.test.tsx
+++ b/packages/ui/test/AddressRelayForm.test.tsx
@@ -1,0 +1,208 @@
+import {
+    useSimulateDAppAddressRelayRelayDAppAddress,
+    useWriteDAppAddressRelayRelayDAppAddress,
+} from "@cartesi/rollups-wagmi";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as viem from "viem";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { useWaitForTransactionReceipt } from "wagmi";
+import { AddressRelayForm } from "../src";
+import { AddressRelayFormProps } from "../src/AddressRelayForm";
+import withMantineTheme from "./utils/WithMantineTheme";
+import { applications } from "./utils/stubs";
+
+vi.mock("@cartesi/rollups-wagmi");
+vi.mock("wagmi");
+vi.mock("viem", async () => {
+    const actual = await vi.importActual<typeof viem>("viem");
+    return {
+        ...actual,
+        getAddress: (address: string) => address,
+    };
+});
+
+const useSimulateRelayDAppAddressMock = vi.mocked(
+    useSimulateDAppAddressRelayRelayDAppAddress,
+    { partial: true },
+);
+const useWriteRelayDAppAddressMock = vi.mocked(
+    useWriteDAppAddressRelayRelayDAppAddress,
+    { partial: true },
+);
+
+const useWaitForTransactionReceiptMock = vi.mocked(
+    useWaitForTransactionReceipt,
+    { partial: true },
+);
+
+const Component = withMantineTheme(AddressRelayForm);
+
+const defaultProps: AddressRelayFormProps = {
+    applications: applications,
+    isLoadingApplications: false,
+    onSearchApplications: vi.fn(),
+    onSuccess: vi.fn(),
+};
+
+describe("AddressRelayform", () => {
+    beforeEach(() => {
+        useSimulateRelayDAppAddressMock.mockReturnValue({
+            isPending: false,
+            isLoading: false,
+            fetchStatus: "idle",
+            data: { request: {} },
+            error: null,
+        });
+
+        useWriteRelayDAppAddressMock.mockReturnValue({
+            isIdle: true,
+            isError: false,
+            status: "idle",
+            reset: () => {},
+        });
+
+        useWaitForTransactionReceiptMock.mockReturnValue({
+            status: "pending",
+            fetchStatus: "idle",
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        cleanup();
+    });
+
+    it("should display expected fields", () => {
+        render(<Component {...defaultProps} />);
+
+        expect(screen.getByText("Application")).toBeInTheDocument();
+        expect(screen.getByText("The application address to relay."));
+    });
+
+    it("should display error when application is not an address", () => {
+        render(<Component {...defaultProps} />);
+
+        fireEvent.change(screen.getByTestId("application"), {
+            target: { value: "non-valid-address" },
+        });
+
+        expect(
+            screen.getByText("Invalid application address"),
+        ).toBeInTheDocument();
+    });
+
+    it("should display an warning message for underployed application", async () => {
+        render(<Component {...defaultProps} />);
+
+        fireEvent.change(screen.getByTestId("application"), {
+            target: { value: "0x7bd3565af78d8457c81ff8b4870a174fa3783eb0" },
+        });
+
+        expect(
+            await screen.findByText("This is an undeployed application."),
+        ).toBeVisible();
+    });
+
+    it("should be able to click the send button when form is valid", () => {
+        const writeContract = vi.fn();
+
+        useWriteRelayDAppAddressMock.mockReturnValue({
+            writeContract,
+            data: "0x0002",
+            status: "idle",
+        });
+
+        render(<Component {...defaultProps} />);
+
+        fireEvent.change(screen.getByTestId("application"), {
+            target: { value: applications[0] },
+        });
+
+        fireEvent.click(screen.getByText("Send"));
+
+        expect(writeContract).toHaveBeenCalledTimes(1);
+    });
+
+    it("should display feedback while waiting transaction confirmation", () => {
+        useWriteRelayDAppAddressMock.mockReturnValue({
+            isIdle: false,
+            status: "pending",
+            data: "0x0001",
+        });
+
+        useWaitForTransactionReceiptMock.mockImplementation((params) => {
+            return params?.hash === "0x0001"
+                ? {
+                      isLoading: true,
+                      status: "pending",
+                      fetchStatus: "fetching",
+                  }
+                : {
+                      isLoading: false,
+                      status: "pending",
+                      fetchStatus: "idle",
+                  };
+        });
+
+        render(<Component {...defaultProps} />);
+
+        fireEvent.change(screen.getByTestId("application"), {
+            target: { value: applications[0] },
+        });
+
+        const btn = screen.getByText("Send").closest("button");
+        expect(btn?.getAttribute("data-loading")).toEqual("true");
+        expect(screen.getByText("Waiting for confirmation...")).toBeVisible();
+    });
+
+    it("should cleanup and call onSuccess once the transaction is confirmed", async () => {
+        const executeReset = vi.fn();
+        // Avoiding infinite loop by making a computed prop change when deposit reset is called.
+        const executeWaitStatus = {
+            _status: "success",
+            get props(): {
+                status?: "success";
+                isSuccess?: true;
+            } {
+                return this._status === "success"
+                    ? { status: "success", isSuccess: true }
+                    : {};
+            },
+            reset() {
+                this._status = "idle";
+            },
+        };
+
+        useWriteRelayDAppAddressMock.mockReturnValue({
+            status: "success",
+            data: "0x0001",
+            reset: () => {
+                executeReset();
+                executeWaitStatus.reset();
+            },
+        });
+
+        useWaitForTransactionReceiptMock.mockImplementation((params) => {
+            return params?.hash === "0x0001"
+                ? {
+                      ...executeWaitStatus.props,
+                      fetchStatus: "idle",
+                      data: { transactionHash: "0x01" },
+                  }
+                : {
+                      fetchStatus: "idle",
+                  };
+        });
+
+        const onSuccess = vi.fn();
+
+        render(<Component {...defaultProps} onSuccess={onSuccess} />);
+
+        fireEvent.change(screen.getByTestId("application"), {
+            target: { value: applications[0] },
+        });
+
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(executeReset).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/ui/test/utils/stubs.ts
+++ b/packages/ui/test/utils/stubs.ts
@@ -1,0 +1,5 @@
+export const applications = [
+    "0x60a7048c3136293071605a4eaffef49923e981cc",
+    "0x70ac08179605af2d9e75782b8decdd3c22aa4d0c",
+    "0x71ab24ee3ddb97dc01a161edf64c8d51102b0cd3",
+];


### PR DESCRIPTION
### Summary
Code changes to add support to use the `DappAddressRelay` to inform off-chain machine the address of the Dapp contract. More details  on #185. 



