### PR TITLE
#222 Update alerts for transaction forms

### DIFF
--- a/apps/web/src/components/sendTransaction.tsx
+++ b/apps/web/src/components/sendTransaction.tsx
@@ -59,14 +59,6 @@ const SendTransaction: FC<DepositProps> = ({
         address: debouncedMultiTokenId,
     });
 
-    const onDepositErc721 = useCallback(() => {
-        notifications.show({
-            message: "Token was deposited successfully",
-            color: "green",
-            withBorder: true,
-        });
-    }, []);
-
     const onSuccess = useCallback(
         ({ receipt, type }: TransactionFormSuccessData) => {
             const message = receipt?.transactionHash
@@ -138,6 +130,7 @@ const SendTransaction: FC<DepositProps> = ({
                     applications={applications}
                     isLoadingApplications={fetching}
                     onSearchApplications={setApplicationId}
+                    onSuccess={onSuccess}
                 />
             ) : depositType === "erc20" ? (
                 <ERC20DepositForm
@@ -146,19 +139,21 @@ const SendTransaction: FC<DepositProps> = ({
                     isLoadingApplications={fetching}
                     onSearchApplications={setApplicationId}
                     onSearchTokens={setTokenId}
+                    onSuccess={onSuccess}
                 />
             ) : depositType === "erc721" ? (
                 <ERC721DepositForm
                     applications={applications}
                     isLoadingApplications={fetching}
                     onSearchApplications={setApplicationId}
-                    onDeposit={onDepositErc721}
+                    onSuccess={onSuccess}
                 />
             ) : depositType === "input" ? (
                 <RawInputForm
                     applications={applications}
                     isLoadingApplications={fetching}
                     onSearchApplications={setApplicationId}
+                    onSuccess={onSuccess}
                 />
             ) : depositType === "erc1155" ? (
                 <ERC1155DepositForm

--- a/packages/ui/src/AddressRelayForm.tsx
+++ b/packages/ui/src/AddressRelayForm.tsx
@@ -12,7 +12,6 @@ import {
     Stack,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { is } from "ramda";
 import { FC, useEffect } from "react";
 import { TbAlertCircle, TbCheck } from "react-icons/tb";
 import { BaseError, getAddress, isAddress, zeroAddress } from "viem";
@@ -26,7 +25,7 @@ export interface AddressRelayFormProps {
     applications: string[];
     isLoadingApplications: boolean;
     onSearchApplications: (applicationId: string) => void;
-    onSuccess?: (receipt: TransactionFormSuccessData) => void;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
 }
 
 export const AddressRelayForm: FC<AddressRelayFormProps> = (props) => {
@@ -77,12 +76,12 @@ export const AddressRelayForm: FC<AddressRelayFormProps> = (props) => {
 
     useEffect(() => {
         if (wait.isSuccess) {
-            if (is(Function, onSuccess))
-                onSuccess({ receipt: wait.data, type: "ADDRESS-RELAY" });
+            onSuccess({ receipt: wait.data, type: "ADDRESS-RELAY" });
             form.reset();
             execute.reset();
         }
-    }, [wait.isSuccess, wait.data, form, execute, onSuccess]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [wait, onSuccess]);
 
     return (
         <form data-testid="address-relay-form">

--- a/packages/ui/src/AddressRelayForm.tsx
+++ b/packages/ui/src/AddressRelayForm.tsx
@@ -80,8 +80,7 @@ export const AddressRelayForm: FC<AddressRelayFormProps> = (props) => {
             form.reset();
             execute.reset();
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [wait, onSuccess]);
+    }, [wait, form, execute, onSuccess]);
 
     return (
         <form data-testid="address-relay-form">

--- a/packages/ui/src/ERC1155DepositForm/DepositFormBatch.tsx
+++ b/packages/ui/src/ERC1155DepositForm/DepositFormBatch.tsx
@@ -253,8 +253,7 @@ const DepositFormBatch: FC<Props> = (props) => {
 
     useEffect(() => {
         if (depositWait.isSuccess) {
-            if (onSuccess)
-                onSuccess({ receipt: depositWait.data, type: "ERC-1155" });
+            onSuccess({ receipt: depositWait.data, type: "ERC-1155" });
             form.reset();
             approve.reset();
             deposit.reset();

--- a/packages/ui/src/ERC1155DepositForm/DepositFormSingle.tsx
+++ b/packages/ui/src/ERC1155DepositForm/DepositFormSingle.tsx
@@ -29,8 +29,8 @@ import {
 } from "react-icons/tb";
 import {
     BaseError,
-    Hex,
     getAddress,
+    Hex,
     isAddress,
     isHex,
     parseUnits,
@@ -233,8 +233,7 @@ const DepositFormSingle: FC<Props> = (props) => {
 
     useEffect(() => {
         if (depositWait.isSuccess) {
-            if (onSuccess)
-                onSuccess({ receipt: depositWait.data, type: "ERC-1155" });
+            onSuccess({ receipt: depositWait.data, type: "ERC-1155" });
             form.reset();
             approve.reset();
             deposit.reset();

--- a/packages/ui/src/ERC1155DepositForm/types.ts
+++ b/packages/ui/src/ERC1155DepositForm/types.ts
@@ -7,5 +7,5 @@ export interface ERC1155DepositFormProps {
     isLoadingApplications: boolean;
     onSearchApplications: (applicationId: string) => void;
     onSearchTokens: (tokenId: string) => void;
-    onSuccess?: (receipt: TransactionFormSuccessData) => void;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
 }

--- a/packages/ui/src/ERC20DepositForm.tsx
+++ b/packages/ui/src/ERC20DepositForm.tsx
@@ -1,10 +1,10 @@
 import {
     erc20Abi,
     erc20PortalAddress,
-    useWriteErc20Approve,
     useSimulateErc20Approve,
-    useWriteErc20PortalDepositErc20Tokens,
     useSimulateErc20PortalDepositErc20Tokens,
+    useWriteErc20Approve,
+    useWriteErc20PortalDepositErc20Tokens,
 } from "@cartesi/rollups-wagmi";
 import {
     Alert,
@@ -16,8 +16,8 @@ import {
     Loader,
     Stack,
     Text,
-    TextInput,
     Textarea,
+    TextInput,
     UnstyledButton,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
@@ -33,9 +33,9 @@ import {
 } from "react-icons/tb";
 import {
     BaseError,
-    Hex,
     formatUnits,
     getAddress,
+    Hex,
     isAddress,
     isHex,
     parseUnits,
@@ -53,6 +53,7 @@ import {
 } from "./TransactionStatus";
 import useWatchQueryOnBlockChange from "./hooks/useWatchQueryOnBlockChange";
 import useUndeployedApplication from "./hooks/useUndeployedApplication";
+import { TransactionFormSuccessData } from "./DepositFormTypes";
 
 export const transactionButtonState = (
     prepare: TransactionWaitStatus,
@@ -78,6 +79,7 @@ export interface ERC20DepositFormProps {
     isLoadingApplications: boolean;
     onSearchApplications: (applicationId: string) => void;
     onSearchTokens: (tokenId: string) => void;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
 }
 
 export const ERC20DepositForm: FC<ERC20DepositFormProps> = (props) => {
@@ -87,6 +89,7 @@ export const ERC20DepositForm: FC<ERC20DepositFormProps> = (props) => {
         isLoadingApplications,
         onSearchApplications,
         onSearchTokens,
+        onSuccess,
     } = props;
 
     const [advanced, { toggle: toggleAdvanced }] = useDisclosure(false);
@@ -252,11 +255,14 @@ export const ERC20DepositForm: FC<ERC20DepositFormProps> = (props) => {
 
     useEffect(() => {
         if (depositWait.isSuccess) {
+            onSuccess({ receipt: depositWait.data, type: "ERC-20" });
             form.reset();
+            approve.reset();
+            deposit.reset();
             onSearchApplications("");
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [depositWait.isSuccess, onSearchApplications]);
+    }, [depositWait, onSearchApplications, onSuccess]);
 
     return (
         <form data-testid="erc20-deposit-form">

--- a/packages/ui/src/ERC721DepositForm.tsx
+++ b/packages/ui/src/ERC721DepositForm.tsx
@@ -1,10 +1,10 @@
 import {
     erc721Abi,
     erc721PortalAddress,
-    useWriteErc721Approve,
     useSimulateErc721Approve,
-    useWriteErc721PortalDepositErc721Token,
     useSimulateErc721PortalDepositErc721Token,
+    useWriteErc721Approve,
+    useWriteErc721PortalDepositErc721Token,
 } from "@cartesi/rollups-wagmi";
 import {
     Alert,
@@ -17,8 +17,8 @@ import {
     Select,
     Stack,
     Text,
-    TextInput,
     Textarea,
+    TextInput,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
@@ -32,8 +32,8 @@ import {
 } from "react-icons/tb";
 import {
     BaseError,
-    Hex,
     getAddress,
+    Hex,
     isAddress,
     isHex,
     zeroAddress,
@@ -51,6 +51,8 @@ import {
 import useWatchQueryOnBlockChange from "./hooks/useWatchQueryOnBlockChange";
 import useUndeployedApplication from "./hooks/useUndeployedApplication";
 import useTokensOfOwnerByIndex from "./hooks/useTokensOfOwnerByIndex";
+import { TransactionFormSuccessData } from "./DepositFormTypes";
+import { isFunction } from "ramda-adjunct";
 
 export const transactionButtonState = (
     prepare: TransactionWaitStatus,
@@ -74,7 +76,7 @@ export interface ERC721DepositFormProps {
     applications: string[];
     isLoadingApplications: boolean;
     onSearchApplications: (applicationId: string) => void;
-    onDeposit: () => void;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
 }
 
 export const ERC721DepositForm: FC<ERC721DepositFormProps> = (props) => {
@@ -82,7 +84,7 @@ export const ERC721DepositForm: FC<ERC721DepositFormProps> = (props) => {
         applications,
         isLoadingApplications,
         onSearchApplications,
-        onDeposit,
+        onSuccess,
     } = props;
     const [advanced, { toggle: toggleAdvanced }] = useDisclosure(false);
     const { address } = useAccount();
@@ -233,6 +235,7 @@ export const ERC721DepositForm: FC<ERC721DepositFormProps> = (props) => {
 
     useEffect(() => {
         if (depositWait.isSuccess) {
+            onSuccess({ receipt: depositWait.data, type: "ERC-721" });
             setDepositedTokens((tokens) => [
                 ...tokens,
                 tokenIdBigInt as bigint,
@@ -240,11 +243,10 @@ export const ERC721DepositForm: FC<ERC721DepositFormProps> = (props) => {
             form.reset();
             approve.reset();
             deposit.reset();
-            onDeposit();
             onSearchApplications("");
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [depositWait.isSuccess, tokenIdBigInt, onDeposit, onSearchApplications]);
+    }, [depositWait, tokenIdBigInt, onSearchApplications, onSuccess]);
 
     return (
         <form data-testid="erc721-deposit-form">

--- a/packages/ui/src/EtherDepositForm.tsx
+++ b/packages/ui/src/EtherDepositForm.tsx
@@ -1,6 +1,6 @@
 import {
-    useWriteEtherPortalDepositEther,
     useSimulateEtherPortalDepositEther,
+    useWriteEtherPortalDepositEther,
 } from "@cartesi/rollups-wagmi";
 import {
     Alert,
@@ -11,8 +11,8 @@ import {
     Loader,
     Stack,
     Text,
-    TextInput,
     Textarea,
+    TextInput,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
@@ -25,8 +25,8 @@ import {
 } from "react-icons/tb";
 import {
     BaseError,
-    Hex,
     getAddress,
+    Hex,
     isAddress,
     isHex,
     parseUnits,
@@ -35,15 +35,22 @@ import {
 import { useAccount, useWaitForTransactionReceipt } from "wagmi";
 import { TransactionProgress } from "./TransactionProgress";
 import useUndeployedApplication from "./hooks/useUndeployedApplication";
+import { TransactionFormSuccessData } from "./DepositFormTypes";
 
 export interface EtherDepositFormProps {
     applications: string[];
     isLoadingApplications: boolean;
     onSearchApplications: (applicationId: string) => void;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
 }
 
 export const EtherDepositForm: FC<EtherDepositFormProps> = (props) => {
-    const { applications, isLoadingApplications, onSearchApplications } = props;
+    const {
+        applications,
+        isLoadingApplications,
+        onSearchApplications,
+        onSuccess,
+    } = props;
     const [advanced, { toggle: toggleAdvanced }] = useDisclosure(false);
     const { chain } = useAccount();
     const form = useForm({
@@ -96,11 +103,13 @@ export const EtherDepositForm: FC<EtherDepositFormProps> = (props) => {
 
     useEffect(() => {
         if (wait.isSuccess) {
+            onSuccess({ receipt: wait.data, type: "ETHER" });
             form.reset();
+            execute.reset();
             onSearchApplications("");
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [wait.isSuccess, onSearchApplications]);
+    }, [wait, onSearchApplications, onSuccess]);
 
     return (
         <form data-testid="ether-deposit-form">

--- a/packages/ui/src/RawInputForm.tsx
+++ b/packages/ui/src/RawInputForm.tsx
@@ -28,6 +28,7 @@ import {
 import { useWaitForTransactionReceipt } from "wagmi";
 import { TransactionProgress } from "./TransactionProgress";
 import useUndeployedApplication from "./hooks/useUndeployedApplication";
+import { TransactionFormSuccessData } from "./DepositFormTypes";
 
 type Format = "hex" | "utf";
 
@@ -35,10 +36,16 @@ export interface RawInputFormProps {
     applications: string[];
     isLoadingApplications: boolean;
     onSearchApplications: (applicationId: string) => void;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
 }
 
 export const RawInputForm: FC<RawInputFormProps> = (props) => {
-    const { applications, isLoadingApplications, onSearchApplications } = props;
+    const {
+        applications,
+        isLoadingApplications,
+        onSearchApplications,
+        onSuccess,
+    } = props;
     const form = useForm({
         validateInputOnBlur: true,
         initialValues: {
@@ -81,11 +88,13 @@ export const RawInputForm: FC<RawInputFormProps> = (props) => {
 
     useEffect(() => {
         if (wait.isSuccess) {
+            onSuccess({ receipt: wait.data, type: "RAW" });
             form.reset();
+            execute.reset();
             onSearchApplications("");
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [wait.isSuccess, onSearchApplications]);
+    }, [wait, onSearchApplications, onSuccess]);
 
     return (
         <form data-testid="raw-input-form">

--- a/packages/ui/test/AddressRelayForm.test.tsx
+++ b/packages/ui/test/AddressRelayForm.test.tsx
@@ -44,7 +44,7 @@ const defaultProps: AddressRelayFormProps = {
     onSuccess: vi.fn(),
 };
 
-describe("AddressRelayform", () => {
+describe("AddressRelayForm", () => {
     beforeEach(() => {
         useSimulateRelayDAppAddressMock.mockReturnValue({
             isPending: false,
@@ -247,5 +247,17 @@ describe("AddressRelayform", () => {
         expect(
             screen.queryByText("Waiting for confirmation..."),
         ).not.toBeInTheDocument();
+    });
+
+    it("should invoke onSuccess callback after successful deposit", () => {
+        useWaitForTransactionReceiptMock.mockReturnValue({
+            error: null,
+            isSuccess: true,
+        });
+
+        const onSuccessMock = vi.fn();
+        render(<Component {...defaultProps} onSuccess={onSuccessMock} />);
+
+        expect(onSuccessMock).toHaveBeenCalled();
     });
 });

--- a/packages/ui/test/AddressRelayForm.test.tsx
+++ b/packages/ui/test/AddressRelayForm.test.tsx
@@ -250,13 +250,19 @@ describe("AddressRelayForm", () => {
     });
 
     it("should invoke onSuccess callback after successful deposit", () => {
-        useWaitForTransactionReceiptMock.mockReturnValue({
-            error: null,
-            isSuccess: true,
+        let counter = 0;
+        useWaitForTransactionReceiptMock.mockImplementation(() => {
+            const value = { error: null, isSuccess: counter === 0 };
+            counter += 1;
+            return value;
         });
 
         const onSuccessMock = vi.fn();
         render(<Component {...defaultProps} onSuccess={onSuccessMock} />);
+        useWaitForTransactionReceiptMock.mockReturnValue({
+            error: null,
+            isSuccess: false,
+        });
 
         expect(onSuccessMock).toHaveBeenCalled();
     });

--- a/packages/ui/test/ERC20DepositForm.test.tsx
+++ b/packages/ui/test/ERC20DepositForm.test.tsx
@@ -29,6 +29,7 @@ const defaultProps = {
     onSearchTokens: () => undefined,
     tokensQuery: mockChangeTokenQuery,
     applicationsQuery: mockChangeApplicationQuery,
+    onSuccess: () => undefined,
 };
 
 vi.mock("@cartesi/rollups-wagmi", async () => {
@@ -44,6 +45,7 @@ vi.mock("@cartesi/rollups-wagmi", async () => {
         useWriteErc20Approve: () => ({
             data: {},
             wait: vi.fn(),
+            reset: vi.fn(),
         }),
         useSimulateErc20PortalDepositErc20Tokens: () => ({
             data: {
@@ -54,6 +56,7 @@ vi.mock("@cartesi/rollups-wagmi", async () => {
         useWriteErc20PortalDepositErc20Tokens: () => ({
             data: {},
             wait: vi.fn(),
+            reset: vi.fn(),
         }),
     };
 });
@@ -171,6 +174,20 @@ describe("Rollups ERC20DepositForm", () => {
             expect(
                 screen.getByText("Invalid Application address"),
             ).toBeInTheDocument();
+        });
+
+        it("should invoke onSuccess callback after successful deposit", async () => {
+            const wagmi = await import("wagmi");
+            wagmi.useWaitForTransactionReceipt = vi.fn().mockReturnValue({
+                ...wagmi.useWaitForTransactionReceipt,
+                error: null,
+                isSuccess: true,
+            });
+
+            const onSuccessMock = vi.fn();
+            render(<Component {...defaultProps} onSuccess={onSuccessMock} />);
+
+            expect(onSuccessMock).toHaveBeenCalled();
         });
 
         it("should correctly format address", async () => {

--- a/packages/ui/test/ERC721DepositForm.test.tsx
+++ b/packages/ui/test/ERC721DepositForm.test.tsx
@@ -63,7 +63,7 @@ const defaultProps = {
     ],
     isLoadingApplications: false,
     onSearchApplications: () => undefined,
-    onDeposit: () => undefined,
+    onSuccess: () => undefined,
 };
 
 describe("ERC721DepositForm", () => {
@@ -321,7 +321,7 @@ describe("ERC721DepositForm", () => {
             expect(depositResetMock).toHaveBeenCalled();
         });
 
-        it("should invoke onDeposit callback after successful deposit", async () => {
+        it("should invoke onSuccess callback after successful deposit", async () => {
             const wagmi = await import("wagmi");
             wagmi.useWaitForTransactionReceipt = vi.fn().mockReturnValue({
                 ...wagmi.useWaitForTransactionReceipt,
@@ -329,10 +329,10 @@ describe("ERC721DepositForm", () => {
                 isSuccess: true,
             });
 
-            const onDepositMock = vi.fn();
-            render(<Component {...defaultProps} onDeposit={onDepositMock} />);
+            const onSuccessMock = vi.fn();
+            render(<Component {...defaultProps} onSuccess={onSuccessMock} />);
 
-            expect(onDepositMock).toHaveBeenCalled();
+            expect(onSuccessMock).toHaveBeenCalled();
         });
 
         it("should display error when application is invalid", () => {

--- a/packages/ui/test/EtherDepositForm.test.tsx
+++ b/packages/ui/test/EtherDepositForm.test.tsx
@@ -16,6 +16,7 @@ const defaultProps = {
     applications,
     isLoadingApplications: false,
     onSearchApplications: () => undefined,
+    onSuccess: () => undefined,
 };
 
 vi.mock("@cartesi/rollups-wagmi", async () => {
@@ -25,9 +26,11 @@ vi.mock("@cartesi/rollups-wagmi", async () => {
                 request: {},
             },
             config: {},
+            reset: vi.fn(),
         }),
         useWriteEtherPortalDepositEther: () => ({
             wait: vi.fn(),
+            reset: vi.fn(),
         }),
     };
 });
@@ -192,6 +195,7 @@ describe("Rollups EtherDepositForm", () => {
                 .mockReturnValue({
                     ...rollupsWagmi.useWriteEtherPortalDepositEther,
                     writeContract: mockedWrite,
+                    reset: vi.fn(),
                 });
 
             const { container } = render(<Component {...defaultProps} />);
@@ -369,6 +373,20 @@ describe("Rollups EtherDepositForm", () => {
                 },
                 value: 100000000000000000n,
             });
+        });
+
+        it("should invoke onSuccess callback after successful deposit", async () => {
+            const wagmi = await import("wagmi");
+            wagmi.useWaitForTransactionReceipt = vi.fn().mockReturnValue({
+                ...wagmi.useWaitForTransactionReceipt,
+                error: null,
+                isSuccess: true,
+            });
+
+            const onSuccessMock = vi.fn();
+            render(<Component {...defaultProps} onSuccess={onSuccessMock} />);
+
+            expect(onSuccessMock).toHaveBeenCalled();
         });
     });
 

--- a/packages/ui/test/RawInputForm.test.tsx
+++ b/packages/ui/test/RawInputForm.test.tsx
@@ -16,6 +16,7 @@ const defaultProps = {
     applications,
     isLoadingApplications: false,
     onSearchApplications: () => undefined,
+    onSuccess: () => undefined,
 };
 
 vi.mock("@cartesi/rollups-wagmi", async () => {
@@ -28,6 +29,8 @@ vi.mock("@cartesi/rollups-wagmi", async () => {
         }),
         useWriteInputBoxAddInput: () => ({
             wait: vi.fn(),
+            reset: vi.fn(),
+            execute: vi.fn(),
         }),
     };
 });
@@ -220,6 +223,8 @@ describe("Rollups RawInputForm", () => {
             rollupsWagmi.useWriteInputBoxAddInput = vi.fn().mockReturnValue({
                 ...rollupsWagmi.useWriteInputBoxAddInput,
                 writeContract: mockedWrite,
+                execute: vi.fn(),
+                reset: vi.fn(),
             });
 
             const { container } = render(<Component {...defaultProps} />);
@@ -334,6 +339,20 @@ describe("Rollups RawInputForm", () => {
                     enabled: true,
                 },
             });
+        });
+
+        it("should invoke onSuccess callback after successful deposit", async () => {
+            const wagmi = await import("wagmi");
+            wagmi.useWaitForTransactionReceipt = vi.fn().mockReturnValue({
+                ...wagmi.useWaitForTransactionReceipt,
+                error: null,
+                isSuccess: true,
+            });
+
+            const onSuccessMock = vi.fn();
+            render(<Component {...defaultProps} onSuccess={onSuccessMock} />);
+
+            expect(onSuccessMock).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
I implemented the `onSuccess` callback for all transaction forms and made that callback also required (instead of optional). Additionally, I had to tweak some unit.