### PR TITLE
Fix: Include main icon for Base

### DIFF
--- a/apps/web/src/components/networks/cartesiScanNetworks.tsx
+++ b/apps/web/src/components/networks/cartesiScanNetworks.tsx
@@ -152,6 +152,10 @@ const getIconByChainId = cond([
         (id: number) => includes(id, [optimism.id, optimismSepolia.id]),
         () => OptimismCircleColorful,
     ],
+    [
+        (id: number) => includes(id, [base.id, baseSepolia.id]),
+        () => BaseCircleColorful,
+    ],
     [T, () => HardhatColorful],
 ]);
 


### PR DESCRIPTION
### Summary
Code changes to add a new main icon for Base on `CartesiScanNetwork` component.