### PR TITLE
#238 Fix voucher execution alert

### DIFF
--- a/apps/web/src/components/inputs/voucherExecution.tsx
+++ b/apps/web/src/components/inputs/voucherExecution.tsx
@@ -86,9 +86,9 @@ const VoucherExecution: FC<VoucherExecutionType> = (props) => {
     }, [wait.isSuccess]);
 
     useEffect(() => {
-        if (prepare.isError) {
+        if (hasVoucherProof && prepare.isError) {
             notifications.show({
-                message: prepare.error.message,
+                message: `Voucher error: ${prepare.error.message}`,
                 color: "red",
                 withBorder: true,
                 withCloseButton: true,
@@ -101,7 +101,7 @@ const VoucherExecution: FC<VoucherExecutionType> = (props) => {
                 },
             });
         }
-    }, [prepare.error, prepare.isError]);
+    }, [hasVoucherProof, prepare.error, prepare.isError]);
 
     return (
         <div>

--- a/apps/web/test/components/inputs/voucherExecution.test.tsx
+++ b/apps/web/test/components/inputs/voucherExecution.test.tsx
@@ -357,13 +357,42 @@ describe("VoucherExecution component", () => {
 
         expect(showMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                message: prepareData.error.message,
+                message: `Voucher error: ${prepareData.error.message}`,
                 color: "red",
                 withBorder: true,
                 withCloseButton: true,
                 autoClose: false,
             }),
         );
+    });
+
+    it("should not display prepare error when proof is pending", async () => {
+        const mantineNotifications = await import("@mantine/notifications");
+        const showMock = vi.fn();
+        mantineNotifications.notifications = {
+            ...mantineNotifications.notifications,
+            show: showMock,
+        } as any;
+
+        const prepareData = {
+            data: false,
+            isError: true,
+            error: {
+                message: "Some error message",
+            },
+        };
+
+        useSimulateCartesiDAppExecuteVoucherMock.mockReturnValue(
+            prepareData as any,
+        );
+        render(
+            <Component
+                {...defaultProps}
+                voucher={{ ...defaultProps.voucher, proof: null }}
+            />,
+        );
+
+        expect(showMock).toHaveBeenCalledTimes(0);
     });
 
     it("should not execute voucher when preparation has failed and execute button is clicked", () => {

--- a/packages/ui/src/InputDetails/index.tsx
+++ b/packages/ui/src/InputDetails/index.tsx
@@ -143,6 +143,7 @@ const Details: FC<InputDetailsProps> = (props) => {
         <Tabs
             defaultValue={selected}
             orientation={isSmallDevice ? "horizontal" : "vertical"}
+            keepMounted={false}
         >
             <InputDetailsTabs />
             <InputDetailsContent />

--- a/packages/ui/test/InputDetails/InputDetails.test.tsx
+++ b/packages/ui/test/InputDetails/InputDetails.test.tsx
@@ -84,6 +84,7 @@ describe("Rollups InputDetails", () => {
             </InputDetailsE>,
         );
 
+        fireEvent.click(screen.getByText("Reports"));
         fireEvent.click(screen.getByText("As JSON"));
         fireEvent.click(screen.getByText("As Text"));
         fireEvent.click(screen.getByText("Raw"));
@@ -105,6 +106,7 @@ describe("Rollups InputDetails", () => {
             </InputDetailsE>,
         );
 
+        fireEvent.click(screen.getByText("Vouchers"));
         fireEvent.click(screen.getByText("As JSON"));
         fireEvent.click(screen.getByText("As Text"));
         fireEvent.click(screen.getByText("Raw"));
@@ -126,6 +128,7 @@ describe("Rollups InputDetails", () => {
             </InputDetailsE>,
         );
 
+        fireEvent.click(screen.getByText("Notices"));
         fireEvent.click(screen.getByText("As JSON"));
         fireEvent.click(screen.getByText("As Text"));
         fireEvent.click(screen.getByText("Raw"));


### PR DESCRIPTION
I tweaked the behaviour related to voucher execution so that the alert for the prepare error is only displayed if the voucher has a proof. I also made the error message a bit more informative so that users are aware that it's for the vouchers.

Additionally, I also disabled the `keepMounted` setting for the input details tabs so that voucher related logic is invoked only when the Vouchers tab is active.

I added a unit test for the voucher alert change and tweaked several for the input details that were failing.