### PR TITLE
#253 Add decoded section in input details

### DIFF
--- a/apps/web/src/components/inputs/inputDetailsView.tsx
+++ b/apps/web/src/components/inputs/inputDetailsView.tsx
@@ -217,7 +217,7 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
         showVouchers && vouchersForExecution.length > 0;
 
     const [
-        inputContent,
+        content,
         {
             specApplied,
             error,
@@ -253,24 +253,25 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
 
     const [voucherContentType, setVoucherContentType] =
         useState<ContentType>("raw");
+    const [inputContentType, setInputContentType] =
+        useState<ContentType>("raw");
 
     const voucherContent =
         voucherContentType === "raw" || voucherDecoderRes.data === null
             ? payloadOrString(vouchers)
             : voucherDecoderRes.data;
 
+    const inputContent =
+        inputContentType === "raw" || error ? input.payload : content;
+
     return (
         <Box py="md">
             <InputDetails>
                 <InputDetails.InputContent
-                    rawContent={input.payload}
                     content={inputContent}
-                    contentType="raw"
-                    additionalControls={
-                        inputContent !== input.payload && !error
-                            ? ["decoded"]
-                            : []
-                    }
+                    contentType={inputContentType}
+                    onContentTypeChange={setInputContentType}
+                    additionalControls={!error ? ["decoded"] : []}
                 >
                     <Stack gap="sm">
                         <Group>
@@ -330,7 +331,6 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
 
                 {showReports && (
                     <InputDetails.ReportContent
-                        rawContent={input.payload}
                         content={payloadOrString(reports)}
                         contentType="raw"
                         onConnect={() => showConnectionModal(appId)}
@@ -373,7 +373,6 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
 
                 {showNotices && (
                     <InputDetails.NoticeContent
-                        rawContent={input.payload}
                         content={payloadOrString(notices)}
                         contentType="raw"
                         onConnect={() => showConnectionModal(appId)}
@@ -416,7 +415,6 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
 
                 {showVouchers && (
                     <InputDetails.VoucherContent
-                        rawContent={input.payload}
                         content={voucherContent}
                         contentType={voucherContentType}
                         additionalControls={

--- a/apps/web/src/components/inputs/inputDetailsView.tsx
+++ b/apps/web/src/components/inputs/inputDetailsView.tsx
@@ -263,8 +263,14 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
         <Box py="md">
             <InputDetails>
                 <InputDetails.InputContent
+                    rawContent={input.payload}
                     content={inputContent}
                     contentType="raw"
+                    additionalControls={
+                        inputContent !== input.payload && !error
+                            ? ["decoded"]
+                            : []
+                    }
                 >
                     <Stack gap="sm">
                         <Group>
@@ -324,6 +330,7 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
 
                 {showReports && (
                     <InputDetails.ReportContent
+                        rawContent={input.payload}
                         content={payloadOrString(reports)}
                         contentType="raw"
                         onConnect={() => showConnectionModal(appId)}
@@ -366,6 +373,7 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
 
                 {showNotices && (
                     <InputDetails.NoticeContent
+                        rawContent={input.payload}
                         content={payloadOrString(notices)}
                         contentType="raw"
                         onConnect={() => showConnectionModal(appId)}
@@ -408,8 +416,12 @@ const InputDetailsView: FC<ApplicationInputDataProps> = ({ input }) => {
 
                 {showVouchers && (
                     <InputDetails.VoucherContent
+                        rawContent={input.payload}
                         content={voucherContent}
                         contentType={voucherContentType}
+                        additionalControls={
+                            voucherDecoderRes.data ? ["decoded"] : []
+                        }
                         onContentTypeChange={setVoucherContentType}
                         onConnect={() => showConnectionModal(appId)}
                         isLoading={result.fetching}

--- a/apps/web/src/components/inputs/inputDetailsView.tsx
+++ b/apps/web/src/components/inputs/inputDetailsView.tsx
@@ -21,7 +21,7 @@ import { useBlockExplorerData } from "../BlockExplorerLink";
 import AddressEl from "../address";
 import { NewSpecificationButton } from "../specification/components/NewSpecificationButton";
 import { findSpecificationFor } from "../specification/conditionals";
-import { Envelope, decodePayload } from "../specification/decoder";
+import { decodePayload, Envelope } from "../specification/decoder";
 import { useSpecification } from "../specification/hooks/useSpecification";
 import { useSystemSpecifications } from "../specification/hooks/useSystemSpecifications";
 import useVoucherDecoder from "../specification/hooks/useVoucherDecoder";

--- a/apps/web/test/components/inputs/inputDetailsView.test.tsx
+++ b/apps/web/test/components/inputs/inputDetailsView.test.tsx
@@ -5,6 +5,7 @@ import {
     getByText,
     render,
     screen,
+    waitFor,
 } from "@testing-library/react";
 import { useQuery } from "urql";
 import { Address } from "viem";
@@ -19,6 +20,7 @@ import {
     inputDetailsSample,
     inputDetailsSampleForPaging,
     inputSample,
+    inputSampleEtherDeposit,
 } from "../../utils/dataSamples";
 import { queryMockImplBuilder } from "../../utils/useQueryMock";
 
@@ -359,6 +361,21 @@ describe("Input details view component", () => {
             fireEvent.click(getByText(panel, "Previous content"));
 
             expect(reExecQuery).toHaveBeenCalledTimes(3);
+        });
+
+        it("should not display additional controls for input when decoded value doesn't exist", () => {
+            render(<View input={inputSample} />);
+            expect(() => screen.getByText("Decoded")).toThrow(
+                "Unable to find an element",
+            );
+        });
+
+        it("should display additional controls for input when decoded value exist", async () => {
+            render(<View input={inputSampleEtherDeposit} />);
+
+            await waitFor(() =>
+                expect(screen.getByText("Decoded")).toBeInTheDocument(),
+            );
         });
     });
 });

--- a/apps/web/test/utils/dataSamples.ts
+++ b/apps/web/test/utils/dataSamples.ts
@@ -1,4 +1,5 @@
 import { VoucherEdge } from "../../src/graphql/rollups/types";
+import { InputItemFragment } from "../../src/graphql/explorer/operations";
 
 export const chainId = "11155111";
 /**
@@ -167,4 +168,21 @@ export const inputSample = {
     chain: {
         id: chainId,
     },
+};
+
+export const inputSampleEtherDeposit: InputItemFragment = {
+    id: "11155111-0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e-132",
+    application: {
+        id: "11155111-0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e",
+        address: "0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e",
+    },
+    chain: { id: "11155111" },
+    index: 132,
+    payload:
+        "0xcc42e700ae461bdf5b560e781110a965a8d4393500000000000000000000000000000000000000000000000000000000000000004465706f7369746564202830292065746865722e",
+    msgSender: "0xffdbe43d4c855bf7e0f105c400a50857f53ab044",
+    timestamp: "1729726392",
+    transactionHash:
+        "0x426a89ff66e1bbbd22947ad43e2efe54c68b842d59dd041c28a0497ac7ba96b8",
+    erc20Deposit: null,
 };

--- a/packages/ui/src/InputDetails/Content.tsx
+++ b/packages/ui/src/InputDetails/Content.tsx
@@ -17,11 +17,11 @@ export interface ContentProps {
     /**default to be located at the bottom, after the textarea element.*/
     childrenPosition?: ContentChildrenPosition;
     /**
-     *  Add a React node independently above the segment control.
+     *  Add a react node independently above the segment control.
      */
     topPosition?: ReactNode;
     /**
-     * Add a React node independently between the content and the segment control.
+     * add a react node independently between the content and the segment control.
      */
     middlePosition?: ReactNode;
     additionalControls?: Omit<ContentType, RequiredContentType>[];

--- a/packages/ui/src/InputDetails/Content.tsx
+++ b/packages/ui/src/InputDetails/Content.tsx
@@ -83,27 +83,26 @@ export const DisplayContent: FC<DisableContentProps> = (props) => {
         }
     });
 
+    if (type === "raw" || type === "text")
+        return (
+            <Textarea
+                key={`${type}-${value}`}
+                rows={10}
+                value={value}
+                readOnly
+                placeholder="No content defined"
+            />
+        );
+
     return (
-        <>
-            {type === "json" ? (
-                <JsonInput
-                    key={`${type}-${value}`}
-                    autoFocus
-                    ref={ref}
-                    rows={10}
-                    defaultValue={value}
-                    placeholder="No content defined"
-                    formatOnBlur
-                />
-            ) : (
-                <Textarea
-                    key={`${type}-${value}`}
-                    rows={10}
-                    value={value}
-                    readOnly
-                    placeholder="No content defined"
-                />
-            )}
-        </>
+        <JsonInput
+            key={`${type}-${value}`}
+            autoFocus
+            ref={ref}
+            rows={10}
+            defaultValue={value}
+            placeholder="No content defined"
+            formatOnBlur
+        />
     );
 };

--- a/packages/ui/src/InputDetails/Content.tsx
+++ b/packages/ui/src/InputDetails/Content.tsx
@@ -62,13 +62,10 @@ export const ContentTypeControl = ({
     );
 };
 
-interface DisableContentProps {
-    type?: ContentType;
-    content: string;
-}
-
-export const DisplayContent: FC<DisableContentProps> = (props) => {
-    const { content, type } = props;
+export const DisplayContent: FC<{ type?: ContentType; content: string }> = ({
+    content,
+    type,
+}) => {
     const value =
         type === "raw"
             ? content

--- a/packages/ui/src/InputDetails/Content.tsx
+++ b/packages/ui/src/InputDetails/Content.tsx
@@ -4,10 +4,11 @@ import { JsonInput, SegmentedControl, Textarea } from "@mantine/core";
 import { FC, ReactNode, useEffect, useRef } from "react";
 import { hexToString, isHex } from "viem";
 
-export type ContentType = "raw" | "text" | "json";
+export type ContentType = "raw" | "text" | "json" | "decoded";
 
 export type ContentChildrenPosition = "top" | "middle" | "bottom";
 export interface ContentProps {
+    rawContent: string;
     content: string;
     contentType: ContentType;
     onContentTypeChange?: (contentType: ContentType) => void;
@@ -22,37 +23,52 @@ export interface ContentProps {
      * add a react node independently between the content and the segment control.
      */
     middlePosition?: ReactNode;
+    additionalControls?: ContentType[];
 }
 interface ContentTypeGroupedButtons {
     type: ContentType;
+    additionalControls?: ContentType[];
     onTypeChange: (v: ContentType) => void;
 }
 
-type SegmentControlData = { label: string; value: ContentType };
+type SegmentControlData = {
+    label: string;
+    value: ContentType;
+    required: boolean;
+};
 
 const segmentControlData: SegmentControlData[] = [
-    { label: "Raw", value: "raw" },
-    { label: "As Text", value: "text" },
-    { label: "As JSON", value: "json" },
+    { label: "Raw", value: "raw", required: true },
+    { label: "As Text", value: "text", required: true },
+    { label: "As JSON", value: "json", required: true },
+    { label: "Decoded", value: "decoded", required: false },
 ];
 
 export const ContentTypeControl = ({
     type,
+    additionalControls = [],
     onTypeChange,
 }: ContentTypeGroupedButtons) => {
+    const data = segmentControlData.filter(
+        (item) => item.required || additionalControls.includes(item.value),
+    );
     return (
         <SegmentedControl
             value={type}
             onChange={(v: string) => onTypeChange(v as ContentType)}
-            data={segmentControlData}
+            data={data}
         />
     );
 };
 
-export const DisplayContent: FC<{ type?: ContentType; content: string }> = ({
-    content,
-    type,
-}) => {
+interface DisableContentProps {
+    type?: ContentType;
+    content: string;
+    rawContent: string;
+}
+
+export const DisplayContent: FC<DisableContentProps> = (props) => {
+    const { content, type, rawContent } = props;
     const value =
         type === "raw"
             ? content
@@ -67,26 +83,27 @@ export const DisplayContent: FC<{ type?: ContentType; content: string }> = ({
         }
     });
 
-    if (type === "raw" || type === "text")
-        return (
-            <Textarea
-                key={`${type}-${value}`}
-                rows={10}
-                value={value}
-                readOnly
-                placeholder="No content defined"
-            />
-        );
-
     return (
-        <JsonInput
-            key={`${type}-${value}`}
-            autoFocus
-            ref={ref}
-            rows={10}
-            defaultValue={value}
-            placeholder="No content defined"
-            formatOnBlur
-        />
+        <>
+            {type === "json" ? (
+                <JsonInput
+                    key={`${type}-${value}`}
+                    autoFocus
+                    ref={ref}
+                    rows={10}
+                    defaultValue={value}
+                    placeholder="No content defined"
+                    formatOnBlur
+                />
+            ) : (
+                <Textarea
+                    key={`${type}-${value}`}
+                    rows={10}
+                    value={type === "raw" ? rawContent : value}
+                    readOnly
+                    placeholder="No content defined"
+                />
+            )}
+        </>
     );
 };

--- a/packages/ui/src/InputDetails/Content.tsx
+++ b/packages/ui/src/InputDetails/Content.tsx
@@ -4,11 +4,12 @@ import { JsonInput, SegmentedControl, Textarea } from "@mantine/core";
 import { FC, ReactNode, useEffect, useRef } from "react";
 import { hexToString, isHex } from "viem";
 
-export type ContentType = "raw" | "text" | "json" | "decoded";
+export type RequiredContentType = "raw" | "text" | "json";
+
+export type ContentType = RequiredContentType | "decoded";
 
 export type ContentChildrenPosition = "top" | "middle" | "bottom";
 export interface ContentProps {
-    rawContent: string;
     content: string;
     contentType: ContentType;
     onContentTypeChange?: (contentType: ContentType) => void;
@@ -16,18 +17,18 @@ export interface ContentProps {
     /**default to be located at the bottom, after the textarea element.*/
     childrenPosition?: ContentChildrenPosition;
     /**
-     *  Add a react node independently above the segment control.
+     *  Add a React node independently above the segment control.
      */
     topPosition?: ReactNode;
     /**
-     * add a react node independently between the content and the segment control.
+     * Add a React node independently between the content and the segment control.
      */
     middlePosition?: ReactNode;
-    additionalControls?: ContentType[];
+    additionalControls?: Omit<ContentType, RequiredContentType>[];
 }
 interface ContentTypeGroupedButtons {
     type: ContentType;
-    additionalControls?: ContentType[];
+    additionalControls?: ContentProps["additionalControls"];
     onTypeChange: (v: ContentType) => void;
 }
 
@@ -64,11 +65,10 @@ export const ContentTypeControl = ({
 interface DisableContentProps {
     type?: ContentType;
     content: string;
-    rawContent: string;
 }
 
 export const DisplayContent: FC<DisableContentProps> = (props) => {
-    const { content, type, rawContent } = props;
+    const { content, type } = props;
     const value =
         type === "raw"
             ? content
@@ -99,7 +99,7 @@ export const DisplayContent: FC<DisableContentProps> = (props) => {
                 <Textarea
                     key={`${type}-${value}`}
                     rows={10}
-                    value={type === "raw" ? rawContent : value}
+                    value={value}
                     readOnly
                     placeholder="No content defined"
                 />

--- a/packages/ui/src/InputDetails/InputContent.tsx
+++ b/packages/ui/src/InputDetails/InputContent.tsx
@@ -13,7 +13,6 @@ import {
 export interface InputContentType extends FC<ContentProps> {}
 
 const InputContent: InputContentType = ({
-    rawContent,
     content,
     contentType,
     onContentTypeChange,
@@ -44,11 +43,7 @@ const InputContent: InputContentType = ({
             </Group>
             {position === "middle" && hasChildren && children}
             {isNotNilOrEmpty(middlePosition) && middlePosition}
-            <DisplayContent
-                type={type}
-                content={content}
-                rawContent={rawContent}
-            />
+            <DisplayContent type={type} content={content} />
             {position === "bottom" && hasChildren && children}
         </Stack>
     );

--- a/packages/ui/src/InputDetails/InputContent.tsx
+++ b/packages/ui/src/InputDetails/InputContent.tsx
@@ -13,6 +13,7 @@ import {
 export interface InputContentType extends FC<ContentProps> {}
 
 const InputContent: InputContentType = ({
+    rawContent,
     content,
     contentType,
     onContentTypeChange,
@@ -20,6 +21,7 @@ const InputContent: InputContentType = ({
     childrenPosition,
     middlePosition,
     topPosition,
+    additionalControls,
 }) => {
     const [type, setContentType] = useState<ContentType>(contentType);
     const position = childrenPosition ?? "bottom";
@@ -32,6 +34,7 @@ const InputContent: InputContentType = ({
             <Group>
                 <ContentTypeControl
                     type={type}
+                    additionalControls={additionalControls}
                     onTypeChange={(contentType: ContentType) => {
                         setContentType(contentType);
                         isFunction(onContentTypeChange) &&
@@ -41,7 +44,11 @@ const InputContent: InputContentType = ({
             </Group>
             {position === "middle" && hasChildren && children}
             {isNotNilOrEmpty(middlePosition) && middlePosition}
-            <DisplayContent type={type} content={content} />
+            <DisplayContent
+                type={type}
+                content={content}
+                rawContent={rawContent}
+            />
             {position === "bottom" && hasChildren && children}
         </Stack>
     );

--- a/packages/ui/src/InputDetails/PageableContent.tsx
+++ b/packages/ui/src/InputDetails/PageableContent.tsx
@@ -75,7 +75,6 @@ export const PageableContent: FunctionComponent<PageableContentProps> = ({
         throw new Error("OnConnect callback not defined");
     },
     isLoading,
-    rawContent,
     content,
     contentType,
     paging,
@@ -176,11 +175,7 @@ export const PageableContent: FunctionComponent<PageableContentProps> = ({
                             </Group>
                             {position === "middle" && hasChildren && children}
                             {isNotNilOrEmpty(middlePosition) && middlePosition}
-                            <DisplayContent
-                                type={type}
-                                content={content}
-                                rawContent={rawContent}
-                            />
+                            <DisplayContent type={type} content={content} />
                         </>
                     ) : (
                         <Group justify="center" align="center">

--- a/packages/ui/src/InputDetails/PageableContent.tsx
+++ b/packages/ui/src/InputDetails/PageableContent.tsx
@@ -75,6 +75,7 @@ export const PageableContent: FunctionComponent<PageableContentProps> = ({
         throw new Error("OnConnect callback not defined");
     },
     isLoading,
+    rawContent,
     content,
     contentType,
     paging,
@@ -84,6 +85,7 @@ export const PageableContent: FunctionComponent<PageableContentProps> = ({
     outputType,
     topPosition,
     middlePosition,
+    additionalControls,
 }) => {
     const theme = useMantineTheme();
     const [type, setContentType] = useState<ContentType>(contentType);
@@ -133,6 +135,7 @@ export const PageableContent: FunctionComponent<PageableContentProps> = ({
                             <Group gap={1} justify="space-between">
                                 <ContentTypeControl
                                     type={type}
+                                    additionalControls={additionalControls}
                                     onTypeChange={(contentType) => {
                                         setContentType(contentType);
                                         isFunction(onContentTypeChange) &&
@@ -173,7 +176,11 @@ export const PageableContent: FunctionComponent<PageableContentProps> = ({
                             </Group>
                             {position === "middle" && hasChildren && children}
                             {isNotNilOrEmpty(middlePosition) && middlePosition}
-                            <DisplayContent type={type} content={content} />
+                            <DisplayContent
+                                type={type}
+                                content={content}
+                                rawContent={rawContent}
+                            />
                         </>
                     ) : (
                         <Group justify="center" align="center">

--- a/packages/ui/test/InputDetails/InputDetails.test.tsx
+++ b/packages/ui/test/InputDetails/InputDetails.test.tsx
@@ -13,12 +13,14 @@ import {
 } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
+    ContentType,
     InputContent,
     InputDetails,
     NoticeContent,
     ReportContent,
     VoucherContent,
 } from "../../src/InputDetails/index";
+import { ContentTypeControl } from "../../src/InputDetails/Content";
 import withMantineTheme from "../utils/WithMantineTheme";
 import { jsonWithdraw0, queryContentAsHex, reportText } from "./mocks";
 
@@ -596,6 +598,39 @@ describe("Rollups InputDetails", () => {
             expect(getByText(segmentControlEl, "As Text")).toBeInTheDocument();
             expect(getByText(segmentControlEl, "As JSON")).toBeInTheDocument();
             expect(getByText(contentEl, queryContentAsHex)).toBeInTheDocument();
+        });
+    });
+
+    describe("ContentTypeControl component", () => {
+        const defaultProps = {
+            type: "hex" as ContentType,
+            additionalControls: [],
+            onTypeChange: () => undefined,
+        };
+
+        const ContentTypeControlComponent =
+            withMantineTheme(ContentTypeControl);
+
+        it("should render additional options when some are available", () => {
+            render(
+                <ContentTypeControlComponent
+                    {...defaultProps}
+                    additionalControls={["decoded"]}
+                />,
+            );
+            expect(screen.getByText("Decoded")).toBeInTheDocument();
+        });
+
+        it("should not render additional options when none are available", () => {
+            render(
+                <ContentTypeControlComponent
+                    {...defaultProps}
+                    additionalControls={[]}
+                />,
+            );
+            expect(() => screen.getByText("Decoded")).toThrow(
+                "Unable to find an element",
+            );
         });
     });
 });


### PR DESCRIPTION
I added the new `Decoded` segment and covered the new logic with unit tests. I added an `additionalControls` array prop to the `InputContent` component that currently supports only one value - 'decoded'.