### PR TITLE
#351 Add applications search

### DIFF
--- a/apps/web/e2e/pages/applications.spec.ts
+++ b/apps/web/e2e/pages/applications.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { honeypotV2Sepolia } from "../utils/constants";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/applications");
@@ -36,7 +37,7 @@ test('should display empty state when "My apps" tab is active', async ({
 
 test("should open application summary page", async ({ page }) => {
     await expect(page.getByTestId("applications-spinner")).not.toBeVisible();
-    const applicationSummaryLinks = await page.getByTestId(
+    const applicationSummaryLinks = page.getByTestId(
         "applications-summary-link",
     );
 
@@ -49,7 +50,7 @@ test("should open application summary page", async ({ page }) => {
 
 test("should open application inputs page", async ({ page }) => {
     await expect(page.getByTestId("applications-spinner")).not.toBeVisible();
-    const applicationInputsLinks = await page.getByTestId("applications-link");
+    const applicationInputsLinks = page.getByTestId("applications-link");
 
     const firstLink = applicationInputsLinks.first();
     const href = (await firstLink.getAttribute("href")) as string;
@@ -60,10 +61,23 @@ test("should open application inputs page", async ({ page }) => {
 
 test("should open add-connection modal", async ({ page }) => {
     await expect(page.getByTestId("applications-spinner")).not.toBeVisible();
-    const addConnectionButton = await page.getByTestId("add-connection");
+    const addConnectionButton = page.getByTestId("add-connection");
 
     const firstButton = addConnectionButton.first();
 
     await firstButton.click();
     await expect(page.getByText("Create App Connection")).toBeVisible();
+});
+
+test("should search for specific application", async ({ page }) => {
+    await expect(page.getByTestId("applications-spinner")).not.toBeVisible();
+
+    const search = page.getByTestId("search-input");
+    await search.focus();
+    await page.keyboard.type(honeypotV2Sepolia.address);
+    await page.waitForTimeout(2000);
+
+    await expect(page.getByText("inputs-table-spinner")).not.toBeVisible();
+    await expect(page.getByRole("row", { name: "Id Owner URL" })).toBeVisible();
+    await expect(page.getByRole("row")).toHaveCount(2);
 });

--- a/apps/web/src/components/applications/applications.tsx
+++ b/apps/web/src/components/applications/applications.tsx
@@ -15,6 +15,7 @@ import Paginated from "../paginated";
 import Search from "../search";
 import UserApplicationsTable from "./userApplicationsTable";
 import { useUrlSearchParams } from "../../hooks/useUrlSearchParams";
+import { checkApplicationsQuery } from "../../lib/query";
 
 const UserApplications: FC = () => {
     const { address, isConnected } = useAccount();
@@ -26,7 +27,7 @@ const UserApplications: FC = () => {
         variables: {
             after,
             limit,
-            orderBy: ApplicationOrderByInput.IdAsc,
+            orderBy: ApplicationOrderByInput.TimestampDesc,
             ownerId: address?.toLowerCase(),
             chainId,
         },
@@ -76,22 +77,16 @@ const AllApplications: FC = () => {
     const [queryDebounced] = useDebouncedValue(query, 500);
     const after = page === 1 ? undefined : ((page - 1) * limit).toString();
     const chainId = getConfiguredChainId();
-    const formattedQueryDebounced = queryDebounced.toLowerCase();
     const [{ data: data, fetching: fetching }] = useApplicationsConnectionQuery(
         {
             variables: {
-                orderBy: ApplicationOrderByInput.IdAsc,
+                orderBy: ApplicationOrderByInput.TimestampDesc,
                 limit,
                 after,
-                where: {
-                    chain: { id_eq: chainId },
-                    address_startsWith: formattedQueryDebounced,
-                    OR: [
-                        {
-                            owner_startsWith: formattedQueryDebounced,
-                        },
-                    ],
-                },
+                where: checkApplicationsQuery({
+                    chainId,
+                    address: queryDebounced.toLowerCase(),
+                }),
             },
         },
     );

--- a/apps/web/src/components/inputs/inputs.tsx
+++ b/apps/web/src/components/inputs/inputs.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Stack } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
 import { FC, useCallback, useMemo, useState } from "react";
 import { useInputsConnectionQuery } from "@cartesi/rollups-explorer-domain/explorer-hooks";
@@ -65,12 +64,15 @@ const Inputs: FC<InputsProps> = ({
      * The memoization is required so that the component doesn't re-render
      * whenever the search input value changes
      */
-    const MemoizedTable = useMemo(
+    return useMemo(
         () => (
             <Paginated
                 fetching={fetching}
                 totalCount={totalCount}
                 onChange={onChangePagination}
+                SearchInput={
+                    <Search isLoading={fetching} onChange={setQuery} />
+                }
             >
                 <InputsTable
                     inputs={inputs}
@@ -80,13 +82,6 @@ const Inputs: FC<InputsProps> = ({
             </Paginated>
         ),
         [fetching, onChangePagination, inputs, totalCount],
-    );
-
-    return (
-        <Stack>
-            <Search isLoading={fetching} onChange={setQuery} />
-            {MemoizedTable}
-        </Stack>
     );
 };
 

--- a/apps/web/src/components/latestEntries.tsx
+++ b/apps/web/src/components/latestEntries.tsx
@@ -96,7 +96,9 @@ const LatestEntries: FC = () => {
             variables: {
                 orderBy: ApplicationOrderByInput.TimestampDesc,
                 limit: 6,
-                chainId: chainIdConfigured,
+                where: {
+                    chain: { id_eq: chainIdConfigured },
+                },
             },
         });
     const inputs =

--- a/apps/web/src/components/latestEntries.tsx
+++ b/apps/web/src/components/latestEntries.tsx
@@ -23,6 +23,7 @@ import {
 } from "@cartesi/rollups-explorer-domain/explorer-types";
 import getConfiguredChainId from "../lib/getConfiguredChain";
 import LatestEntriesTable, { Entry } from "./latestEntriesTable";
+import { checkApplicationsQuery } from "../lib/query";
 
 interface LatestEntriesCard {
     title: string;
@@ -96,9 +97,9 @@ const LatestEntries: FC = () => {
             variables: {
                 orderBy: ApplicationOrderByInput.TimestampDesc,
                 limit: 6,
-                where: {
-                    chain: { id_eq: chainIdConfigured },
-                },
+                where: checkApplicationsQuery({
+                    chainId: chainIdConfigured,
+                }),
             },
         });
     const inputs =

--- a/apps/web/src/components/paginated.tsx
+++ b/apps/web/src/components/paginated.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import {
+    Box,
+    Flex,
     Group,
     Pagination,
     Select,
@@ -24,17 +26,26 @@ export interface PaginatedProps extends Omit<StackProps, "onChange"> {
     children: ReactNode;
     totalCount?: number;
     fetching: boolean;
+    SearchInput?: ReactNode;
     onChange: (limit: number, page: number) => void;
 }
 
 const Paginated: FC<PaginatedProps> = (props) => {
-    const { children, totalCount, fetching, onChange, ...restProps } = props;
+    const {
+        children,
+        totalCount,
+        fetching,
+        SearchInput = null,
+        onChange,
+        ...restProps
+    } = props;
     const [{ limit, page, query }, updateParams] = useUrlSearchParams();
     const totalPages = Math.ceil(
         totalCount === undefined || totalCount === 0 ? 1 : totalCount / limit,
     );
     const theme = useMantineTheme();
     const isSmallDevice = useMediaQuery(`(max-width:${theme.breakpoints.xs})`);
+    const hasSearchInput = SearchInput !== null;
 
     const [activePage, setActivePage] = useState(
         page > totalPages ? totalPages : page,
@@ -87,18 +98,23 @@ const Paginated: FC<PaginatedProps> = (props) => {
 
     return (
         <Stack {...restProps}>
-            <Pagination
-                styles={{
-                    root: { alignSelf: "flex-end" },
-                }}
-                value={activePage}
-                total={totalPages}
-                siblings={isSmallDevice ? 0 : 1}
-                onChange={onChangeTopPagination}
-                getControlProps={(control) => ({
-                    "aria-label": control,
-                })}
-            />
+            <Flex
+                direction={{ base: "column", lg: "row" }}
+                align={{ base: "flex-end", lg: "center" }}
+                justify={{ base: "flex-start", lg: "space-between" }}
+                gap={hasSearchInput ? "sm" : 0}
+            >
+                <Box w={{ base: "100%", lg: "50%" }}>{SearchInput}</Box>
+                <Pagination
+                    value={activePage}
+                    total={totalPages}
+                    siblings={isSmallDevice ? 0 : 1}
+                    onChange={onChangeTopPagination}
+                    getControlProps={(control) => ({
+                        "aria-label": control,
+                    })}
+                />
+            </Flex>
 
             {children}
 

--- a/apps/web/src/components/search.tsx
+++ b/apps/web/src/components/search.tsx
@@ -1,15 +1,21 @@
-import { Box, Loader, TextInput } from "@mantine/core";
+import { Loader, TextInput } from "@mantine/core";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { CiSearch } from "react-icons/ci";
+import { TbSearch } from "react-icons/tb";
 import { LimitBound, useUrlSearchParams } from "../hooks/useUrlSearchParams";
 import { useDebouncedCallback } from "@mantine/hooks";
 
 export type SearchProps = {
+    placeholder?: string;
     isLoading: boolean;
     onChange: (query: string) => void;
 };
 
-const Search: React.FC<SearchProps> = ({ onChange, isLoading }) => {
+const Search: React.FC<SearchProps> = (props) => {
+    const {
+        placeholder = "Search by Address / Txn Hash / Index",
+        onChange,
+        isLoading,
+    } = props;
     const [{ limit, page, query }, updateParams] = useUrlSearchParams();
     const [search, setSearch] = useState<string>(query);
     const lastSearch = useRef(search);
@@ -52,22 +58,18 @@ const Search: React.FC<SearchProps> = ({ onChange, isLoading }) => {
     useEffect(() => syncSearchWithQuery(), [syncSearchWithQuery]);
 
     return (
-        <Box w={{ sm: "10%%", lg: "50%" }} mb={{ sm: "1rem", lg: "-3.25rem" }}>
-            <TextInput
-                placeholder="Search by Address / Txn Hash / Index"
-                leftSection={<CiSearch />}
-                rightSection={
-                    search &&
-                    isLoading && (
-                        <Loader size={"xs"} aria-label="loader-input" />
-                    )
-                }
-                size="md"
-                data-testid="search-input"
-                value={search}
-                onChange={onSearch}
-            />
-        </Box>
+        <TextInput
+            placeholder={placeholder}
+            leftSection={<TbSearch />}
+            rightSection={
+                search &&
+                isLoading && <Loader size={"xs"} aria-label="loader-input" />
+            }
+            size="md"
+            data-testid="search-input"
+            value={search}
+            onChange={onSearch}
+        />
     );
 };
 

--- a/apps/web/src/lib/query.ts
+++ b/apps/web/src/lib/query.ts
@@ -72,3 +72,35 @@ export const checkQuery = (
 
     return chainQuery;
 };
+
+interface CheckApplicationsQueryParams {
+    chainId: string;
+    address?: string;
+}
+
+/**
+ * @description Builds an applications' query
+ * @param params
+ */
+export const checkApplicationsQuery = (
+    params: CheckApplicationsQueryParams,
+) => {
+    const { chainId, address } = params;
+    const chainQuery = {
+        chain: { id_eq: chainId },
+    };
+
+    if (isNotNilOrEmpty(address)) {
+        return {
+            ...chainQuery,
+            address_startsWith: address,
+            OR: [
+                {
+                    owner_startsWith: address,
+                },
+            ],
+        };
+    }
+
+    return chainQuery;
+};

--- a/apps/web/test/components/applications/applications.test.tsx
+++ b/apps/web/test/components/applications/applications.test.tsx
@@ -189,7 +189,7 @@ describe("Applications component", () => {
                     variables: {
                         after: undefined,
                         limit: 10,
-                        orderBy: "id_ASC",
+                        orderBy: "timestamp_DESC",
                         where: {
                             OR: [
                                 {

--- a/apps/web/test/components/applications/applications.test.tsx
+++ b/apps/web/test/components/applications/applications.test.tsx
@@ -1,5 +1,11 @@
 import { afterAll, beforeEach, describe, it } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+    cleanup,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from "@testing-library/react";
 import { useAccount } from "wagmi";
 import { Applications } from "../../../src/components/applications/applications";
 import { withMantineTheme } from "../../utils/WithMantineTheme";
@@ -7,15 +13,26 @@ import {
     useApplicationsConnectionOwnerQuery,
     useApplicationsConnectionQuery,
 } from "@cartesi/rollups-explorer-domain/explorer-hooks";
-import { ReactNode } from "react";
+import userEvent from "@testing-library/user-event";
+import {
+    ReadonlyURLSearchParams,
+    usePathname,
+    useRouter,
+    useSearchParams,
+} from "next/navigation";
+import { useUrlSearchParams } from "../../../src/hooks/useUrlSearchParams";
+import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+
+vi.mock("next/navigation");
+const usePathnameMock = vi.mocked(usePathname, true);
+const useRouterMock = vi.mocked(useRouter, true);
+const useSearchParamsMock = vi.mocked(useSearchParams, true);
+
+vi.mock("../../../src/hooks/useUrlSearchParams");
+const useUrlSearchParamsMock = vi.mocked(useUrlSearchParams, true);
 
 vi.mock("wagmi");
 vi.mock("@cartesi/rollups-explorer-domain/explorer-hooks");
-vi.mock("../../../src/components/paginated", async () => ({
-    default: (props: { children: ReactNode; ["data-testid"]: string }) => (
-        <div data-testid={props["data-testid"]}>{props.children}</div>
-    ),
-}));
 
 const useAccountMock = vi.mocked(useAccount, true);
 const useAccountData = {
@@ -65,6 +82,19 @@ describe("Applications component", () => {
                 fetching: false,
             },
         ] as any);
+
+        usePathnameMock.mockReturnValue("/applications");
+        useRouterMock.mockReturnValue({
+            push: vi.fn(),
+        } as unknown as AppRouterInstance);
+        useSearchParamsMock.mockReturnValue(
+            new URLSearchParams() as unknown as ReadonlyURLSearchParams,
+        );
+
+        useUrlSearchParamsMock.mockReturnValue([
+            { limit: 10, page: 1, query: "" },
+            vi.fn(),
+        ]);
     });
 
     afterAll(() => {
@@ -110,5 +140,70 @@ describe("Applications component", () => {
 
         fireEvent.click(AllAppsButton);
         expect(screen.getByTestId("all-applications")).toBeInTheDocument();
+    });
+
+    it("should search for specific application", async () => {
+        const address = "0xccebaa7e541bcaa99de39ca248f0aa6cd33f9e3e";
+
+        useApplicationsConnectionQueryMock.mockReturnValue([
+            {
+                data: {
+                    applicationsConnection: {
+                        edges: [
+                            {
+                                node: {
+                                    id: "11155111-0xccebaa7e541bcaa99de39ca248f0aa6cd33f9e3e-v2",
+                                    address,
+                                    rollupVersion: "v2",
+                                    __typename: "Application",
+                                    owner: "0x0000000000000000000000000000000000000000",
+                                    timestamp: "1749557112",
+                                    factory: {
+                                        id: "11155111-0xc7006f70875bade89032001262a846d3ee160051",
+                                        address:
+                                            "0xc7006f70875bade89032001262a846d3ee160051",
+                                        __typename: "ApplicationFactory",
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+                fetching: false,
+            },
+        ] as any);
+
+        render(<Component />);
+
+        const searchInput = screen.getByTestId("search-input");
+        fireEvent.focus(searchInput);
+
+        await waitFor(() => userEvent.type(searchInput, address));
+        await waitFor(
+            () =>
+                expect(
+                    useApplicationsConnectionQueryMock,
+                ).toHaveBeenLastCalledWith({
+                    variables: {
+                        after: undefined,
+                        limit: 10,
+                        orderBy: "id_ASC",
+                        where: {
+                            OR: [
+                                {
+                                    owner_startsWith: address,
+                                },
+                            ],
+                            address_startsWith: address,
+                            chain: {
+                                id_eq: "11155111",
+                            },
+                        },
+                    },
+                }),
+            {
+                timeout: 1000,
+            },
+        );
     });
 });

--- a/apps/web/test/components/applications/applications.test.tsx
+++ b/apps/web/test/components/applications/applications.test.tsx
@@ -178,7 +178,9 @@ describe("Applications component", () => {
         const searchInput = screen.getByTestId("search-input");
         fireEvent.focus(searchInput);
 
-        await waitFor(() => userEvent.type(searchInput, address));
+        await waitFor(() => userEvent.type(searchInput, address), {
+            timeout: 2000,
+        });
         await waitFor(
             () =>
                 expect(

--- a/apps/web/test/lib/query.test.ts
+++ b/apps/web/test/lib/query.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { checkQuery } from "../../src/lib/query";
+import { checkQuery, checkApplicationsQuery } from "../../src/lib/query";
 
 describe("Lib query tests", () => {
     const address = "0x4ca2f6935200b9a782a78f408f640f17b29809d8" as const;
@@ -11,103 +11,139 @@ describe("Lib query tests", () => {
     const chainId = "11155111" as const;
     const chainQ = { chain: { id_eq: chainId } };
 
-    it("should return an only chain related query when input and application is not defined", () => {
-        expect(checkQuery("", "", chainId)).toEqual({
-            chain: { id_eq: chainId },
+    describe("checkQuery", () => {
+        it("should return an only chain related query when input and application is not defined", () => {
+            expect(checkQuery("", "", chainId)).toEqual({
+                chain: { id_eq: chainId },
+            });
+        });
+
+        describe("Application is defined", () => {
+            const byAppId = {
+                application: {
+                    address_startsWith: address,
+                    ...chainQ,
+                },
+            };
+
+            it("should return query only by app id when input is not defined", () => {
+                const result = checkQuery("", address, chainId);
+                expect(result).toEqual(byAppId);
+            });
+
+            describe("with input defined", () => {
+                it("should return AND operator including transaction hash", () => {
+                    const result = checkQuery(txHash, address, chainId);
+                    expect(result).toEqual({
+                        AND: [
+                            byAppId,
+                            {
+                                transactionHash_eq: txHash,
+                                ...chainQ,
+                            },
+                        ],
+                    });
+                });
+
+                it("should return AND operator including message-sender for valid hex", () => {
+                    const result = checkQuery(messageSender, address, chainId);
+
+                    expect(result).toEqual({
+                        AND: [
+                            byAppId,
+                            {
+                                msgSender_startsWith: messageSender,
+                                ...chainQ,
+                            },
+                        ],
+                    });
+
+                    expect(checkQuery(validHex, address, chainId)).toEqual({
+                        AND: [
+                            byAppId,
+                            { msgSender_startsWith: "0x", ...chainQ },
+                        ],
+                    });
+                });
+
+                it("should return AND operator including input-index for number", () => {
+                    const result = checkQuery(inputIndex, address, chainId);
+                    expect(result).toEqual({
+                        AND: [byAppId, { index_eq: 10, ...chainQ }],
+                    });
+                });
+            });
+        });
+
+        describe("When only input is defined", () => {
+            it("should return query by transaction-hash for valid tx", () => {
+                const result = checkQuery(txHash, "", chainId);
+                expect(result).toEqual({
+                    transactionHash_eq: txHash,
+                    ...chainQ,
+                });
+            });
+
+            it("should return OR operator for valid Hex value checking for msg-sender and application id", () => {
+                const result = checkQuery(address, "", chainId);
+
+                expect(result).toEqual({
+                    OR: [
+                        { msgSender_startsWith: address, ...chainQ },
+                        {
+                            application: { address_startsWith: address },
+                            ...chainQ,
+                        },
+                    ],
+                });
+
+                expect(checkQuery(validHex, "", chainId)).toEqual({
+                    OR: [
+                        { msgSender_startsWith: validHex, ...chainQ },
+                        {
+                            application: {
+                                address_startsWith: validHex,
+                            },
+                            ...chainQ,
+                        },
+                    ],
+                });
+            });
+
+            it("should return query checking by index_eq for anything else", () => {
+                expect(checkQuery(inputIndex, "", chainId)).toEqual({
+                    ...chainQ,
+                    index_eq: 10,
+                });
+                expect(checkQuery("hello", "", chainId)).toEqual({
+                    index_eq: NaN,
+                    ...chainQ,
+                });
+            });
         });
     });
 
-    describe("Application is defined", () => {
-        const byAppId = {
-            application: {
+    describe("checkApplicationsQuery", () => {
+        it("should return an only chain related query when application is not defined", () => {
+            expect(checkApplicationsQuery({ chainId })).toEqual({
+                chain: { id_eq: chainId },
+            });
+        });
+
+        it("should return chain and application related query when both chain id and application are defined", () => {
+            expect(
+                checkApplicationsQuery({
+                    chainId,
+                    address,
+                }),
+            ).toEqual({
+                chain: { id_eq: chainId },
                 address_startsWith: address,
-                ...chainQ,
-            },
-        };
-
-        it("should return query only by app id when input is not defined", () => {
-            const result = checkQuery("", address, chainId);
-            expect(result).toEqual(byAppId);
-        });
-
-        describe("with input defined", () => {
-            it("should return AND operator including transaction hash", () => {
-                const result = checkQuery(txHash, address, chainId);
-                expect(result).toEqual({
-                    AND: [
-                        byAppId,
-                        {
-                            transactionHash_eq: txHash,
-                            ...chainQ,
-                        },
-                    ],
-                });
-            });
-
-            it("should return AND operator including message-sender for valid hex", () => {
-                const result = checkQuery(messageSender, address, chainId);
-
-                expect(result).toEqual({
-                    AND: [
-                        byAppId,
-                        {
-                            msgSender_startsWith: messageSender,
-                            ...chainQ,
-                        },
-                    ],
-                });
-
-                expect(checkQuery(validHex, address, chainId)).toEqual({
-                    AND: [byAppId, { msgSender_startsWith: "0x", ...chainQ }],
-                });
-            });
-
-            it("should return AND operator including input-index for number", () => {
-                const result = checkQuery(inputIndex, address, chainId);
-                expect(result).toEqual({
-                    AND: [byAppId, { index_eq: 10, ...chainQ }],
-                });
-            });
-        });
-    });
-
-    describe("When only input is defined", () => {
-        it("should return query by transaction-hash for valid tx", () => {
-            const result = checkQuery(txHash, "", chainId);
-            expect(result).toEqual({ transactionHash_eq: txHash, ...chainQ });
-        });
-
-        it("should return OR operator for valid Hex value checking for msg-sender and application id", () => {
-            const result = checkQuery(address, "", chainId);
-
-            expect(result).toEqual({
                 OR: [
-                    { msgSender_startsWith: address, ...chainQ },
-                    { application: { address_startsWith: address }, ...chainQ },
-                ],
-            });
-
-            expect(checkQuery(validHex, "", chainId)).toEqual({
-                OR: [
-                    { msgSender_startsWith: validHex, ...chainQ },
                     {
-                        application: {
-                            address_startsWith: validHex,
-                        },
-                        ...chainQ,
+                        owner_startsWith: address,
                     },
                 ],
-            });
-        });
-
-        it("should return query checking by index_eq for anything else", () => {
-            expect(checkQuery(inputIndex, "", chainId)).toEqual({
-                ...chainQ,
-                index_eq: 10,
-            });
-            expect(checkQuery("hello", "", chainId)).toEqual({
-                index_eq: NaN,
-                ...chainQ,
             });
         });
     });

--- a/packages/domain/graphql/queries.graphql
+++ b/packages/domain/graphql/queries.graphql
@@ -126,15 +126,14 @@ fragment ApplicationItem on Application {
 query applicationsConnection(
         $orderBy: [ApplicationOrderByInput!]!, 
         $limit: Int, 
-        $after: String, 
-        $factoryId: String, 
-        $chainId:String
+        $after: String,
+        $where: ApplicationWhereInput
     ) {
     applicationsConnection(
             orderBy: $orderBy, 
             first: $limit, 
-            after: $after, 
-            where: {factory: {id_startsWith: $factoryId}, chain: {id_eq: $chainId}}
+            after: $after,
+            where: $where
         ) {
         totalCount
         pageInfo {


### PR DESCRIPTION
I added the applications search that handles application addresses or owners.

Additionally, I refactored the search input removing its wrapper with negative margins and created a slot in the `Paginated` component for it.

Finally, I covered the new logic with unit and e2e tests. 