### PR TITLE
#370 Fix issues with filters persistence

### DIFF
--- a/apps/web/src/components/applications/applications.tsx
+++ b/apps/web/src/components/applications/applications.tsx
@@ -18,6 +18,7 @@ import Paginated from "../paginated";
 import Search from "../search";
 import VersionsFilter from "../versionsFilter";
 import UserApplicationsTable from "./userApplicationsTable";
+import { splitString } from "../../lib/textUtils";
 
 const UserApplications: FC = () => {
     const { address, isConnected } = useAccount();
@@ -74,11 +75,10 @@ const UserApplications: FC = () => {
 const AllApplications: FC = () => {
     const [limit, setLimit] = useState(10);
     const [page, setPage] = useState(1);
-    const [{ query: urlQuery }] = useUrlSearchParams();
+    const [{ query: urlQuery, version }] = useUrlSearchParams();
     const [query, setQuery] = useState(urlQuery);
     const [queryDebounced] = useDebouncedValue(query, 500);
-    const [versions, setVersions] = useState<string[]>([]);
-    const [versionsDebounced] = useDebouncedValue(versions, 500);
+    const [versions, setVersions] = useState<string[]>(splitString(version));
     const after = page === 1 ? undefined : ((page - 1) * limit).toString();
     const { chainId } = useAppConfig();
     const [{ data: data, fetching: fetching }] = useApplicationsConnectionQuery(
@@ -90,7 +90,7 @@ const AllApplications: FC = () => {
                 where: checkApplicationsQuery({
                     chainId,
                     address: queryDebounced.toLowerCase(),
-                    versions: versionsDebounced as RollupVersion[],
+                    versions: versions as RollupVersion[],
                 }),
             },
         },

--- a/apps/web/src/components/inputs/inputs.tsx
+++ b/apps/web/src/components/inputs/inputs.tsx
@@ -15,6 +15,7 @@ import InputsTable from "../inputs/inputsTable";
 import Paginated from "../paginated";
 import Search from "../search";
 import VersionsFilter from "../versionsFilter";
+import { splitString } from "../../lib/textUtils";
 
 export type InputsProps = {
     orderBy?: InputOrderByInput;
@@ -28,11 +29,10 @@ const Inputs: FC<InputsProps> = ({
     appVersion,
 }) => {
     const { chainId } = useAppConfig();
-    const [{ query: urlQuery }] = useUrlSearchParams();
+    const [{ query: urlQuery, version }] = useUrlSearchParams();
     const [query, setQuery] = useState(urlQuery);
     const [queryDebounced] = useDebouncedValue(query, 500);
-    const [versions, setVersions] = useState<string[]>([]);
-    const [versionsDebounced] = useDebouncedValue(versions, 500);
+    const [versions, setVersions] = useState<string[]>(splitString(version));
     const [limit, setLimit] = useState(10);
     const [page, setPage] = useState(1);
     const after = page === 1 ? undefined : ((page - 1) * limit).toString();
@@ -46,9 +46,7 @@ const Inputs: FC<InputsProps> = ({
                 queryDebounced.toLowerCase(),
                 appAddress?.toLowerCase(),
                 chainId,
-                appVersion
-                    ? [appVersion]
-                    : (versionsDebounced as RollupVersion[]),
+                appVersion ? [appVersion] : (versions as RollupVersion[]),
             ),
         },
     });

--- a/apps/web/src/components/versionsFilter.tsx
+++ b/apps/web/src/components/versionsFilter.tsx
@@ -10,7 +10,7 @@ import { ActionIcon, Button, Checkbox, Flex, Menu } from "@mantine/core";
 import { TbFilter, TbFilterFilled } from "react-icons/tb";
 import { useUrlSearchParams } from "../hooks/useUrlSearchParams";
 import { RollupVersion } from "@cartesi/rollups-explorer-domain/explorer-types";
-import { isNilOrEmpty } from "ramda-adjunct";
+import { splitString } from "../lib/textUtils";
 
 export type FilterVersion = `${RollupVersion}`;
 
@@ -65,9 +65,7 @@ const VersionsFilter: FC<VersionFilterProps> = (props) => {
             }
 
             if (!opened && !isApplied.current) {
-                const versions = isNilOrEmpty(version)
-                    ? []
-                    : (version.split(",") as FilterVersion[]);
+                const versions = splitString<FilterVersion>(version);
                 setActiveVersions(versions);
             }
         },
@@ -82,9 +80,7 @@ const VersionsFilter: FC<VersionFilterProps> = (props) => {
             !isFilterSyncedWithQuery.current &&
             lastActiveVersions.current.join() !== version
         ) {
-            const versions = isNilOrEmpty(version)
-                ? []
-                : (version.split(",") as FilterVersion[]);
+            const versions = splitString<FilterVersion>(version);
             setActiveVersions(versions);
             onChange(versions);
             lastActiveVersions.current = versions;

--- a/apps/web/src/hooks/useUrlSearchParams.ts
+++ b/apps/web/src/hooks/useUrlSearchParams.ts
@@ -2,6 +2,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { pathOr } from "ramda";
 import { useCallback, useMemo } from "react";
 import { RollupVersion } from "@cartesi/rollups-explorer-domain/explorer-types";
+import { splitString } from "../lib/textUtils";
 
 const availableVersions = Object.values(RollupVersion).reduce(
     (accumulator, version) => ({
@@ -30,7 +31,12 @@ export const useUrlSearchParams = () => {
     const page = isNaN(pg) ? 1 : pg;
     const query = urlSearchParams.get("query") ?? "";
     const versionParam = urlSearchParams.get("version") ?? "";
-    const version = pathOr("", [versionParam], availableVersions);
+    const version = versionParam.includes(",")
+        ? splitString<string>(versionParam)
+              .map((version) => pathOr("", [version], availableVersions))
+              .filter((version) => version !== "")
+              .join(",")
+        : pathOr("", [versionParam], availableVersions);
 
     const updateParams = useCallback(
         (page: number, limit: number, query: string, version = ""): void => {

--- a/apps/web/src/lib/textUtils.ts
+++ b/apps/web/src/lib/textUtils.ts
@@ -1,3 +1,12 @@
+import { isNilOrEmpty } from "ramda-adjunct";
+import { FilterVersion } from "../components/versionsFilter";
+
 export const shortenHash = (hash: string) => {
     return `${hash.slice(0, 8)}...${hash.slice(-6)}`;
+};
+
+export const splitString = <T>(value: string, separator = ",") => {
+    return (
+        isNilOrEmpty(value) ? [] : (value.split(separator) as FilterVersion[])
+    ) as T[];
 };


### PR DESCRIPTION
I fixed the issue related to the multiple rollups versions not being correctly persisted on page refresh.

Additionally, I noticed that on production there are cases where 2 requests are being made for the filters. This was caused by the debouncing logic for the filters, so I removed it. Changes to the filters are low-frequency (you need to select the filters and then hit `Apply` or `Reset` buttons after which the filters popover is closed) so there won't be a possibility for the users to spam requests in such ways.