### PR TITLE
chore: Bump rollups-contracts to its stable v2.

### DIFF
--- a/packages/rollups-wagmi/deployments/ApplicationFactory.json
+++ b/packages/rollups-wagmi/deployments/ApplicationFactory.json
@@ -1,5 +1,5 @@
 {
-  "address": "0x2210ad1d9B0bD2D470c2bfA4814ab6253BC421A0",
+  "address": "0xc7006f70875BaDe89032001262A846D3Ee160051",
   "abi": [
     {
       "type": "function",
@@ -153,12 +153,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0x3f64dd4339edba3bed5a1b76c0721f54b5ff7430a90233c60ab1ebfd7e213f43",
+  "deployTxnHash": "0x39c05a189bd69011782ddff4b94f1151bee0ece3324aa333e9f9f60a51f4be54",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/dapp/ApplicationFactory.sol",
   "contractName": "ApplicationFactory",
   "deployedOn": "deploy.ApplicationFactory",
-  "gasUsed": 1249720,
-  "gasCost": "1307089154"
+  "gasUsed": 1241858,
+  "gasCost": "1307280719"
 }

--- a/packages/rollups-wagmi/deployments/AuthorityFactory.json
+++ b/packages/rollups-wagmi/deployments/AuthorityFactory.json
@@ -1,5 +1,5 @@
 {
-  "address": "0x451f57Ca716046D114Ab9ff23269a2F9F4a1bdaF",
+  "address": "0xC7003566dD09Aa0fC0Ce201aC2769aFAe3BF0051",
   "abi": [
     {
       "type": "function",
@@ -99,12 +99,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0x32fc5fdfcde6c71d6331452defed1019c5f47483624b11c4eb6f1209eb44ff5c",
+  "deployTxnHash": "0x932b4010ea2dc99c79a2f7e462965ee451c346047a107796793d159a4380c5ae",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/consensus/authority/AuthorityFactory.sol",
   "contractName": "AuthorityFactory",
   "deployedOn": "deploy.AuthorityFactory",
-  "gasUsed": 481603,
-  "gasCost": "1271901139"
+  "gasUsed": 529911,
+  "gasCost": "1272050621"
 }

--- a/packages/rollups-wagmi/deployments/ERC1155BatchPortal.json
+++ b/packages/rollups-wagmi/deployments/ERC1155BatchPortal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xBc70d79F916A6d48aB0b8F03AC58f89742dEDA34",
+  "address": "0xc700A2e5531E720a2434433b6ccf4c0eA2400051",
   "abi": [
     {
       "type": "constructor",
@@ -65,15 +65,15 @@
     }
   ],
   "constructorArgs": [
-    "0xB6b39Fb3dD926A9e3FBc7A129540eEbeA3016a6c"
+    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0x2076bc2995b4cda946265fa53f6a5a51c86803c2042793f175f6173edc8b885f",
+  "deployTxnHash": "0x80b3b6038ad0caede6191b27a812c67264e6d63a801441cdcdadab0586bc657b",
   "deployTxnBlockNumber": "3",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/portals/ERC1155BatchPortal.sol",
   "contractName": "ERC1155BatchPortal",
   "deployedOn": "deploy.ERC1155BatchPortal",
-  "gasUsed": 306740,
-  "gasCost": "1767389905"
+  "gasUsed": 297734,
+  "gasCost": "1767332330"
 }

--- a/packages/rollups-wagmi/deployments/ERC1155SinglePortal.json
+++ b/packages/rollups-wagmi/deployments/ERC1155SinglePortal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xB778147D50219544F113A55DE1d8de626f0cC1bB",
+  "address": "0xc700A261279aFC6F755A3a67D86ae43E2eBD0051",
   "abi": [
     {
       "type": "constructor",
@@ -65,15 +65,15 @@
     }
   ],
   "constructorArgs": [
-    "0xB6b39Fb3dD926A9e3FBc7A129540eEbeA3016a6c"
+    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0xec303b5b9c845b64fed2e68f3d55bfa2d7f7e7a8f6becb85f3630891eaf6b8f2",
+  "deployTxnHash": "0x0543316cf5e81703f6b9759cfb2c2be233e77b1eba6a92d56c9b52f87c880fc3",
   "deployTxnBlockNumber": "4",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/portals/ERC1155SinglePortal.sol",
   "contractName": "ERC1155SinglePortal",
   "deployedOn": "deploy.ERC1155SinglePortal",
-  "gasUsed": 259714,
-  "gasCost": "1673427744"
+  "gasUsed": 256590,
+  "gasCost": "1673319630"
 }

--- a/packages/rollups-wagmi/deployments/ERC20Portal.json
+++ b/packages/rollups-wagmi/deployments/ERC20Portal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0x05355c2F9bA566c06199DEb17212c3B78C1A3C31",
+  "address": "0xc700D6aDd016eECd59d989C028214Eaa0fCC0051",
   "abi": [
     {
       "type": "constructor",
@@ -60,15 +60,15 @@
     }
   ],
   "constructorArgs": [
-    "0xB6b39Fb3dD926A9e3FBc7A129540eEbeA3016a6c"
+    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0xb0d47464356a7fbecf4b193349c8a176c08e20002da4cbd3317666e94adbcc9a",
+  "deployTxnHash": "0xecb4581f3880441c9f23649ac4f1fcc0805e5499ae90504e6c5331873f1aba2e",
   "deployTxnBlockNumber": "5",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/portals/ERC20Portal.sol",
   "contractName": "ERC20Portal",
   "deployedOn": "deploy.ERC20Portal",
-  "gasUsed": 220318,
-  "gasCost": "1590706765"
+  "gasUsed": 216064,
+  "gasCost": "1590594402"
 }

--- a/packages/rollups-wagmi/deployments/ERC721Portal.json
+++ b/packages/rollups-wagmi/deployments/ERC721Portal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0x0F5A20d3729c44FedabBb560b3D633dc1c246DDe",
+  "address": "0xc700d52F5290e978e9CAe7D1E092935263b60051",
   "abi": [
     {
       "type": "constructor",
@@ -60,15 +60,15 @@
     }
   ],
   "constructorArgs": [
-    "0xB6b39Fb3dD926A9e3FBc7A129540eEbeA3016a6c"
+    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0xfa1ffa4bd3069064938ec3a2740e0342afef40d3a08c73915d7aa2563b9e136d",
+  "deployTxnHash": "0x41cd6b2726b240a9e6a00990a260e578e142c9ec1ec429a35fd2b2a9a3e3a25d",
   "deployTxnBlockNumber": "6",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/portals/ERC721Portal.sol",
   "contractName": "ERC721Portal",
   "deployedOn": "deploy.ERC721Portal",
-  "gasUsed": 254764,
-  "gasCost": "1517952948"
+  "gasUsed": 253126,
+  "gasCost": "1517833487"
 }

--- a/packages/rollups-wagmi/deployments/EtherPortal.json
+++ b/packages/rollups-wagmi/deployments/EtherPortal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xd31aD6613bDaA139E7D12B2428C0Dd00fdBF8aDa",
+  "address": "0xc70076a466789B595b50959cdc261227F0D70051",
   "abi": [
     {
       "type": "constructor",
@@ -50,15 +50,15 @@
     }
   ],
   "constructorArgs": [
-    "0xB6b39Fb3dD926A9e3FBc7A129540eEbeA3016a6c"
+    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0x0019b2fa6a38eb92fe088a6534276ed0440e7d615016d593ee6e1c702819a9eb",
+  "deployTxnHash": "0xca315ebb01393b8fdf13cbcab8fe77e49b323919245f58f8dd42a75735b13cd8",
   "deployTxnBlockNumber": "7",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610368",
   "sourceName": "src/portals/EtherPortal.sol",
   "contractName": "EtherPortal",
   "deployedOn": "deploy.EtherPortal",
-  "gasUsed": 200794,
-  "gasCost": "1454308461"
+  "gasUsed": 193966,
+  "gasCost": "1454196611"
 }

--- a/packages/rollups-wagmi/deployments/InputBox.json
+++ b/packages/rollups-wagmi/deployments/InputBox.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xB6b39Fb3dD926A9e3FBc7A129540eEbeA3016a6c",
+  "address": "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051",
   "abi": [
     {
       "type": "function",
@@ -130,12 +130,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0x08152eb866e9611e4fb52f4c2b815f83d7d1d5358e8c3e348092b3f27f079709",
+  "deployTxnHash": "0x6362936bea9a78f1d079aabf8200ed60f6ada33c6c2800d7ae01203430eabcaf",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1742931757",
+  "deployTimestamp": "1748610369",
   "sourceName": "src/inputs/InputBox.sol",
   "contractName": "InputBox",
   "deployedOn": "deploy.InputBox",
-  "gasUsed": 242044,
+  "gasUsed": 234148,
   "gasCost": "2000000000"
 }

--- a/packages/rollups-wagmi/deployments/QuorumFactory.json
+++ b/packages/rollups-wagmi/deployments/QuorumFactory.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xb85D3942e551E6E5f19AC2CCF8dAb195f5f0347E",
+  "address": "0xC7003CAb437640b91C3351B98e9e8aA413410051",
   "abi": [
     {
       "type": "function",
@@ -99,12 +99,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0xfcb247d903064f7336c1aa5e54f33b467c010a0d05aacd58d37c8404d3a8c9d7",
+  "deployTxnHash": "0x260299cc5a8f37230a64d38aabdc9228afdf8a3823689afda758bcdb0fecebc3",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/consensus/quorum/QuorumFactory.sol",
   "contractName": "QuorumFactory",
   "deployedOn": "deploy.QuorumFactory",
-  "gasUsed": 625423,
-  "gasCost": "1398280091"
+  "gasUsed": 723857,
+  "gasCost": "1398156191"
 }

--- a/packages/rollups-wagmi/deployments/SafeERC20Transfer.json
+++ b/packages/rollups-wagmi/deployments/SafeERC20Transfer.json
@@ -1,5 +1,5 @@
 {
-  "address": "0x35187C9f069D34aB73c02327ae155746a8274208",
+  "address": "0xc700903d822E108a93B21F69A0a6475F42930051",
   "abi": [
     {
       "type": "function",
@@ -38,12 +38,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0xe0eaefca9d4c789933a0c279b6fa3acd0d88108ee625a9ce39b3b3f15b2f4ab9",
+  "deployTxnHash": "0xd5e15e94f4b4c0c979fa77ee305b943179e809103b9f09d4e95aab23631a8467",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/delegatecall/SafeERC20Transfer.sol",
   "contractName": "SafeERC20Transfer",
   "deployedOn": "deploy.SafeERC20Transfer",
-  "gasUsed": 116262,
-  "gasCost": "1350570860"
+  "gasUsed": 116606,
+  "gasCost": "1350788402"
 }

--- a/packages/rollups-wagmi/deployments/SelfHostedApplicationFactory.json
+++ b/packages/rollups-wagmi/deployments/SelfHostedApplicationFactory.json
@@ -1,5 +1,5 @@
 {
-  "address": "0x4a409e1CaB9229711C4e1f68625DdbC75809e721",
+  "address": "0xc700285Ab555eeB5201BC00CFD4b2CC8DED90051",
   "abi": [
     {
       "type": "constructor",
@@ -143,16 +143,16 @@
     }
   ],
   "constructorArgs": [
-    "0x451f57Ca716046D114Ab9ff23269a2F9F4a1bdaF",
-    "0x2210ad1d9B0bD2D470c2bfA4814ab6253BC421A0"
+    "0xC7003566dD09Aa0fC0Ce201aC2769aFAe3BF0051",
+    "0xc7006f70875BaDe89032001262A846D3Ee160051"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0x2d4587e12f531e6bd8539ed26e52e40d5bd8f4d567b948cca027d83ef4d0b820",
+  "deployTxnHash": "0x0efd61480362fb377d6689fb29fe9fd88edf03c9e8a579ca7bb86f3b70051aa6",
   "deployTxnBlockNumber": "3",
-  "deployTimestamp": "1742931756",
+  "deployTimestamp": "1748610367",
   "sourceName": "src/dapp/SelfHostedApplicationFactory.sol",
   "contractName": "SelfHostedApplicationFactory",
   "deployedOn": "deploy.SelfHostedApplicationFactory",
-  "gasUsed": 325530,
-  "gasCost": "1182988001"
+  "gasUsed": 350222,
+  "gasCost": "1183172451"
 }

--- a/packages/rollups-wagmi/package.json
+++ b/packages/rollups-wagmi/package.json
@@ -20,7 +20,7 @@
         "build": "tsup",
         "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
         "codegen": "wagmi generate",
-        "cannon:inspect": "cannon inspect cartesi-rollups:2.0.0-rc.17 --write-deployments ./deployments",
+        "cannon:inspect": "cannon inspect cartesi-rollups:2.0.0 --write-deployments ./deployments",
         "dev": "tsup --watch"
     },
     "dependencies": {
@@ -31,21 +31,21 @@
     },
     "devDependencies": {
         "@cartesi/rollups": "^1.2.0",
-        "@cartesi/rollups-v2": "npm:@cartesi/rollups@2.0.0-rc.17",
+        "@cartesi/rollups-v2": "npm:@cartesi/rollups@2.0.0",
         "@cartesi/tsconfig": "*",
         "@sunodo/wagmi-plugin-hardhat-deploy": "^0.3",
+        "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@usecannon/cli": "^2.21.5",
-        "@types/node": "^20",
-        "viem": "^2",
         "@wagmi/cli": "^2",
         "eslint": "^8",
         "eslint-config-cartesi": "*",
         "react": "^18",
         "tsup": "^7",
         "tsx": "^4.19.2",
-        "typescript": "^5"
+        "typescript": "^5",
+        "viem": "^2"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/rollups-wagmi/tsconfig.json
+++ b/packages/rollups-wagmi/tsconfig.json
@@ -4,6 +4,7 @@
     "exclude": ["dist", "build", "node_modules"],
     "compilerOptions": {
         "resolveJsonModule": true,
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "moduleResolution": "bundler"
     }
 }

--- a/packages/rollups-wagmi/wagmi.config.ts
+++ b/packages/rollups-wagmi/wagmi.config.ts
@@ -51,7 +51,9 @@ const generateV2ContractsConfig = (): ContractConfig[] => {
     return contractConfigs;
 };
 
-export default defineConfig({
+type Config = ReturnType<typeof defineConfig>;
+
+const config: Config = defineConfig({
     out: "src/index.tsx",
     contracts: [
         {
@@ -89,3 +91,5 @@ export default defineConfig({
         react(),
     ],
 });
+
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,10 +1631,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cartesi/rollups-v2@npm:@cartesi/rollups@2.0.0-rc.17":
-  version "2.0.0-rc.17"
-  resolved "https://registry.yarnpkg.com/@cartesi/rollups/-/rollups-2.0.0-rc.17.tgz#9f93843796759b5b2c333a7120b06e0d4064c9a9"
-  integrity sha512-W3yCVyRsbgv8t4qwSogKNT8Zy4bcdDxTIuK4rDNPKFvuDuppSQbZfKaaG2fx0NJGfbmm2c7M/t+on8aB+IN9mg==
+"@cartesi/rollups-v2@npm:@cartesi/rollups@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cartesi/rollups/-/rollups-2.0.0.tgz#a0142a5f7ec7f5f43371dd5e259255a9823a158a"
+  integrity sha512-41Dtq73wD5JTepuryUiXumjMNx/e5AlOROKlao4/A0rG34R8emblnTGwvMaMpzKd+USDk2M/aLtIPZ6tnDXD/g==
 
 "@cartesi/rollups@^1.2.0":
   version "1.4.0"


### PR DESCRIPTION
## Summary
Bumping cartesi/rollups to its stable version. 