### PR TITLE
feat(apps/web): Improve responsive design for latest entries tables

### DIFF
--- a/apps/web/src/components/applications/latestInputsTable.tsx
+++ b/apps/web/src/components/applications/latestInputsTable.tsx
@@ -32,7 +32,11 @@ const LatestInputsTable: FC<LatestInputsTableProps> = ({
     }, []);
 
     return (
-        <Table width="100%" miw={500} style={{ borderCollapse: "collapse" }}>
+        <Table
+            width="100%"
+            miw="max-content"
+            style={{ borderCollapse: "collapse" }}
+        >
             <Table.Thead>
                 <Table.Tr>
                     <Table.Th>From</Table.Th>

--- a/apps/web/src/components/latestEntries.tsx
+++ b/apps/web/src/components/latestEntries.tsx
@@ -56,7 +56,7 @@ export const LatestEntriesCard: FC<LatestEntriesCard> = (props) => {
                 </Text>
             </Group>
 
-            <Group gap={5}>
+            <Group gap={5} style={{ overflowX: "auto" }}>
                 <LatestEntriesTable
                     entries={entries}
                     fetching={fetching}

--- a/apps/web/src/components/latestEntriesTable.tsx
+++ b/apps/web/src/components/latestEntriesTable.tsx
@@ -30,7 +30,11 @@ const LatestEntriesTable: FC<LatestEntriesTableProps> = ({
     }, []);
 
     return (
-        <Table>
+        <Table
+            width="100%"
+            miw="max-content"
+            style={{ borderCollapse: "collapse" }}
+        >
             <Table.Thead>
                 <Table.Tr>
                     <Table.Th>Address</Table.Th>


### PR DESCRIPTION
While testing https://github.com/cartesi/rollups-explorer/pull/318 I noticed that a couple of tables are still not sufficiently responsive on small screens so I made several minor fixes to improve that.