### PR TITLE
#286 Add e2e tests for specifications pages

### DIFF
--- a/apps/web/e2e/pages/specifications.spec.ts
+++ b/apps/web/e2e/pages/specifications.spec.ts
@@ -16,5 +16,19 @@ test("should have correct title", async ({ page }) => {
 test("should display empty state", async ({ page }) => {
     await expect(page.getByText("No Specifications Found!")).toBeVisible();
     await expect(page.getByText("Create one")).toBeVisible();
-    await expect(page.getByText("Import Specifications")).toBeVisible();
+    await expect(page.getByText("Import specifications")).toBeVisible();
+});
+
+test("should open file chooser when 'Import Specifications' is clicked", async ({
+    page,
+}) => {
+    const importSpecificationsButton = page.getByText("Import specifications");
+    await expect(importSpecificationsButton).toBeVisible();
+
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await importSpecificationsButton.click();
+
+    const fileChooser = await fileChooserPromise;
+
+    expect(fileChooser.isMultiple()).toBe(false);
 });

--- a/apps/web/e2e/pages/specifications.spec.ts
+++ b/apps/web/e2e/pages/specifications.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/specifications");
+});
+
+test("should have correct page title", async ({ page }) => {
+    await expect(page).toHaveTitle(/Specifications \| CartesiScan/);
+});
+
+test("should have correct title", async ({ page }) => {
+    const title = page.getByRole("heading", { name: "Specifications" });
+    await expect(title.first()).toBeVisible();
+});
+
+test("should display empty state", async ({ page }) => {
+    await expect(page.getByText("No Specifications Found!")).toBeVisible();
+    await expect(page.getByText("Create one")).toBeVisible();
+    await expect(page.getByText("Import Specifications")).toBeVisible();
+});

--- a/apps/web/e2e/pages/specificationsNew.spec.ts
+++ b/apps/web/e2e/pages/specificationsNew.spec.ts
@@ -224,5 +224,8 @@ test("should be able to delete JSON ABI spec", async ({ page }) => {
     const deleteButton = page.getByTestId(`remove-specification-${specId}`);
     await deleteButton.click();
 
+    await expect(page.getByText("Delete specification?")).toBeVisible();
+    await page.getByText("Confirm").click();
+
     await expect(gridCell).not.toBeVisible();
 });

--- a/apps/web/e2e/pages/specificationsNew.spec.ts
+++ b/apps/web/e2e/pages/specificationsNew.spec.ts
@@ -1,0 +1,228 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/specifications/new");
+});
+
+test("should have correct page title", async ({ page }) => {
+    await expect(page).toHaveTitle(/New Specification \| CartesiScan/);
+});
+
+test("should have correct title", async ({ page }) => {
+    const title = page.getByRole("heading", {
+        name: "Create a Specification",
+    });
+    await expect(title.first()).toBeVisible();
+});
+
+test("should create JSON ABI spec", async ({ page }) => {
+    const name = "My E2E JSON ABI spec";
+    const nameInput = page.getByTestId("specification-name-input");
+    await nameInput.focus();
+    await page.keyboard.type(name);
+
+    const jsonAbiTextarea = page.getByTestId("human-readable-abi-input");
+    await jsonAbiTextarea.focus();
+
+    const jsonAbiSpec =
+        "struct User { string name; uint amount; address}\n" +
+        "function createAccount(User user, string role)\n" +
+        "function deposit(User user, address from, string reason)";
+    await page.keyboard.type(jsonAbiSpec);
+
+    const saveButton = page.getByTestId("specification-form-save");
+    await saveButton.click();
+
+    await expect(page.getByText(`Specification ${name} Saved!`)).toBeVisible();
+    await page.goto("/specifications");
+    await expect(page.getByText(name)).toBeVisible();
+});
+
+test("should create ABI Parameters spec", async ({ page }) => {
+    const abiParametersTab = page.getByText("ABI Parameters");
+    await abiParametersTab.click();
+
+    const name = "My ABI Parameters spec";
+    const nameInput = page.getByTestId("specification-name-input");
+    await nameInput.focus();
+    await page.keyboard.type(name);
+
+    const abiParameterInput = page.getByPlaceholder(
+        "address to, uint256 amount, bool succ",
+    );
+    await abiParameterInput.focus();
+
+    const abiParametersSpec =
+        "address to, uint256 amount, (uint256 counter, string name) structy";
+    await page.keyboard.type(abiParametersSpec);
+
+    const addButton = page.getByTestId("abi-parameter-add-button");
+    await addButton.click();
+
+    const saveButton = page.getByTestId("specification-form-save");
+    await saveButton.click();
+
+    await expect(page.getByText(`Specification ${name} Saved!`)).toBeVisible();
+    await page.goto("/specifications");
+    await expect(page.getByText(name)).toBeVisible();
+});
+
+test("should validate JSON ABI spec", async ({ page }) => {
+    const saveButton = page.getByTestId("specification-form-save");
+    await saveButton.click();
+
+    await expect(page.getByText("Name is required.")).toBeVisible();
+    await expect(
+        page.getByText("The ABI is required on JSON ABI mode."),
+    ).toBeVisible();
+
+    const name = "My JSON ABI spec";
+    const nameInput = page.getByTestId("specification-name-input");
+    await nameInput.focus();
+    await page.keyboard.type(name);
+
+    const jsonAbiSpec = "invalid abi spec";
+    const jsonAbiTextarea = page.getByTestId("human-readable-abi-input");
+    await jsonAbiTextarea.focus();
+    await page.keyboard.type(jsonAbiSpec);
+
+    await expect(
+        page.getByText(
+            `Unknown signature. Details: ${jsonAbiSpec} Version: abitype@1.0.7`,
+        ),
+    ).toBeVisible();
+
+    await saveButton.click();
+
+    await expect(
+        page.getByText("The ABI is required on JSON ABI mode."),
+    ).toBeVisible();
+
+    await expect(
+        page.getByText(`Specification ${name} Saved!`),
+    ).not.toBeVisible({
+        timeout: 300,
+    });
+});
+
+// TODO: Resume using this test after https://github.com/cartesi/rollups-explorer/issues/297 is tackled
+test.skip("should validate ABI Parameters spec", async ({ page }) => {
+    const abiParametersTab = page.getByText("ABI Parameters");
+    await abiParametersTab.click();
+
+    const saveButton = page.getByTestId("specification-form-save");
+    await saveButton.click();
+
+    await expect(page.getByText("Name is required.")).toBeVisible();
+    await expect(
+        page.getByText(
+            "At least one ABI parameter is required when not defining the byte range slices.",
+        ),
+    ).toBeVisible();
+
+    const name = "My ABI Parameters spec";
+    const nameInput = page.getByTestId("specification-name-input");
+    await nameInput.focus();
+    await page.keyboard.type(name);
+
+    const abiParameterInput = page.getByPlaceholder(
+        "address to, uint256 amount, bool succ",
+    );
+    await abiParameterInput.focus();
+
+    const abiParametersSpec = "invalid-abi-parameter";
+    await page.keyboard.type(abiParametersSpec);
+
+    const addButton = page.getByTestId("abi-parameter-add-button");
+    await addButton.click();
+
+    await expect(
+        page.getByText(
+            `Invalid ABI parameter. Details: ${abiParametersSpec} Version: abitype@1.0.7`,
+        ),
+    ).toBeVisible();
+
+    await saveButton.click();
+    await expect(
+        page.getByText(`Specification ${name} Saved!`),
+    ).not.toBeVisible({
+        timeout: 300,
+    });
+});
+
+test("should be able to edit JSON ABI spec", async ({ page }) => {
+    const name = "My E2E JSON ABI spec";
+    const nameInput = page.getByTestId("specification-name-input");
+    await nameInput.focus();
+    await page.keyboard.type(name);
+
+    const jsonAbiTextarea = page.getByTestId("human-readable-abi-input");
+    await jsonAbiTextarea.focus();
+
+    const jsonAbiSpec =
+        "struct User { string name; uint amount; address}\n" +
+        "function createAccount(User user, string role)\n" +
+        "function deposit(User user, address from, string reason)";
+    await page.keyboard.type(jsonAbiSpec);
+
+    const saveButton = page.getByTestId("specification-form-save");
+    await saveButton.click();
+
+    await expect(page.getByText(`Specification ${name} Saved!`)).toBeVisible();
+    await page.goto("/specifications");
+    await expect(page.getByText(name)).toBeVisible();
+
+    const gridCell = page.getByRole("gridcell");
+    const testId = await gridCell.getAttribute("data-testid");
+    const specId = testId
+        ?.replace("specification", "")
+        .replace("card", "")
+        .slice(1)
+        .slice(0, -1);
+
+    const editButton = page.getByTestId(`edit-specification-${specId}`);
+    await editButton.click();
+    await page.waitForURL(`/specifications/edit/${specId}`);
+
+    const savedNameInput = await page
+        .getByTestId("specification-name-input")
+        .inputValue();
+
+    expect(savedNameInput).toBe(name);
+});
+
+test("should be able to delete JSON ABI spec", async ({ page }) => {
+    const name = "My E2E JSON ABI spec";
+    const nameInput = page.getByTestId("specification-name-input");
+    await nameInput.focus();
+    await page.keyboard.type(name);
+
+    const jsonAbiTextarea = page.getByTestId("human-readable-abi-input");
+    await jsonAbiTextarea.focus();
+
+    const jsonAbiSpec =
+        "struct User { string name; uint amount; address}\n" +
+        "function createAccount(User user, string role)\n" +
+        "function deposit(User user, address from, string reason)";
+    await page.keyboard.type(jsonAbiSpec);
+
+    const saveButton = page.getByTestId("specification-form-save");
+    await saveButton.click();
+
+    await expect(page.getByText(`Specification ${name} Saved!`)).toBeVisible();
+    await page.goto("/specifications");
+    await expect(page.getByText(name)).toBeVisible();
+
+    let gridCell = page.getByRole("gridcell");
+    const testId = await gridCell.getAttribute("data-testid");
+    const specId = testId
+        ?.replace("specification", "")
+        .replace("card", "")
+        .slice(1)
+        .slice(0, -1);
+
+    const deleteButton = page.getByTestId(`remove-specification-${specId}`);
+    await deleteButton.click();
+
+    await expect(gridCell).not.toBeVisible();
+});

--- a/apps/web/src/components/specification/SpecificationListView.tsx
+++ b/apps/web/src/components/specification/SpecificationListView.tsx
@@ -11,7 +11,6 @@ import {
     Flex,
     Grid,
     Group,
-    Modal,
     SegmentedControl,
     Skeleton,
     Stack,
@@ -21,7 +20,6 @@ import {
     useMantineTheme,
     VisuallyHidden,
 } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
 import { cond, filter, isEmpty, propEq, range, T } from "ramda";
 import { isNilOrEmpty, isNotNilOrEmpty } from "ramda-adjunct";
 import React, { FC, useState } from "react";
@@ -305,10 +303,6 @@ export const SpecificationListView: FC = () => {
         useSpecification();
 
     const specifications = listSpecifications();
-    const [opened, { open, close }] = useDisclosure(false);
-    const [specForRemoval, setSpecForRemoval] = useState<Specification | null>(
-        null,
-    );
 
     if (fetching) return <Feedback />;
     if (isNilOrEmpty(specifications)) return <NoSpecifications />;
@@ -319,151 +313,119 @@ export const SpecificationListView: FC = () => {
     });
 
     return (
-        <>
-            <Modal
-                opened={opened}
-                onClose={close}
-                title="Delete specification?"
-                centered
-            >
-                <Text>
-                    This will delete the data for this specification. Are you
-                    sure you want to proceed?
-                </Text>
-
-                <Group mt="xl" justify="flex-end">
-                    <Button variant="default" onClick={close}>
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={() => {
-                            if (specForRemoval) {
-                                removeSpecification(specForRemoval.id!);
-                            }
-                            close();
-                        }}
-                    >
-                        Confirm
-                    </Button>
-                </Group>
-            </Modal>
-
-            <Stack>
-                <Flex justify="stretch">
-                    <Group mr="auto">
-                        <SegmentedControl
-                            data-testid="specification-filter-control"
-                            data={[
-                                { value: "all", label: "All" },
-                                { value: JSON_ABI, label: "JSON ABI" },
-                                { value: ABI_PARAMS, label: "ABI Params" },
-                            ]}
-                            value={filter}
-                            onChange={(value) => setFilter(value as ModeFilter)}
-                        />
-                        <NewSpecificationButton />
-                        <SpecificationsActionsMenu />
-                    </Group>
-                </Flex>
-
-                {isNilOrEmpty(filteredSpecs) && (
-                    <NoSpecificationsFiltered
-                        filterName={filter}
-                        quantity={specifications?.length ?? 0}
+        <Stack>
+            <Flex justify="stretch">
+                <Group mr="auto">
+                    <SegmentedControl
+                        data-testid="specification-filter-control"
+                        data={[
+                            { value: "all", label: "All" },
+                            { value: JSON_ABI, label: "JSON ABI" },
+                            { value: ABI_PARAMS, label: "ABI Params" },
+                        ]}
+                        value={filter}
+                        onChange={(value) => setFilter(value as ModeFilter)}
                     />
-                )}
+                    <NewSpecificationButton />
+                    <SpecificationsActionsMenu />
+                </Group>
+            </Flex>
 
-                <Grid
-                    justify="flex-start"
-                    align="stretch"
-                    data-testid="specs-grid"
-                >
-                    {filteredSpecs?.map((spec, idx) => (
-                        <Grid.Col span={{ base: 12, md: 6 }} key={spec.id}>
-                            <Card
-                                style={{ minHeight: CARD_MIN_HEIGHT }}
-                                data-testid={`specification-${spec.id}-card`}
+            {isNilOrEmpty(filteredSpecs) && (
+                <NoSpecificationsFiltered
+                    filterName={filter}
+                    quantity={specifications?.length ?? 0}
+                />
+            )}
+
+            <Grid
+                justify="flex-start"
+                align="stretch"
+                data-testid="specs-grid"
+                role="grid"
+            >
+                {filteredSpecs?.map((spec, idx) => (
+                    <Grid.Col span={{ base: 12, md: 6 }} key={spec.id}>
+                        <Card
+                            style={{ minHeight: CARD_MIN_HEIGHT }}
+                            data-testid={`specification-${spec.id}-card`}
+                            role="gridcell"
+                        >
+                            <Card.Section
+                                inheritPadding
+                                py="sm"
+                                data-testid={`specification-${spec.id}`}
                             >
-                                <Card.Section
-                                    inheritPadding
-                                    py="sm"
-                                    data-testid={`specification-${spec.id}`}
-                                >
-                                    <Group
-                                        justify="space-between"
-                                        wrap="nowrap"
+                                <Group justify="space-between" wrap="nowrap">
+                                    <Title
+                                        order={3}
+                                        lineClamp={1}
+                                        title={spec.name}
                                     >
-                                        <Title
-                                            order={3}
-                                            lineClamp={1}
-                                            title={spec.name}
+                                        {spec.name}
+                                    </Title>
+                                    <Group gap={0} wrap="nowrap">
+                                        <EditSpecificationButton
+                                            id={spec.id!}
+                                            iconSize={theme.other.iconSize}
+                                        />
+                                        <Button
+                                            aria-label={`remove-${spec.name}`}
+                                            role="button"
+                                            size="compact-sm"
+                                            variant="transparent"
+                                            color="red"
+                                            data-testid={`remove-specification-${spec.id}`}
+                                            onClick={() =>
+                                                removeSpecification(spec.id!)
+                                            }
                                         >
-                                            {spec.name}
-                                        </Title>
-                                        <Group gap={0} wrap="nowrap">
-                                            <EditSpecificationButton
-                                                id={spec.id!}
-                                                iconSize={theme.other.iconSize}
+                                            <TbTrash
+                                                size={theme.other.iconSize}
                                             />
-                                            <Button
-                                                aria-label={`remove-${spec.name}`}
-                                                role="button"
-                                                size="compact-sm"
-                                                variant="transparent"
-                                                color="red"
-                                                data-testid={`remove-specification-${spec.id}`}
-                                                onClick={() => {
-                                                    setSpecForRemoval(spec);
-                                                    open();
-                                                }}
-                                            >
-                                                <TbTrash
-                                                    size={theme.other.iconSize}
-                                                />
-                                                <VisuallyHidden>
-                                                    Remove specification id{" "}
-                                                    {spec.id}
-                                                </VisuallyHidden>
-                                            </Button>
-                                        </Group>
+                                            <VisuallyHidden>
+                                                Remove specification id{" "}
+                                                {spec.id}
+                                            </VisuallyHidden>
+                                        </Button>
                                     </Group>
-                                </Card.Section>
-                                <Badge>
-                                    {spec.mode === "abi_params"
-                                        ? "ABI Parameters"
-                                        : "Json ABI"}
-                                </Badge>
+                                </Group>
+                            </Card.Section>
+                            <Badge>
+                                {spec.mode === "abi_params"
+                                    ? "ABI Parameters"
+                                    : "Json ABI"}
+                            </Badge>
 
-                                <Accordion
-                                    variant="default"
-                                    chevronPosition="right"
-                                    py="sm"
-                                    data-testid={`specification-${spec.id}-accordion`}
-                                >
-                                    {spec.mode === "json_abi" && (
-                                        <DisplayABI abi={spec.abi} />
-                                    )}
+                            <Accordion
+                                variant="default"
+                                chevronPosition="right"
+                                py="sm"
+                                data-testid={`specification-${spec.id}-accordion`}
+                            >
+                                {spec.mode === "json_abi" && (
+                                    <DisplayABI abi={spec.abi} />
+                                )}
 
-                                    {spec.mode === "abi_params" && (
-                                        <>
-                                            <DisplayABIParams
-                                                abiParams={spec.abiParams}
-                                                sliceTarget={spec.sliceTarget}
-                                            />
-                                            <DisplayInstructions
-                                                slices={spec.sliceInstructions}
-                                            />
-                                        </>
-                                    )}
-                                    <DisplayConditional
-                                        conditionals={spec.conditionals ?? []}
-                                    />
-                                </Accordion>
-                            </Card>
-                        </Grid.Col>
-                    ))}
-                </Grid>
-            </Stack>
-        </>
+                                {spec.mode === "abi_params" && (
+                                    <>
+                                        <DisplayABIParams
+                                            abiParams={spec.abiParams}
+                                            sliceTarget={spec.sliceTarget}
+                                        />
+                                        <DisplayInstructions
+                                            slices={spec.sliceInstructions}
+                                        />
+                                    </>
+                                )}
+                                <DisplayConditional
+                                    conditionals={spec.conditionals ?? []}
+                                />
+                            </Accordion>
+                        </Card>
+                    </Grid.Col>
+                ))}
+            </Grid>
+        </Stack>
     );
 };


### PR DESCRIPTION
I added e2e tests for:

- `/specifications` page
- `/specifications/new` page
- `/specifications/edit` page

One of those tests caught an issue for the ABI Parameters that I logged [here](https://github.com/cartesi/rollups-explorer/issues/297).