### PR TITLE
Fix typo in "Package Installation" section Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can add, remove and upgrade packages from within your monorepo using your pa
 
 `yarn workspace <workspace> add <package>`
 
-> Refer to Turborepo [package-installation](https://turbo.build/repo/docs/handbook/package-installation) session for more information.
+> Refer to Turborepo [package-installation](https://turbo.build/repo/docs/handbook/package-installation) section for more information.
 
 ## Apps and Packages
 


### PR DESCRIPTION
In the "Package Installation" section, there was a small typo where the word "session" was used incorrectly. It has been corrected to "**section**" to reflect the proper terminology. This change improves clarity and ensures that the documentation accurately directs users to the correct reference. Proper terminology is crucial for maintaining clear and precise documentation, especially for new developers who might be unfamiliar with the project setup.

Thank you for reviewing this update!