### PR TITLE
feat: Add formatting for JSON content in the input-details.

### DIFF
--- a/packages/ui/src/InputDetails/Content.tsx
+++ b/packages/ui/src/InputDetails/Content.tsx
@@ -2,6 +2,7 @@
 
 import { JsonInput, SegmentedControl, Textarea } from "@mantine/core";
 import { T, cond, equals, pipe, propOr } from "ramda";
+import { useEffect, useRef } from "react";
 import { Hex, hexToString } from "viem";
 
 export interface ContentProps {
@@ -43,14 +44,27 @@ export const DisplayContent = cond<
 >([
     [
         pipe(propOr("", "type"), equals("json")),
-        ({ content }) => (
-            <JsonInput
-                rows={10}
-                value={hexToString(content as Hex)}
-                readOnly
-                placeholder="No content defined"
-            />
-        ),
+        ({ content }) => {
+            const value = hexToString(content as Hex);
+            const ref = useRef<HTMLTextAreaElement>(null);
+
+            useEffect(() => {
+                if (ref.current !== null) {
+                    ref.current.blur();
+                }
+            }, [value]);
+
+            return (
+                <JsonInput
+                    autoFocus
+                    ref={ref}
+                    rows={10}
+                    defaultValue={value}
+                    placeholder="No content defined"
+                    formatOnBlur
+                />
+            );
+        },
     ],
     [
         pipe(propOr("", "type"), equals("text")),


### PR DESCRIPTION
### Summary
Apply code changes to improve readability in the input-details area. When the input payload is in a valid JSON format, the content inside the `<TextArea />` will be formatted to give better readability. 


![2024-06-18 15 48 46](https://github.com/cartesi/rollups-explorer/assets/1239768/bf9a085a-37da-44b7-9f13-da7fbaef6361)

I noticed a few oddities within the data already on-chain. Below are examples: One is a valid JSON format, and the other looks like one, but it is a string escaping other strings, therefore formatting will not be applied. 

Good format:
```JSON
{"name": "my-app-action", "value":"some_value"}
```

Bad format: 
```JSON
"{\"method\":\"create_something\",\"data\":{}}"
```
