### PR TITLE
Fix: Navbar and footer z-index.

### DIFF
--- a/apps/web/mantine.d.ts
+++ b/apps/web/mantine.d.ts
@@ -5,5 +5,6 @@ declare module "@mantine/core" {
     export interface MantineThemeOther {
         iconSize: number;
         chainIconSize: number;
+        footerZIndex: number;
     }
 }

--- a/apps/web/src/components/layout/footer.tsx
+++ b/apps/web/src/components/layout/footer.tsx
@@ -1,4 +1,3 @@
-import type { FC, ReactNode } from "react";
 import {
     Anchor,
     Box,
@@ -10,6 +9,7 @@ import {
 } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 import Link from "next/link";
+import type { FC, ReactNode } from "react";
 import {
     TbBrandDiscord,
     TbBrandGithub,
@@ -44,12 +44,13 @@ const Footer: FC = () => {
     const theme = useMantineTheme();
     const { colorScheme } = useMantineColorScheme();
     const isSmallDevice = useMediaQuery(`(max-width:${theme.breakpoints.sm})`);
+    const zIndex = theme.other.footerZIndex ?? 102;
 
     return (
         <footer
             style={{
                 position: "relative",
-                zIndex: 102,
+                zIndex,
                 backgroundColor: "var(--mantine-color-body)",
                 padding: isSmallDevice ? "2rem" : "3rem 4rem",
                 borderTop: `calc(0.0625rem * var(--mantine-scale)) solid ${

--- a/apps/web/src/components/layout/shell.tsx
+++ b/apps/web/src/components/layout/shell.tsx
@@ -31,8 +31,8 @@ import { useAccount } from "wagmi";
 import CartesiLogo from "../../components/cartesiLogo";
 import Footer from "../../components/layout/footer";
 import SendTransaction from "../../components/sendTransaction";
-import { CartesiScanChains } from "../networks/cartesiScanNetworks";
 import getConfiguredChainId from "../../lib/getConfiguredChain";
+import { CartesiScanChains } from "../networks/cartesiScanNetworks";
 
 const Shell: FC<{ children: ReactNode }> = ({ children }) => {
     const [opened, { toggle: toggleMobileMenu, close: closeMobileMenu }] =
@@ -61,6 +61,7 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
     });
     const isSmallDevice = useMediaQuery(`(max-width:${theme.breakpoints.xs})`);
     const themeDefaultProps = theme.components?.AppShell?.defaultProps ?? {};
+    const footerZIndex = theme.other.footerZIndex ?? 102;
 
     return (
         <AppShell
@@ -144,7 +145,12 @@ const Shell: FC<{ children: ReactNode }> = ({ children }) => {
                     </Group>
                 </Group>
             </AppShell.Header>
-            <AppShell.Navbar py="md" px={4} zIndex={110} data-testid="navbar">
+            <AppShell.Navbar
+                py="md"
+                px={4}
+                zIndex={isSmallDevice ? footerZIndex + 2 : "auto"}
+                data-testid="navbar"
+            >
                 <Stack px={13}>
                     <NavLink
                         component={Link}

--- a/apps/web/src/providers/theme.tsx
+++ b/apps/web/src/providers/theme.tsx
@@ -17,6 +17,7 @@ const themeOverride: MantineThemeOverride = createTheme({
     other: {
         iconSize: 21,
         chainIconSize: 24,
+        footerZIndex: 102,
     },
     components: {
         Modal: Modal.extend({


### PR DESCRIPTION
### Summary
Code changes to fix the visualisation of the Footer content on a Desktop size screen. The z-index of the navbar will vary based on screen size. The menu has a full-screen drawer effect on a small device, and it will be on top of the body and footer contents. Otherwise, the footer is above the navbar, as previously.  GIF below of the currently deployed version. 


![2025-02-21 13 36 01](https://github.com/user-attachments/assets/bde34f3d-465a-49be-8b8a-9f274e5b715d)
