### PR TITLE
Bugfix: Applications my apps tab.

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/components/applications/userApplicationsRow.tsx
+++ b/apps/web/src/components/applications/userApplicationsRow.tsx
@@ -33,7 +33,7 @@ const UserApplicationsRow: FC<UserApplicationsRowProps> = (props) => {
         showConnectionModal,
         removeConnection,
     } = useConnectionConfig();
-    const appId = application.id as AddressType;
+    const appId = application.address as AddressType;
     const connection = getConnection(appId);
     return (
         <Table.Tr key={application.id}>

--- a/apps/web/test/components/applications/userApplicationRow.test.tsx
+++ b/apps/web/test/components/applications/userApplicationRow.test.tsx
@@ -3,7 +3,6 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import prettyMilliseconds from "pretty-ms";
 import type { FC } from "react";
 import { afterEach, beforeEach, describe, it } from "vitest";
-import { ApplicationRowProps } from "../../../src/components/applications/applicationRow";
 import UserApplicationsRow, {
     UserApplicationsRowProps,
 } from "../../../src/components/applications/userApplicationsRow";
@@ -24,12 +23,20 @@ const Component = withMantineTheme(TableComponent);
 
 const defaultProps: UserApplicationsRowProps = {
     application: {
-        id: "0x028367fe226cd9e5699f4288d512fe3a4a4a0012",
+        id: "11155111-0x028367fe226cd9e5699f4288d512fe3a4a4a0012",
         owner: "0x74d093f6911ac080897c3145441103dabb869307",
         timestamp: 1700593992,
+        address: "0x028367fe226cd9e5699f4288d512fe3a4a4a0012",
+        chain: {
+            id: "11155111",
+        },
         factory: {
-            id: "0x7122cd1221c20892234186facfe8615e6743ab02",
+            id: "11155111-0x7122cd1221c20892234186facfe8615e6743ab02",
             applications: [],
+            address: "0x7122cd1221c20892234186facfe8615e6743ab02",
+            chain: {
+                id: "11155111",
+            },
         },
     },
     keepDataColVisible: false,
@@ -51,6 +58,7 @@ describe("UserApplicationRow component", () => {
             hideConnectionModal: vi.fn(),
             showConnectionModal: vi.fn(),
             listConnections: vi.fn(),
+            fetching: false,
         });
     });
 
@@ -59,10 +67,10 @@ describe("UserApplicationRow component", () => {
         cleanup();
     });
 
-    it("should display shortened application id", () => {
+    it("should display shortened application address", () => {
         render(<Component {...defaultProps} />);
         const { application } = defaultProps;
-        const appId = application.id;
+        const appId = application.address;
         const shortenedId = `${appId.slice(0, 8)}...${appId.slice(-6)}`;
 
         expect(screen.getByText(shortenedId)).toBeInTheDocument();
@@ -114,7 +122,7 @@ describe("UserApplicationRow component", () => {
 
         expect(link).toBeInTheDocument();
         expect(link.getAttribute("href")).toBe(
-            `/applications/${defaultProps.application.id}`,
+            `/applications/${defaultProps.application.address}`,
         );
     });
 
@@ -124,7 +132,7 @@ describe("UserApplicationRow component", () => {
 
         expect(link).toBeInTheDocument();
         expect(link.getAttribute("href")).toBe(
-            `/applications/${defaultProps.application.id}/inputs`,
+            `/applications/${defaultProps.application.address}/inputs`,
         );
     });
 
@@ -133,7 +141,7 @@ describe("UserApplicationRow component", () => {
         expect(screen.getByTestId("add-connection")).toBeInTheDocument();
     });
 
-    it("should invoke showConnectionModal with application id, when add-connection button is clicked", () => {
+    it("should invoke showConnectionModal with application address, when add-connection button is clicked", () => {
         const showConnectionModalMock = vi.fn();
         useConnectionConfigMock.mockReturnValue({
             ...useConnectionConfigMock(),
@@ -147,7 +155,7 @@ describe("UserApplicationRow component", () => {
         fireEvent.click(addConnectionButton);
 
         expect(showConnectionModalMock).toHaveBeenCalledWith(
-            defaultProps.application.id,
+            defaultProps.application.address,
         );
     });
 
@@ -160,7 +168,7 @@ describe("UserApplicationRow component", () => {
         expect(screen.getByTestId("remove-connection")).toBeInTheDocument();
     });
 
-    it("should invoke removeConnection with application id, when remove-connection button is clicked", () => {
+    it("should invoke removeConnection with application address, when remove-connection button is clicked", () => {
         const removeConnectionMock = vi.fn();
         useConnectionConfigMock.mockReturnValue({
             ...useConnectionConfigMock(),
@@ -175,7 +183,7 @@ describe("UserApplicationRow component", () => {
         fireEvent.click(addConnectionButton);
 
         expect(removeConnectionMock).toHaveBeenCalledWith(
-            defaultProps.application.id,
+            defaultProps.application.address,
         );
     });
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "format:check": "prettier \"**/*.{ts,tsx}\" --check",
         "format": "prettier --write \"**/*.{ts,tsx,md}\"",
         "test": "turbo run test",
-        "test:ci": "turbo run test:ci",
+        "test:ci": "turbo run test:ci --filter=!workshop",
         "test:e2e": "turbo run test:e2e",
         "changeset": "changeset",
         "version-packages": "changeset version",


### PR DESCRIPTION
### Summary
Code changes to fix a bug when trying to list the connected user's application. It was looking at the ID property of the application that was composed of only the address, but it is not reliable as it is now composed with the chain it belongs to and it may have more information. So the `address` property is the correct property to use.