### PR TITLE
#280 Improve balance error for ether deposit form

### DIFF
--- a/apps/web/test/components/sendTransaction.test.tsx
+++ b/apps/web/test/components/sendTransaction.test.tsx
@@ -15,6 +15,7 @@ import {
     useTokensQuery,
     useMultiTokensQuery,
 } from "../../src/graphql/explorer/hooks/queries";
+import { useBalance } from "wagmi";
 
 vi.mock("../../src/graphql/explorer/hooks/queries");
 const useApplicationsQueryMock = vi.mocked(useApplicationsQuery, {
@@ -35,6 +36,7 @@ vi.mock("viem", async () => {
 
 vi.mock("@cartesi/rollups-wagmi");
 vi.mock("wagmi");
+const useBalanceMock = vi.mocked(useBalance, { partial: true });
 
 vi.mock("@tanstack/react-query", async () => {
     const actual = await vi.importActual("@tanstack/react-query");
@@ -58,6 +60,12 @@ describe("SendTransaction component", () => {
         useMultiTokensQueryMock.mockReturnValue([
             { data: {}, fetching: false },
         ] as any);
+        useBalanceMock.mockReturnValue({
+            data: {
+                value: 355943959031747438n,
+                decimals: 18,
+            },
+        });
     });
 
     afterEach(() => {

--- a/packages/ui/src/EtherDepositForm.tsx
+++ b/packages/ui/src/EtherDepositForm.tsx
@@ -36,6 +36,7 @@ import { useAccount, useWaitForTransactionReceipt } from "wagmi";
 import { TransactionProgress } from "./TransactionProgress";
 import useUndeployedApplication from "./hooks/useUndeployedApplication";
 import { TransactionFormSuccessData } from "./DepositFormTypes";
+import { useFormattedBalance } from "./hooks/useFormattedBalance";
 
 export interface EtherDepositFormProps {
     applications: string[];
@@ -53,6 +54,8 @@ export const EtherDepositForm: FC<EtherDepositFormProps> = (props) => {
     } = props;
     const [advanced, { toggle: toggleAdvanced }] = useDisclosure(false);
     const { chain } = useAccount();
+    const balance = useFormattedBalance();
+
     const form = useForm({
         validateInputOnBlur: true,
         initialValues: {
@@ -63,8 +66,16 @@ export const EtherDepositForm: FC<EtherDepositFormProps> = (props) => {
         validate: {
             application: (value) =>
                 value !== "" && isAddress(value) ? null : "Invalid application",
-            amount: (value) =>
-                value !== "" && Number(value) > 0 ? null : "Invalid amount",
+            amount: (value) => {
+                if (value !== "" && Number(value) > 0) {
+                    if (Number(value) > Number(balance)) {
+                        return `The amount ${value} exceeds your current balance of ${balance} ETH`;
+                    }
+                    return null;
+                } else {
+                    return "Invalid amount";
+                }
+            },
             execLayerData: (value) =>
                 isHex(value) ? null : "Invalid hex string",
         },

--- a/packages/ui/src/hooks/useFormattedBalance.ts
+++ b/packages/ui/src/hooks/useFormattedBalance.ts
@@ -1,0 +1,15 @@
+import { useAccount, useBalance } from "wagmi";
+import { formatUnits } from "viem";
+import { useMemo } from "react";
+
+export const useFormattedBalance = () => {
+    const { address } = useAccount();
+    const { data } = useBalance({
+        address,
+    });
+
+    return useMemo(
+        () => (data ? formatUnits(data.value, data.decimals) : "0"),
+        [data],
+    );
+};

--- a/packages/ui/test/hooks/useFormattedBalance.test.ts
+++ b/packages/ui/test/hooks/useFormattedBalance.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useFormattedBalance } from "../../src/hooks/useFormattedBalance";
+import { useBalance, useAccount } from "wagmi";
+
+vi.mock("wagmi");
+const useAccountMock = vi.mocked(useAccount, { partial: true });
+const useBalanceMock = vi.mocked(useBalance, { partial: true });
+
+describe("Hooks/useFormattedBalance", () => {
+    beforeEach(() => {
+        useAccountMock.mockReturnValue({
+            address: "0x8FD78976f8955D13bAA4fC99043208F4EC020D7E",
+            isConnected: true,
+        });
+        useBalanceMock.mockReturnValue({
+            data: {
+                value: 355943959031747438n,
+                decimals: 18,
+            },
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("should return correct formatted value for balance", () => {
+        useBalanceMock.mockReturnValue({
+            data: {
+                value: 355943959031747438n,
+                decimals: 18,
+            },
+        });
+        const { result } = renderHook(() => useFormattedBalance());
+        expect(result.current).toBe("0.355943959031747438");
+    });
+
+    it("should return correct fallback value for balance", () => {
+        useBalanceMock.mockReturnValue({
+            data: undefined,
+        });
+        const { result } = renderHook(() => useFormattedBalance());
+        expect(result.current).toBe("0");
+    });
+});


### PR DESCRIPTION
I tweaked the validation for the ether deposit amount field so that it's compared to the balance of the logged user. I also covered the new logic with unit tests.

I had to slightly refactor some code related to the unit tests for that form, it's mostly related to the `wagmi` mocks. I had to either continue using the async mocking approach (which we decide to drop) for the new tests or refactor the code so that the standard "synchronous" mocking approach is used throughout the test suite. I went for the latter, I think this is ok because https://github.com/cartesi/rollups-explorer/pull/269 is on hold (which also touches the same files).