### PR TITLE
refactor: Specification ID generator

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -71,6 +71,7 @@
         "@types/ramda": "^0.30.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.1.0",
         "@vitest/coverage-v8": "0.34.2",
         "@wagmi/cli": "^2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
         "react-icons": "^4",
         "react-jazzicon": "^1",
         "urql": "^4",
+        "uuid": "^10.0.0",
         "viem": "^2",
         "wagmi": "^2"
     },

--- a/apps/web/src/components/specification/hooks/localRepository.ts
+++ b/apps/web/src/components/specification/hooks/localRepository.ts
@@ -1,5 +1,6 @@
 "use client";
 import { clone, hasPath, omit, pathOr, values } from "ramda";
+import { v4 as uuidv4 } from "uuid";
 import { Repository, Specification } from "../types";
 
 export const namespace = `cartesiscan:specs` as const;
@@ -22,7 +23,7 @@ const getConfig = () => {
 const localRepository: Repository = {
     async add(spec: Specification) {
         const cfg = getConfig();
-        spec.id = Date.now().toString();
+        spec.id = uuidv4();
         spec.timestamp = Date.now();
         cfg[spec.id] = spec;
         localStorage.setItem(namespace, serialize(cfg));

--- a/yarn.lock
+++ b/yarn.lock
@@ -14367,6 +14367,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4781,6 +4781,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.2.tgz#6dd61e43ef60b34086287f83683a5c1b2dc53d20"
   integrity sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==
 
+"@types/uuid@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
 "@types/uuid@^9.0.1":
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.7.tgz#b14cebc75455eeeb160d5fe23c2fcc0c64f724d8"


### PR DESCRIPTION
#### Summary
Changes for the repository add method implementation to use UUID v4 as ID instead of time as a number. That avoids overrides for fast inserts (e.g. Specification imports)


**PS: This PR is targeting the branch-PR #232**