### PR TITLE
feat: change default cartesi port from 8080 to 6751

### DIFF
--- a/apps/web/.env.cartesi
+++ b/apps/web/.env.cartesi
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_CHAIN_ID=13370
-NEXT_PUBLIC_EXPLORER_API_URL="http://localhost:8080/explorer-api/graphql"
-NEXT_PUBLIC_NODE_RPC_URL="http://localhost:8080/anvil"
+NEXT_PUBLIC_EXPLORER_API_URL="http://127.0.0.1:6751/explorer-api/graphql"
+NEXT_PUBLIC_NODE_RPC_URL="http://127.0.0.1:6751/anvil"
 INTERNAL_EXPLORER_API_URL="http://explorer_api:4350/graphql"
 BASE_PATH="/explorer"


### PR DESCRIPTION
The Cartesi CLI changed its default port from 8080 to 6751.
