### PR TITLE
#264 Add optional switch for byte slice

### DIFF
--- a/apps/web/src/components/specification/form/fields/ByteSlices.tsx
+++ b/apps/web/src/components/specification/form/fields/ByteSlices.tsx
@@ -318,7 +318,7 @@ const SliceInstructionFields: FC<SliceInstructionFieldsProps> = ({
                                         Optional
                                     </Text>
                                     <Tooltip
-                                        label="An optional boolean flag used to control the decoding behavior for the byte slice. When turned on, the decoder won't throw an exception caused by slicing the byte range, if that range is out of bounds (not found). Instead a fallback value of nil ('0x') will by used for that byte slice."
+                                        label="An optional boolean flag used to control the decoding behavior for the byte slice. When turned on, the decoder won't throw an exception caused by slicing the byte range, if that range is out of bounds (not found). Instead a fallback value of nil ('0x') will be used for that byte slice."
                                         multiline
                                         w={300}
                                     >

--- a/apps/web/test/components/specification/SpecificationFormView.test.tsx
+++ b/apps/web/test/components/specification/SpecificationFormView.test.tsx
@@ -473,6 +473,7 @@ describe("Specification Form View", () => {
                             name: "tokenAddress",
                             to: 20,
                             type: "",
+                            optional: false,
                         },
                     ],
                     sliceTarget: "tokenAddress",
@@ -481,6 +482,90 @@ describe("Specification Form View", () => {
                     ],
                 }),
             });
+        });
+
+        it("should correctly set the default value for the optional byte-slice flag", async () => {
+            await act(async () => render(<StatefulView />));
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByText("ABI Parameters")
+                        .parentNode as HTMLLabelElement,
+                );
+                fireEvent.click(screen.getByTestId("add-byte-slice-switch"));
+
+                fireEvent.change(screen.getByTestId("slice-name-input"), {
+                    target: { value: "tokenAddress" },
+                });
+
+                fireEvent.change(screen.getByTestId("slice-from-input"), {
+                    target: { value: "0" },
+                });
+
+                fireEvent.change(screen.getByTestId("slice-to-input"), {
+                    target: { value: "20" },
+                });
+
+                fireEvent.click(screen.getByTestId("slice-add-button"));
+            });
+
+            fireEvent.click(screen.getByText("Review your definition"));
+
+            await waitFor(() =>
+                expect(screen.getByTestId("0-tokenAddress")).toBeVisible(),
+            );
+
+            const reviewTable = screen.getByTestId(
+                "batch-review-table",
+            ) as HTMLDivElement;
+
+            expect(getByText(reviewTable, "Optional")).toBeInTheDocument();
+            expect(getByText(reviewTable, "No")).toBeInTheDocument();
+
+            fireEvent.click(screen.getByText("Remove slice-tokenAddress"));
+        });
+
+        it("should correctly configure the optional boolean flag for a byte slice", async () => {
+            await act(async () => render(<StatefulView />));
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByText("ABI Parameters")
+                        .parentNode as HTMLLabelElement,
+                );
+                fireEvent.click(screen.getByTestId("add-byte-slice-switch"));
+
+                fireEvent.change(screen.getByTestId("slice-name-input"), {
+                    target: { value: "tokenAddress" },
+                });
+
+                fireEvent.change(screen.getByTestId("slice-from-input"), {
+                    target: { value: "0" },
+                });
+
+                fireEvent.change(screen.getByTestId("slice-to-input"), {
+                    target: { value: "20" },
+                });
+
+                fireEvent.click(
+                    screen.getByTestId("byte-slice-optional-switch"),
+                );
+
+                fireEvent.click(screen.getByTestId("slice-add-button"));
+            });
+
+            fireEvent.click(screen.getByText("Review your definition"));
+
+            await waitFor(() =>
+                expect(screen.getByTestId("0-tokenAddress")).toBeVisible(),
+            );
+
+            const reviewTable = screen.getByTestId(
+                "batch-review-table",
+            ) as HTMLDivElement;
+
+            expect(getByText(reviewTable, "Optional")).toBeInTheDocument();
+            expect(getByText(reviewTable, "Yes")).toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
I added the optional field for byte slices under the ABI Parameters form and covered the new logic with unit tests.