### PR TITLE
#313 Improve responsive design on small devices

### DIFF
--- a/apps/web/src/app/applications/[address]/inputs/page.tsx
+++ b/apps/web/src/app/applications/[address]/inputs/page.tsx
@@ -69,8 +69,7 @@ const ApplicationInputsPage: FC<ApplicationInputsPageProps> = async (props) => {
                     value={params.address as AddressType}
                     href={`/applications/${params.address}`}
                     shorten
-                    icon
-                    mr={-8}
+                    canCopy={false}
                 />
                 <Text>Inputs</Text>
             </Breadcrumbs>

--- a/apps/web/src/app/applications/[address]/inputs/page.tsx
+++ b/apps/web/src/app/applications/[address]/inputs/page.tsx
@@ -68,11 +68,14 @@ const ApplicationInputsPage: FC<ApplicationInputsPageProps> = async (props) => {
                 <Address
                     value={params.address as AddressType}
                     href={`/applications/${params.address}`}
+                    shorten
+                    icon
+                    mr={-8}
                 />
                 <Text>Inputs</Text>
             </Breadcrumbs>
 
-            <PageTitle title="Inputs" Icon={TbInbox} />
+            <PageTitle title="Application Inputs" Icon={TbInbox} />
             <Inputs applicationId={params.address} />
         </Stack>
     );

--- a/apps/web/src/app/applications/[address]/inputs/page.tsx
+++ b/apps/web/src/app/applications/[address]/inputs/page.tsx
@@ -75,7 +75,7 @@ const ApplicationInputsPage: FC<ApplicationInputsPageProps> = async (props) => {
                 <Text>Inputs</Text>
             </Breadcrumbs>
 
-            <PageTitle title="Application Inputs" Icon={TbInbox} />
+            <PageTitle title="Inputs" Icon={TbInbox} />
             <Inputs applicationId={params.address} />
         </Stack>
     );

--- a/apps/web/src/app/applications/[address]/page.tsx
+++ b/apps/web/src/app/applications/[address]/page.tsx
@@ -68,7 +68,7 @@ const ApplicationPage: FC<ApplicationPageProps> = async (props) => {
                 <Address value={params.address as AddressType} icon shorten />
             </Breadcrumbs>
 
-            <PageTitle title="Application Summary" Icon={TbStack2} />
+            <PageTitle title="Summary" Icon={TbStack2} />
             <ApplicationSummary applicationId={params.address} />
         </Stack>
     );

--- a/apps/web/src/app/applications/[address]/page.tsx
+++ b/apps/web/src/app/applications/[address]/page.tsx
@@ -65,10 +65,10 @@ const ApplicationPage: FC<ApplicationPageProps> = async (props) => {
                     },
                 ]}
             >
-                <Address value={params.address as AddressType} icon />
+                <Address value={params.address as AddressType} icon shorten />
             </Breadcrumbs>
 
-            <PageTitle title="Summary" Icon={TbStack2} />
+            <PageTitle title="Application Summary" Icon={TbStack2} />
             <ApplicationSummary applicationId={params.address} />
         </Stack>
     );

--- a/apps/web/src/app/applications/[address]/page.tsx
+++ b/apps/web/src/app/applications/[address]/page.tsx
@@ -65,7 +65,11 @@ const ApplicationPage: FC<ApplicationPageProps> = async (props) => {
                     },
                 ]}
             >
-                <Address value={params.address as AddressType} icon shorten />
+                <Address
+                    value={params.address as AddressType}
+                    shorten
+                    canCopy={false}
+                />
             </Breadcrumbs>
 
             <PageTitle title="Summary" Icon={TbStack2} />

--- a/apps/web/src/app/specifications/edit/[id]/page.tsx
+++ b/apps/web/src/app/specifications/edit/[id]/page.tsx
@@ -1,8 +1,9 @@
-import { Group, Stack, Title } from "@mantine/core";
+import { Stack } from "@mantine/core";
 import { Metadata } from "next";
 import { TbFileCode } from "react-icons/tb";
 import Breadcrumbs from "../../../../components/breadcrumbs";
 import { SpecificationContainer } from "../../../../components/specification/SpecificationContainer";
+import PageTitle from "../../../../components/layout/pageTitle";
 
 export const metadata: Metadata = {
     title: "Edit Specifications",
@@ -31,10 +32,7 @@ export default async function EditSpecificationPage(props: PageProps) {
                 ]}
             />
 
-            <Group mb="xl">
-                <TbFileCode size={40} />
-                <Title order={1}>Edit Specifications</Title>
-            </Group>
+            <PageTitle title="Edit Specifications" Icon={TbFileCode} />
 
             <SpecificationContainer specificationId={params.id} />
         </Stack>

--- a/apps/web/src/app/specifications/new/page.tsx
+++ b/apps/web/src/app/specifications/new/page.tsx
@@ -1,8 +1,9 @@
-import { Group, Stack, Title } from "@mantine/core";
+import { Stack } from "@mantine/core";
 import { Metadata } from "next";
 import { TbFileCode } from "react-icons/tb";
 import Breadcrumbs from "../../../components/breadcrumbs";
 import { SpecificationContainer } from "../../../components/specification/SpecificationContainer";
+import PageTitle from "../../../components/layout/pageTitle";
 
 export const metadata: Metadata = {
     title: "New Specification",
@@ -24,10 +25,7 @@ export default function NewSpecificationPage() {
                 ]}
             />
 
-            <Group mb="xl">
-                <TbFileCode size={40} />
-                <Title order={1}>Create a Specification</Title>
-            </Group>
+            <PageTitle title="Create a Specification" Icon={TbFileCode} />
 
             <SpecificationContainer />
         </Stack>

--- a/apps/web/src/components/address.tsx
+++ b/apps/web/src/components/address.tsx
@@ -5,6 +5,7 @@ import {
     Anchor,
     CopyButton,
     Group,
+    GroupProps,
     rem,
     Text,
     Tooltip,
@@ -25,14 +26,14 @@ import {
     etherPortalAddress,
 } from "@cartesi/rollups-wagmi";
 
-export type AddressProps = {
+export interface AddressProps extends GroupProps {
     value: AddressType;
     href?: string;
     hrefTarget?: "_self" | "_blank" | "_top" | "_parent";
     icon?: boolean;
     iconSize?: number;
     shorten?: boolean;
-};
+}
 
 const cartesi: Record<AddressType, string> = {
     [dAppAddressRelayAddress]: "DAppAddressRelay",
@@ -54,6 +55,7 @@ const Address: FC<AddressProps> = ({
     iconSize,
     shorten,
     hrefTarget = "_self",
+    ...restProps
 }) => {
     value = getAddress(value);
     const name = resolveName(value);
@@ -71,21 +73,23 @@ const Address: FC<AddressProps> = ({
         <Text>{text}</Text>
     );
     return (
-        <Group gap={10}>
-            {icon && (
-                <Jazzicon
-                    diameter={iconSize ?? 20}
-                    seed={jsNumberForAddress(value)}
-                />
-            )}
+        <Group gap={0} {...restProps}>
+            <Group gap={10}>
+                {icon && (
+                    <Jazzicon
+                        diameter={iconSize ?? 20}
+                        seed={jsNumberForAddress(value)}
+                    />
+                )}
 
-            {href ? (
-                <Anchor href={href} component={Link} target={hrefTarget}>
-                    {label}
-                </Anchor>
-            ) : (
-                label
-            )}
+                {href ? (
+                    <Anchor href={href} component={Link} target={hrefTarget}>
+                        {label}
+                    </Anchor>
+                ) : (
+                    label
+                )}
+            </Group>
             <CopyButton value={value} timeout={2000}>
                 {({ copied, copy }) => (
                     <Tooltip

--- a/apps/web/src/components/address.tsx
+++ b/apps/web/src/components/address.tsx
@@ -74,7 +74,7 @@ const Address: FC<AddressProps> = ({
     );
     return (
         <Group gap={0} {...restProps}>
-            <Group gap={10}>
+            <Group gap={8}>
                 {icon && (
                     <Jazzicon
                         diameter={iconSize ?? 20}

--- a/apps/web/src/components/address.tsx
+++ b/apps/web/src/components/address.tsx
@@ -33,6 +33,7 @@ export interface AddressProps extends GroupProps {
     icon?: boolean;
     iconSize?: number;
     shorten?: boolean;
+    canCopy?: boolean;
 }
 
 const cartesi: Record<AddressType, string> = {
@@ -55,6 +56,7 @@ const Address: FC<AddressProps> = ({
     iconSize,
     shorten,
     hrefTarget = "_self",
+    canCopy = true,
     ...restProps
 }) => {
     value = getAddress(value);
@@ -90,27 +92,29 @@ const Address: FC<AddressProps> = ({
                     label
                 )}
             </Group>
-            <CopyButton value={value} timeout={2000}>
-                {({ copied, copy }) => (
-                    <Tooltip
-                        label={copied ? "Copied" : "Copy"}
-                        withArrow
-                        position="right"
-                    >
-                        <ActionIcon
-                            color={copied ? "teal" : "gray"}
-                            variant="subtle"
-                            onClick={copy}
+            {canCopy && (
+                <CopyButton value={value} timeout={2000}>
+                    {({ copied, copy }) => (
+                        <Tooltip
+                            label={copied ? "Copied" : "Copy"}
+                            withArrow
+                            position="right"
                         >
-                            {copied ? (
-                                <TbCheck style={{ width: rem(16) }} />
-                            ) : (
-                                <TbCopy style={{ width: rem(16) }} />
-                            )}
-                        </ActionIcon>
-                    </Tooltip>
-                )}
-            </CopyButton>
+                            <ActionIcon
+                                color={copied ? "teal" : "gray"}
+                                variant="subtle"
+                                onClick={copy}
+                            >
+                                {copied ? (
+                                    <TbCheck style={{ width: rem(16) }} />
+                                ) : (
+                                    <TbCopy style={{ width: rem(16) }} />
+                                )}
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                </CopyButton>
+            )}
         </Group>
     );
 };

--- a/apps/web/src/components/applications/applicationSummary.tsx
+++ b/apps/web/src/components/applications/applicationSummary.tsx
@@ -66,7 +66,7 @@ const ApplicationSummary: FC<ApplicationSummaryProps> = ({ applicationId }) => {
     return (
         <Stack>
             <Grid gutter="sm">
-                <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+                <Grid.Col span={{ base: 6, md: 3 }} mb="sm">
                     <SummaryCard
                         title="Inputs"
                         value={data?.inputsConnection?.totalCount ?? 0}
@@ -116,7 +116,7 @@ const ApplicationSummary: FC<ApplicationSummaryProps> = ({ applicationId }) => {
                         </Text>
                     </Group>
 
-                    <Group gap={5}>
+                    <Group gap={5} style={{ overflowX: "auto" }}>
                         <LatestInputsTable
                             inputs={inputs}
                             fetching={fetching}

--- a/apps/web/src/components/applications/applicationSummary.tsx
+++ b/apps/web/src/components/applications/applicationSummary.tsx
@@ -66,7 +66,7 @@ const ApplicationSummary: FC<ApplicationSummaryProps> = ({ applicationId }) => {
     return (
         <Stack>
             <Grid gutter="sm">
-                <Grid.Col span={{ base: 6, md: 3 }} mb="sm">
+                <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
                     <SummaryCard
                         title="Inputs"
                         value={data?.inputsConnection?.totalCount ?? 0}

--- a/apps/web/src/components/applications/latestInputsTable.tsx
+++ b/apps/web/src/components/applications/latestInputsTable.tsx
@@ -65,7 +65,7 @@ const LatestInputsTable: FC<LatestInputsTableProps> = ({
                     )
                 )}
                 {inputs.map((input) => (
-                    <Table.Tr key={`${input.application}-${input.timestamp}`}>
+                    <Table.Tr key={input.id}>
                         <Table.Td>
                             <Box
                                 display="flex"

--- a/apps/web/src/components/applications/latestInputsTable.tsx
+++ b/apps/web/src/components/applications/latestInputsTable.tsx
@@ -32,7 +32,7 @@ const LatestInputsTable: FC<LatestInputsTableProps> = ({
     }, []);
 
     return (
-        <Table>
+        <Table width="100%" miw={500} style={{ borderCollapse: "collapse" }}>
             <Table.Thead>
                 <Table.Tr>
                     <Table.Th>From</Table.Th>

--- a/apps/web/src/components/applications/latestInputsTable.tsx
+++ b/apps/web/src/components/applications/latestInputsTable.tsx
@@ -65,7 +65,7 @@ const LatestInputsTable: FC<LatestInputsTableProps> = ({
                     )
                 )}
                 {inputs.map((input) => (
-                    <Table.Tr key={input.id}>
+                    <Table.Tr key={`${input.application.id}-${input.id}`}>
                         <Table.Td>
                             <Box
                                 display="flex"

--- a/apps/web/src/components/connection/connectionInfo.tsx
+++ b/apps/web/src/components/connection/connectionInfo.tsx
@@ -55,13 +55,12 @@ const ConnectionInfo: FC<ConnectionInfoProps> = ({ connection }) => {
 
             <Card
                 withBorder
-                py="lg"
                 radius="sm"
                 shadow="sm"
                 data-testid="connection-card"
             >
-                <Card.Section inheritPadding withBorder>
-                    <Flex justify="space-between">
+                <Card.Section withBorder py={4}>
+                    <Flex justify="space-between" pl={12}>
                         <Address value={connection.address} shorten icon />
                         <Button
                             aria-label={`remove-${connection.address}`}
@@ -82,13 +81,17 @@ const ConnectionInfo: FC<ConnectionInfoProps> = ({ connection }) => {
                     </Flex>
                 </Card.Section>
 
-                <List pt="sm" center>
-                    <List.Item icon={<TbNetwork size={theme.other.iconSize} />}>
-                        <Text style={{ lineBreak: "anywhere" }}>
-                            {connection.url}
-                        </Text>
-                    </List.Item>
-                </List>
+                <Card.Section py="md" px="sm">
+                    <List center>
+                        <List.Item
+                            icon={<TbNetwork size={theme.other.iconSize} />}
+                        >
+                            <Text style={{ lineBreak: "anywhere" }}>
+                                {connection.url}
+                            </Text>
+                        </List.Item>
+                    </List>
+                </Card.Section>
             </Card>
         </>
     );

--- a/apps/web/src/components/connection/connectionSummary.tsx
+++ b/apps/web/src/components/connection/connectionSummary.tsx
@@ -29,21 +29,21 @@ export const ConnectionSummary: FC<ConnectionSummaryProps> = ({ url }) => {
 
     return (
         <>
-            <Grid.Col span={{ base: 6, md: 3 }} mb="sm">
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
                 <SummaryCard
                     title="Notices"
                     value={result.data?.notices.totalCount ?? 0}
                     icon={TbAlertTriangle}
                 />
             </Grid.Col>
-            <Grid.Col span={{ base: 6, md: 3 }} mb="sm">
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
                 <SummaryCard
                     title="Vouchers"
                     value={result.data?.vouchers.totalCount ?? 0}
                     icon={TbTicket}
                 />
             </Grid.Col>
-            <Grid.Col span={{ base: 6, md: 3 }} mb="sm">
+            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
                 <SummaryCard
                     title="Reports"
                     value={result.data?.reports.totalCount ?? 0}

--- a/apps/web/src/components/connection/connectionSummary.tsx
+++ b/apps/web/src/components/connection/connectionSummary.tsx
@@ -29,21 +29,21 @@ export const ConnectionSummary: FC<ConnectionSummaryProps> = ({ url }) => {
 
     return (
         <>
-            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+            <Grid.Col span={{ base: 6, md: 3 }} mb="sm">
                 <SummaryCard
                     title="Notices"
                     value={result.data?.notices.totalCount ?? 0}
                     icon={TbAlertTriangle}
                 />
             </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+            <Grid.Col span={{ base: 6, md: 3 }} mb="sm">
                 <SummaryCard
                     title="Vouchers"
                     value={result.data?.vouchers.totalCount ?? 0}
                     icon={TbTicket}
                 />
             </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 6, md: 3 }} mb="sm">
+            <Grid.Col span={{ base: 6, md: 3 }} mb="sm">
                 <SummaryCard
                     title="Reports"
                     value={result.data?.reports.totalCount ?? 0}

--- a/apps/web/src/components/connection/connectionView.tsx
+++ b/apps/web/src/components/connection/connectionView.tsx
@@ -58,7 +58,7 @@ const ConnectionView = () => {
         <>
             <Group justify="flex-start">
                 <NewConnectionButton data-testid="add-connection">
-                    New
+                    Create connection
                 </NewConnectionButton>
             </Group>
 

--- a/apps/web/src/components/layout/pageTitle.tsx
+++ b/apps/web/src/components/layout/pageTitle.tsx
@@ -9,8 +9,14 @@ interface PageTitleProps {
 const PageTitle: FC<PageTitleProps> = ({ title, Icon }) => {
     return (
         <Group mb="sm" data-testid="page-title">
-            <Icon size={40} />
-            <Title order={1}>{title}</Title>
+            <Title order={1} display="inline-flex">
+                <Icon
+                    size={40}
+                    aria-hidden
+                    style={{ marginRight: "0.5rem", marginTop: "0.215rem" }}
+                />
+                {title}
+            </Title>
         </Group>
     );
 };

--- a/apps/web/src/components/layout/shell.tsx
+++ b/apps/web/src/components/layout/shell.tsx
@@ -59,6 +59,7 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
     const { colorScheme, toggleColorScheme } = useMantineColorScheme({
         keepTransitions: true,
     });
+    const isSmallDevice = useMediaQuery(`(max-width:${theme.breakpoints.xs})`);
     const themeDefaultProps = theme.components?.AppShell?.defaultProps ?? {};
 
     return (
@@ -80,21 +81,20 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
             >
                 <SendTransaction />
             </Modal>
-            <AppShell.Header data-testid="header">
+            <AppShell.Header data-testid="header" zIndex={110}>
                 <Group h="100%" px="md">
                     <Burger
                         data-testid="burger-menu-btn"
                         opened={opened}
                         onClick={toggleMobileMenu}
                         hiddenFrom="sm"
-                        size="sm"
                     />
                     <Group justify="space-between" style={{ flex: 1 }}>
                         <Link href="/">
-                            <CartesiLogo height={40} />
+                            <CartesiLogo height={isSmallDevice ? 30 : 40} />
                         </Link>
                         <Group ml={{ lg: "xl" }}>
-                            <CartesiScanChains />
+                            <CartesiScanChains onOpen={closeMobileMenu} />
                             <Button
                                 variant="subtle"
                                 leftSection={<TbArrowsDownUp />}
@@ -144,7 +144,7 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
                     </Group>
                 </Group>
             </AppShell.Header>
-            <AppShell.Navbar py="md" px={4} data-testid="navbar">
+            <AppShell.Navbar py="md" px={4} zIndex={110} data-testid="navbar">
                 <Stack px={13}>
                     <NavLink
                         component={Link}

--- a/apps/web/src/components/networks/cartesiScanNetworks.tsx
+++ b/apps/web/src/components/networks/cartesiScanNetworks.tsx
@@ -1,14 +1,14 @@
 "use client";
 import {
-    Button,
     Divider,
     Group,
     Indicator,
     Menu,
     Text,
     Tooltip,
-    VisuallyHidden,
+    UnstyledButton,
     useMantineTheme,
+    VisuallyHidden,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { FC } from "react";
@@ -147,14 +147,21 @@ const NetworkGroup: FC<NetworkGroupProps> = ({
 };
 
 const CaretIcon: FC<{ up: boolean }> = ({ up }) => {
+    const theme = useMantineTheme();
     const styles = {
         transform: `rotateZ(${up ? 0 : 180}deg)`,
         transitionTimingFunction: "ease-in-out",
         transitionDuration: "300ms",
-        tansitionProperty: "all",
+        transitionProperty: "all",
     };
 
-    return <TbCaretUpFilled style={styles} size={18} />;
+    return (
+        <TbCaretUpFilled
+            style={styles}
+            size={18}
+            color={theme.colors.cyan[5]}
+        />
+    );
 };
 
 const allNetworks = [...mainnets, ...testnets];
@@ -171,7 +178,11 @@ const MainIcon: FC<{ chainId: number }> = ({ chainId }) => {
     return <Icon size={28} id={`chain-${chainId}-icon`} />;
 };
 
-export const CartesiScanChains = () => {
+interface CartesiScanChainsProps {
+    onOpen: () => void;
+}
+
+export const CartesiScanChains: FC<CartesiScanChainsProps> = ({ onOpen }) => {
     const [isOpen, { close, open }] = useDisclosure(false);
     const config = useConfig();
     const chain = config.chains[0];
@@ -179,20 +190,27 @@ export const CartesiScanChains = () => {
 
     return (
         <Menu
+            id="cartesiscan-chain-menu"
             withArrow
             withinPortal={false}
+            zIndex={120}
+            offset={9}
+            arrowSize={12}
+            shadow="xl"
             onClose={close}
-            onOpen={open}
-            id="cartesiscan-chain-menu"
+            onOpen={() => {
+                open();
+                onOpen();
+            }}
         >
             <Menu.Target>
-                <Button variant="transparent" p={0}>
+                <UnstyledButton variant="transparent" p={0}>
                     <Group gap={3}>
                         <VisuallyHidden>{chainName}</VisuallyHidden>
                         <MainIcon chainId={chain.id} />
                         <CaretIcon up={isOpen} />
                     </Group>
-                </Button>
+                </UnstyledButton>
             </Menu.Target>
 
             <Menu.Dropdown>

--- a/apps/web/src/components/paginated.tsx
+++ b/apps/web/src/components/paginated.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import {
+    Flex,
     Group,
     Pagination,
     Select,
     Stack,
     StackProps,
     Text,
+    useMantineTheme,
 } from "@mantine/core";
-import { useScrollIntoView } from "@mantine/hooks";
+import { useMediaQuery, useScrollIntoView } from "@mantine/hooks";
 import { pathOr } from "ramda";
 import { FC, ReactNode, useCallback, useEffect, useState } from "react";
 import { limitBounds, useUrlSearchParams } from "../hooks/useUrlSearchParams";
@@ -31,6 +33,8 @@ const Paginated: FC<PaginatedProps> = (props) => {
     const totalPages = Math.ceil(
         totalCount === undefined || totalCount === 0 ? 1 : totalCount / limit,
     );
+    const theme = useMantineTheme();
+    const isSmallDevice = useMediaQuery(`(max-width:${theme.breakpoints.xs})`);
 
     const [activePage, setActivePage] = useState(
         page > totalPages ? totalPages : page,
@@ -84,9 +88,12 @@ const Paginated: FC<PaginatedProps> = (props) => {
     return (
         <Stack {...restProps}>
             <Pagination
-                styles={{ root: { alignSelf: "flex-end" } }}
+                styles={{
+                    root: { alignSelf: "flex-end" },
+                }}
                 value={activePage}
                 total={totalPages}
+                siblings={isSmallDevice ? 0 : 1}
                 onChange={onChangeTopPagination}
             />
 
@@ -107,6 +114,7 @@ const Paginated: FC<PaginatedProps> = (props) => {
                     styles={{ root: { alignSelf: "flex-end" } }}
                     value={activePage}
                     total={totalPages}
+                    siblings={isSmallDevice ? 0 : 1}
                     onChange={onChangeBottomPagination}
                 />
             </Group>

--- a/apps/web/src/components/specification/SpecificationListView.tsx
+++ b/apps/web/src/components/specification/SpecificationListView.tsx
@@ -360,8 +360,10 @@ export const SpecificationListView: FC = () => {
                             value={filter}
                             onChange={(value) => setFilter(value as ModeFilter)}
                         />
-                        <NewSpecificationButton />
-                        <SpecificationsActionsMenu />
+                        <Group>
+                            <NewSpecificationButton />
+                            <SpecificationsActionsMenu />
+                        </Group>
                     </Group>
                 </Flex>
 

--- a/apps/web/src/components/specification/components/NewSpecificationButton.tsx
+++ b/apps/web/src/components/specification/components/NewSpecificationButton.tsx
@@ -9,7 +9,7 @@ interface NewSpecificationButtonProps extends ButtonProps {
 export const NewSpecificationButton: FC<NewSpecificationButtonProps> = (
     props,
 ) => {
-    const { btnText = "New", ...rest } = props;
+    const { btnText = "Create specification", ...rest } = props;
     return (
         <Button component={Link} href="/specifications/new" {...rest}>
             {btnText}

--- a/apps/web/src/components/specification/form/fields/ByteSlices.tsx
+++ b/apps/web/src/components/specification/form/fields/ByteSlices.tsx
@@ -242,7 +242,10 @@ const SliceInstructionFields: FC<SliceInstructionFieldsProps> = ({
     }, [key]);
 
     return (
-        <Stack data-testid="slice-instruction-fields">
+        <Stack
+            pl={{ base: 0, xs: "sm" }}
+            data-testid="slice-instruction-fields"
+        >
             <Fieldset p="xs">
                 <Group justify="space-between">
                     <Text fw="bold">Define a slice</Text>

--- a/apps/web/src/components/specification/form/fields/ByteSlices.tsx
+++ b/apps/web/src/components/specification/form/fields/ByteSlices.tsx
@@ -473,12 +473,10 @@ export const ByteSlices: FC<ByteSlicesProps> = ({
             </Group>
 
             {isActive ? (
-                <Stack pl="sm">
-                    <SliceInstructionFields
-                        onSliceInstructionsChange={onSliceInstructionsChange}
-                        onSliceTargetChange={onSliceTargetChange}
-                    />
-                </Stack>
+                <SliceInstructionFields
+                    onSliceInstructionsChange={onSliceInstructionsChange}
+                    onSliceTargetChange={onSliceTargetChange}
+                />
             ) : (
                 ""
             )}

--- a/apps/web/src/components/specification/form/fields/Conditions.tsx
+++ b/apps/web/src/components/specification/form/fields/Conditions.tsx
@@ -98,7 +98,7 @@ export const AddConditions: FC<AddConditionsProps> = ({
     }, [isValid, conditions, logicalOperator, onConditionalsChange]);
 
     return (
-        <Stack>
+        <Stack gap="xs">
             {conditions.map((cond, idx) => (
                 <Stack key={idx}>
                     {idx > 0 ? (
@@ -224,11 +224,7 @@ export const Conditions: FC<Props> = ({
                 />
             </Group>
             {isActive ? (
-                <Stack pl="sm" gap="xs">
-                    <AddConditions
-                        onConditionalsChange={onConditionalsChange}
-                    />
-                </Stack>
+                <AddConditions onConditionalsChange={onConditionalsChange} />
             ) : (
                 ""
             )}

--- a/apps/web/src/components/specification/form/fields/Conditions.tsx
+++ b/apps/web/src/components/specification/form/fields/Conditions.tsx
@@ -98,7 +98,7 @@ export const AddConditions: FC<AddConditionsProps> = ({
     }, [isValid, conditions, logicalOperator, onConditionalsChange]);
 
     return (
-        <Stack gap="xs">
+        <Stack pl={{ base: 0, xs: "sm" }} gap="xs">
             {conditions.map((cond, idx) => (
                 <Stack key={idx}>
                     {idx > 0 ? (

--- a/packages/ui/src/InputDetails/PageableContent.tsx
+++ b/packages/ui/src/InputDetails/PageableContent.tsx
@@ -63,7 +63,9 @@ const Connect: FC<ConnectProps> = ({ onConnect }) => {
                 radius="xl"
             />
             <Group justify="center">
-                <Button onClick={() => onConnect()}>Connect</Button>
+                <Button mr="auto" onClick={() => onConnect()}>
+                    Connect
+                </Button>
             </Group>
         </Stack>
     );

--- a/packages/ui/src/InputDetails/index.tsx
+++ b/packages/ui/src/InputDetails/index.tsx
@@ -53,7 +53,7 @@ const MemoTabs = memo(function MemoTabs({ isSmallDevice }: MemoTabsProps) {
                 // eslint-disable-next-line react/display-name
                 const CText = forwardRef<HTMLParagraphElement>(
                     (_props, ref) => (
-                        <Text ref={ref} size={isSmallDevice ? "xs" : "md"}>
+                        <Text ref={ref} size={isSmallDevice ? "sm" : "md"}>
                             {item.label}
                         </Text>
                     ),
@@ -137,7 +137,7 @@ const Details: FC<InputDetailsProps> = (props) => {
 
     useEffect(() => {
         dispatch({ type: "SET_DEFINED_CONTENT", payload: dict });
-    }, [dict]);
+    }, [dict, dispatch]);
 
     return (
         <Tabs

--- a/packages/ui/src/SummaryCard.tsx
+++ b/packages/ui/src/SummaryCard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Card, Group, Text } from "@mantine/core";
+import { Card, Flex, Text } from "@mantine/core";
 import { FC } from "react";
 import { IconType } from "react-icons";
 import TweenedNumber from "./TweenedNumber";
@@ -13,15 +13,17 @@ export type SummaryCardProps = {
 export const SummaryCard: FC<SummaryCardProps> = (props) => {
     return (
         <Card shadow="xs">
-            <Group gap={5}>
+            <Flex gap={5} align="center">
                 {props.icon && (
                     <props.icon
-                        size={20}
+                        size={28}
                         data-testid={`summary-card-${props.title?.toLowerCase()}-icon`}
                     />
                 )}
-                <Text c="dimmed">{props.title}</Text>
-            </Group>
+                <Text c="dimmed" size="lg" inline>
+                    {props.title}
+                </Text>
+            </Flex>
             <Text fw="bold" fz="2rem">
                 <TweenedNumber value={props.value} />
             </Text>


### PR DESCRIPTION
Summary of the changes:

- Shortened the address in breadcrumbs.
- Changed inline page title for `/applications/:id` to `Application Summary` to make the title more explanatory.
- Changed inline page title for `/applications/:id/inputs` to `Application Inputs` to make the title more explanatory.
- Utilised `PageTitle` component on pages `/specifications/new` and `specifications/:id`.
- Tweaked gap between elements in the `Address` component to mitigate extra space between them and the copy button.
- Made the latest inputs table on `/applications/:id` page responsive.
- Fixed warning for duplicate keys for latest inputs table.
- Improved spacings for the connection card.
- Made the grid 2x2 for the application summary cards on small screens.
- Changed text for the create connection button to be `Create connection` to make the CTA more explanatory.
- Placed the icon within the heading for `PageTitle` component to improve multi-line visualisation.
- Fixed issues with z-index between mobile nav, footer and networks dropdown.
- Used `UnstyledButton` component for the networks dropdown trigger to mitigate the activate state (button pressed) behaviour.
- Reduced number of siblings for pagination on small screens to keep the pagination on a single line.
- Placed actions for `/specifications` page on a separate line for small screens.
- Changed text for the create specification button to be `Create specification` to make the CTA more explanatory.
- Removed left padding for conditions and slice instructions to gain some horizontal real estate, for `/specifications/new` and `/specifications/:id` pages.
- Placed the `Connect` button for notices, reports and vouchers on the inputs page in the beginning of the line to improve its visibility on small screens.
- Increased text size for Inputs/Notices/Reports/Vouchers tabs for small screens.
- Centered vertically icon and text for summary card. Also increased size for icon and text to make the content more readable across small screens.