### PR TITLE
#323 Improve inputs search performance

### DIFF
--- a/apps/web/src/components/paginated.tsx
+++ b/apps/web/src/components/paginated.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-    Flex,
     Group,
     Pagination,
     Select,

--- a/apps/web/test/components/search.test.tsx
+++ b/apps/web/test/components/search.test.tsx
@@ -102,7 +102,7 @@ describe("Search Component", () => {
                     queryAddress,
                 ),
             {
-                timeout: 400,
+                timeout: 600,
             },
         );
     });


### PR DESCRIPTION
While working on https://github.com/cartesi/rollups-explorer/issues/323, I noticed some performance issues with the inputs search:

- The search was causing some of the Next.js's contexts (related to routing) to be re-rendered on each key stroke.
- The search was causing the table beneath it to re-render on each key stroke (whenever the search value was changing).

In some cases, when you are quickly typing in the search, this resulted in noticeable FPS drops (from ~60 to ~30). 

Here's a video demonstrating this:
https://github.com/user-attachments/assets/eb67ebff-4b2d-4afb-8331-1bee9627a100

I implemented a couple of minor tweaks in order to optimise this:

- The search will update the page query params using a debounced function.
- The table is memoized and doesn't re-render on each key stroke, instead it re-renders only when its props change.

Here's a video after the optimisations:
https://github.com/user-attachments/assets/adb93059-e80c-45ce-8ca6-be0c36161b95

