### PR TITLE
#297 Validate abi params entry when adding it

### DIFF
--- a/apps/web/e2e/pages/specificationsNew.spec.ts
+++ b/apps/web/e2e/pages/specificationsNew.spec.ts
@@ -105,8 +105,7 @@ test("should validate JSON ABI spec", async ({ page }) => {
     });
 });
 
-// TODO: Resume using this test after https://github.com/cartesi/rollups-explorer/issues/297 is tackled
-test.skip("should validate ABI Parameters spec", async ({ page }) => {
+test("should validate ABI Parameters spec", async ({ page }) => {
     const abiParametersTab = page.getByText("ABI Parameters");
     await abiParametersTab.click();
 

--- a/apps/web/src/components/specification/form/fields/HumanReadableABIParameter.tsx
+++ b/apps/web/src/components/specification/form/fields/HumanReadableABIParameter.tsx
@@ -10,8 +10,8 @@ import {
 } from "@mantine/core";
 import { createFormActions, useForm } from "@mantine/form";
 import { clone } from "ramda";
-import { isFunction, isNotNilOrEmpty } from "ramda-adjunct";
-import { FC, ReactNode, useEffect, useRef } from "react";
+import { isFunction, isNilOrEmpty, isNotNilOrEmpty } from "ramda-adjunct";
+import { FC, ReactNode, useEffect, useMemo, useRef } from "react";
 import { TbTrash } from "react-icons/tb";
 import { parseAbiParameters } from "viem";
 
@@ -49,7 +49,10 @@ export const HumanReadableABIParameter: FC<HumanReadableABIParameter> = (
 
     const ref = useRef<HTMLInputElement>(null);
     const { entries, abiParamEntry } = form.getTransformedValues();
-    const error = isNotNilOrEmpty(entries) ? checkError(entries) : null;
+    const error = useMemo(
+        () => (isNotNilOrEmpty(entries) ? checkError(entries) : null),
+        [entries],
+    );
     const onAbiParamsChange = props.onAbiParamsChange;
 
     const addABIParam = () => {
@@ -81,22 +84,12 @@ export const HumanReadableABIParameter: FC<HumanReadableABIParameter> = (
                 rightSection={
                     <Button
                         data-testid="abi-parameter-add-button"
-                        onClick={() => {
-                            try {
-                                parseAbiParameters(abiParamEntry);
-                                addABIParam();
-                            } catch (error: any) {
-                                form.setFieldError(
-                                    "abiParamEntry",
-                                    error.message,
-                                );
-                            }
-                        }}
+                        onClick={addABIParam}
                     >
                         Add
                     </Button>
                 }
-                error={props.error || form.errors.abiParamEntry}
+                error={isNilOrEmpty(entries) ? props.error : null}
             />
 
             {entries.length > 0 && (

--- a/apps/web/src/components/specification/form/fields/HumanReadableABIParameter.tsx
+++ b/apps/web/src/components/specification/form/fields/HumanReadableABIParameter.tsx
@@ -11,7 +11,7 @@ import {
 import { createFormActions, useForm } from "@mantine/form";
 import { clone } from "ramda";
 import { isFunction, isNilOrEmpty, isNotNilOrEmpty } from "ramda-adjunct";
-import { FC, ReactNode, useEffect, useMemo, useRef } from "react";
+import { FC, ReactNode, useEffect, useRef } from "react";
 import { TbTrash } from "react-icons/tb";
 import { parseAbiParameters } from "viem";
 
@@ -49,10 +49,7 @@ export const HumanReadableABIParameter: FC<HumanReadableABIParameter> = (
 
     const ref = useRef<HTMLInputElement>(null);
     const { entries, abiParamEntry } = form.getTransformedValues();
-    const error = useMemo(
-        () => (isNotNilOrEmpty(entries) ? checkError(entries) : null),
-        [entries],
-    );
+    const error = isNotNilOrEmpty(entries) ? checkError(entries) : null;
     const onAbiParamsChange = props.onAbiParamsChange;
 
     const addABIParam = () => {

--- a/apps/web/src/components/specification/form/fields/HumanReadableABIParameter.tsx
+++ b/apps/web/src/components/specification/form/fields/HumanReadableABIParameter.tsx
@@ -81,7 +81,17 @@ export const HumanReadableABIParameter: FC<HumanReadableABIParameter> = (
                 rightSection={
                     <Button
                         data-testid="abi-parameter-add-button"
-                        onClick={addABIParam}
+                        onClick={() => {
+                            try {
+                                parseAbiParameters(abiParamEntry);
+                                addABIParam();
+                            } catch (error: any) {
+                                form.setFieldError(
+                                    "abiParamEntry",
+                                    error.message,
+                                );
+                            }
+                        }}
                     >
                         Add
                     </Button>

--- a/apps/web/src/components/specification/form/validations.ts
+++ b/apps/web/src/components/specification/form/validations.ts
@@ -1,6 +1,6 @@
 import { includes } from "ramda";
 import { isBlank, isNilOrEmpty, isNotNilOrEmpty } from "ramda-adjunct";
-import { Abi, Hex, isHex } from "viem";
+import { Abi, Hex, isHex, parseAbiParameters } from "viem";
 import { Modes, Predicate, SliceInstruction } from "../types";
 import { SpecFormValues } from "./context";
 
@@ -38,6 +38,12 @@ const specAbiParamValidation = (value: string[], values: SpecFormValues) => {
             isNilOrEmpty(value)
         )
             return `A slice name ${values.sliceTarget} was selected, making ABI parameter required!`;
+
+        try {
+            parseAbiParameters(value);
+        } catch (error: any) {
+            return error.message;
+        }
     }
 
     return null;

--- a/apps/web/test/components/specification/SpecificationFormView.test.tsx
+++ b/apps/web/test/components/specification/SpecificationFormView.test.tsx
@@ -355,6 +355,32 @@ describe("Specification Form View", () => {
             expect(screen.queryByText(abiParameter)).not.toBeInTheDocument();
         });
 
+        it("should not allow adding invalid abi parameters", async () => {
+            await act(async () => render(<StatefulView />));
+
+            const abiParameter = "address from, uint amount";
+            const invalidAbiParam = "invalid-abi-params";
+
+            act(() => {
+                fireEvent.click(
+                    screen.getByText("ABI Parameters")
+                        .parentNode as HTMLLabelElement,
+                );
+
+                fireEvent.change(screen.getByLabelText("ABI Parameter"), {
+                    target: { value: invalidAbiParam },
+                });
+
+                fireEvent.click(screen.getByTestId("abi-parameter-add-button"));
+            });
+
+            await waitFor(() =>
+                expect(() => screen.getByText(abiParameter)).toThrow(
+                    "Unable to find an element",
+                ),
+            );
+        });
+
         it("should be able to add and remove byte range definitions", async () => {
             await act(async () => render(<StatefulView />));
 


### PR DESCRIPTION
I tweaked slightly the logic for adding abi params from the specs form. Now, when clicking on the `Add` button next to the abi params input, we'll first parse the params to ensure they're valid. Only if they are, we'll add them to the entries array.

I kept the validation for entries, this line:
```
const error = isNotNilOrEmpty(entries) ? checkError(entries) : null;
```

so that users can still see an error for the entries if they previously saved a spec with invalid params.