### PR TITLE
#257 Tweak layout on small screens

### DIFF
--- a/apps/web/src/components/specification/form/fields/ByteSlices.tsx
+++ b/apps/web/src/components/specification/form/fields/ByteSlices.tsx
@@ -78,11 +78,12 @@ const InstructionsReview: FC<Props> = ({ slices, onSliceChange }) => {
                     <Title order={4}>Review your definition</Title>
                 </Accordion.Control>
 
-                <Accordion.Panel>
+                <Accordion.Panel style={{ overflow: "auto" }}>
                     <Table
                         horizontalSpacing="xl"
                         highlightOnHover
                         data-testid="batch-review-table"
+                        styles={{ table: { width: "max-content" } }}
                     >
                         <Table.Thead>
                             <Table.Tr>

--- a/apps/web/test/components/specification/SpecificationFormView.test.tsx
+++ b/apps/web/test/components/specification/SpecificationFormView.test.tsx
@@ -19,6 +19,20 @@ import withMantineTheme from "../../utils/WithMantineTheme";
 import { encodedDataSamples } from "./encodedData.stubs";
 import { JotaiTestProvider } from "./jotaiHelpers";
 import { erc1155JSONABISpecStub } from "./specification.stubs";
+import * as mantineHooks from "@mantine/hooks";
+
+vi.mock("@mantine/hooks", async () => {
+    const actual = await vi.importActual<typeof mantineHooks>("@mantine/hooks");
+
+    return {
+        ...actual,
+        useMediaQuery: vi.fn(),
+    };
+});
+
+const useMediaQueryMock = vi.mocked(mantineHooks.useMediaQuery, {
+    partial: true,
+});
 
 const View = withMantineTheme(SpecificationFormView);
 type Props = Parameters<typeof View>[0];
@@ -829,6 +843,26 @@ describe("Specification Form View", () => {
                 amount: "420",
                 success: true,
             });
+        });
+    });
+
+    describe("Layout", () => {
+        it("should hide view switch on small devices", async () => {
+            useMediaQueryMock.mockReturnValue(true);
+            await act(async () => render(<StatefulView />));
+
+            expect(() =>
+                screen.getByTestId("specification-creation-view-switch"),
+            ).toThrow("Unable to find an element");
+        });
+
+        it("should show view switch on large devices", async () => {
+            useMediaQueryMock.mockReturnValue(false);
+            await act(async () => render(<StatefulView />));
+
+            expect(
+                screen.getByTestId("specification-creation-view-switch"),
+            ).toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
I made a couple of small tweaks so that on small screens the `stack_screen` layout is automatically activated and the view switch is hidden. When resizing back to large screen, the view switch is shown again and the last selected view is activated.