### PR TITLE
#204 Add e2e tests for ether deposit form

### DIFF
--- a/apps/web/e2e/transactions/depositEther.spec.ts
+++ b/apps/web/e2e/transactions/depositEther.spec.ts
@@ -9,7 +9,9 @@ test.describe.configure({
 
 test.describe.serial("Ether Deposit form", () => {
     test.afterEach(async ({ context }) => {
-        await context.close();
+        if (context) {
+            await context.close();
+        }
     });
 
     test("should render 'Ether Deposit' transaction form", async ({ page }) => {

--- a/apps/web/e2e/transactions/depositEther.spec.ts
+++ b/apps/web/e2e/transactions/depositEther.spec.ts
@@ -76,9 +76,8 @@ test.describe.serial("Ether Deposit form", () => {
         await amountInput.blur();
         await expect(form.getByText("Invalid amount")).toBeVisible();
 
-        const advancedButton = form.locator(
-            'button[data-variant="transparent"]',
-        );
+        const modalFooterActionButtons = form.locator(".mantine-Button-root");
+        const advancedButton = modalFooterActionButtons.first();
         await advancedButton.click();
         const extraDataLocator = form.locator("textarea");
         await extraDataLocator.focus();
@@ -127,8 +126,17 @@ test.describe.serial("Ether Deposit form", () => {
         await page.keyboard.type("0.0000001");
         await amountInput.blur();
         await expect(form.getByText("Invalid amount")).not.toBeVisible();
-
-        const submitButton = form.getByText("Deposit");
-        expect(submitButton.getAttribute("disabled")).toBe(undefined);
+        const modalFooterActionButtons = form.locator(".mantine-Button-root");
+        const advancedButton = modalFooterActionButtons.first();
+        await advancedButton.click();
+        const extraDataLocator = form.locator("textarea");
+        await extraDataLocator.click();
+        await extraDataLocator.click();
+        for (let i = 0; i <= 2; i++) {
+            await page.keyboard.press("Backspace");
+        }
+        await page.keyboard.type("0x123");
+        await extraDataLocator.blur();
+        await expect(form.getByText("Invalid hex string")).not.toBeVisible();
     });
 });


### PR DESCRIPTION
I added the following e2e tests for the ether deposit form:

- Test that the form is rendered correctly (correct fields, labels, etc)
- Test that the form correctly validates invalid inputs and displays correct error messages (invalid address, amount, hex for extra data layer)
- Test that the form correctly validates valid inputs and do not display any error messages (valid address, amount, hex for extra data layer)

I didn't add tests for the `Deposit` functionality because currently we use a 'dummy' test account that doesn't have any ETH available.