### PR TITLE
#376 Add e2e test for performance measuring

### DIFF
--- a/apps/web/e2e/pages/inputs.spec.ts
+++ b/apps/web/e2e/pages/inputs.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { findInputsRequestForRollupsV2 } from "../utils/requests";
 
 test.beforeEach(async ({ page }) => {
     await page.goto("/inputs");
@@ -88,6 +89,10 @@ test("should search for specific input", async ({ page }) => {
 });
 
 test("should filter inputs based on rollups v2 version", async ({ page }) => {
+    const rollupsVersionV2Request = page.waitForRequest(
+        findInputsRequestForRollupsV2,
+    );
+
     await expect(page.getByTestId("inputs-table-spinner")).not.toBeVisible();
 
     const versionsFilterTrigger = page.getByTestId("versions-filter-trigger");
@@ -99,16 +104,16 @@ test("should filter inputs based on rollups v2 version", async ({ page }) => {
     const applyButton = page.getByText("Apply");
     await applyButton.click();
 
-    await page.waitForURL("/inputs", {
-        waitUntil: "networkidle",
-    });
+    await rollupsVersionV2Request;
 
     await expect(page.getByTestId("inputs-table-spinner")).not.toBeVisible();
 
-    const href = await page.evaluate(() => document.location.search, {
-        timeout: 1000,
-    });
-    expect(href).toContain("version=v2");
+    const inputBadges = await page.getByTestId("rollup-version-badge").all();
+
+    for (const inputBadge of inputBadges) {
+        const textContent = await inputBadge.textContent();
+        expect(textContent).toBe("v2");
+    }
 });
 
 test("should filter applications based on multiple version", async ({

--- a/apps/web/e2e/performance/applications.spec.ts
+++ b/apps/web/e2e/performance/applications.spec.ts
@@ -26,9 +26,6 @@ test("applications should load normally", async ({ page }) => {
     // Set initial value for the after param
     let after = 10;
 
-    // Initialize an empty array to store the request times
-    const requestTimes: number[] = [];
-
     // Iterate the buttons from 2 to 5
     for (const button of buttonsForPagesTwoToFive) {
         // Intercept the paginated request associated with the button
@@ -41,37 +38,15 @@ test("applications should load normally", async ({ page }) => {
         // Measure the start time of the request
         const startTime = Date.now();
         // Await the request to settle
-        const request = await paginatedRequest;
-        // Await the response
-        const response = await request.response();
-        // Assert that the request is successful
-        expect(response?.status()).toBe(200);
-        // Measure the end time of the request
-        const endTime = Date.now();
-        // Measure the request time
-        const requestTime = (endTime - startTime) / 1000;
-        // Save the request time
-        requestTimes.push(requestTime);
+        await paginatedRequest;
+        // Await the table spinner to be visible
+        await expect(page.getByTestId("table-spinner")).toBeVisible();
+        // Await the table spinner to be hidden
+        await expect(page.getByTestId("table-spinner")).not.toBeVisible({
+            timeout: 1000,
+        });
         // Iterate the after param for the next request
         after += 10;
-    }
-
-    // Calculate the combined request time
-    const combinedRequestTime = requestTimes.reduce(
-        (totalTime, requestTime) => {
-            return totalTime + requestTime;
-        },
-        0,
-    );
-
-    // Verify that the combined time of the requests was no more than 2 seconds
-    // Four requests were made so the average time needs to be <= 0.5 seconds per request
-    expect(combinedRequestTime).toBeLessThanOrEqual(2);
-
-    // Verify that none of the requests took more than 1 second to settle
-    // Typically, the paginated requests take between 150 ms to 600 ms depending on the network speed. We consider a request that took more than a second to be flawed in some way.
-    for (const requestTime of requestTimes) {
-        expect(requestTime).toBeLessThanOrEqual(1);
     }
 });
 

--- a/apps/web/e2e/performance/applications.spec.ts
+++ b/apps/web/e2e/performance/applications.spec.ts
@@ -4,16 +4,13 @@ import {
     findGraphQlRequest,
 } from "../utils/requests";
 
-const maxAllowedRequestTime = 0.5;
-
 test.beforeEach(async ({ page }) => {
     await page.goto("/applications");
 });
 
 test("applications should load normally", async ({ page }) => {
     // Wait for the initial inputs request
-    const inputsRequest = page.waitForRequest(findGraphQlRequest);
-    await inputsRequest;
+    await page.waitForRequest(findGraphQlRequest);
 
     // Wait for the spinner to disappear
     await expect(page.getByTestId("table-spinner")).not.toBeVisible();
@@ -28,6 +25,9 @@ test("applications should load normally", async ({ page }) => {
 
     // Set initial value for the after param
     let after = 10;
+
+    // Initialize an empty array to store the request times
+    const requestTimes: number[] = [];
 
     // Iterate the buttons from 2 to 5
     for (const button of buttonsForPagesTwoToFive) {
@@ -50,9 +50,99 @@ test("applications should load normally", async ({ page }) => {
         const endTime = Date.now();
         // Measure the request time
         const requestTime = (endTime - startTime) / 1000;
-        // Expect the request to have taken no more than 0.5 seconds
-        expect(requestTime).toBeLessThanOrEqual(maxAllowedRequestTime);
+        // Save the request time
+        requestTimes.push(requestTime);
         // Iterate the after param for the next request
         after += 10;
     }
+
+    // Calculate the combined request time
+    const combinedRequestTime = requestTimes.reduce(
+        (totalTime, requestTime) => {
+            return totalTime + requestTime;
+        },
+        0,
+    );
+
+    // Verify that the combined time of the requests was no more than 2 seconds
+    // Four requests were made so the average time needs to be <= 0.5 seconds per request
+    expect(combinedRequestTime).toBeLessThanOrEqual(2);
+
+    // Verify that none of the requests took more than 1 second to settle
+    // Typically, the paginated requests take between 150 ms to 600 ms depending on the network speed. We consider a request that took more than a second to be flawed in some way.
+    for (const requestTime of requestTimes) {
+        expect(requestTime).toBeLessThanOrEqual(1);
+    }
+});
+
+test("cache should be used for the same requests", async ({ page }) => {
+    // Wait for the initial inputs request
+    await page.waitForRequest(findGraphQlRequest);
+
+    // Wait for the spinner to disappear
+    await expect(page.getByTestId("table-spinner")).not.toBeVisible();
+
+    // Get the top pagination buttons
+    const topPagination = page.getByTestId("top-pagination");
+    const paginationButtons = topPagination.getByRole("button");
+    // Get the numbered buttons from 2 to 5
+    const buttonsForPagesTwoToFour = await paginationButtons
+        .filter({ hasText: /^[2-4]$/ })
+        .all();
+
+    // Set initial value for the after param
+    let after = 10;
+
+    // Iterate the buttons from 2 to 4
+    for (const button of buttonsForPagesTwoToFour) {
+        // Intercept the paginated request associated with the button
+        const paginatedRequest = page.waitForRequest(
+            (request) => findGraphQlPaginatedRequest(request, after),
+            { timeout: 1000 },
+        );
+
+        // Trigger the request by clicking on the button
+        await button.click();
+        // Await the request to settle
+        const request = await paginatedRequest;
+        // Await the response
+        const response = await request.response();
+        // Assert that the request is successful
+        expect(response?.status()).toBe(200);
+        // Iterate the after param for the next request
+        after += 10;
+    }
+
+    // Reset the after value
+    after = 0;
+
+    // Set the initial flag for verifying if any subsequent requests were made
+    let paginatedRequestWasMade = false;
+
+    // Listen for requests and set the flag to true if any graphql requests are made
+    page.on("request", (request) => {
+        if (request.url().includes("/graphql")) {
+            paginatedRequestWasMade = true;
+        }
+    });
+
+    // Get the numbered buttons from 2 to 5
+    const buttonsForPagesOneToFour = await paginationButtons
+        .filter({ hasText: /^[1-4]$/ })
+        .all();
+
+    // Iterate the buttons from 1 to 5
+    for (const button of buttonsForPagesOneToFour) {
+        // Click on the pagination button
+        await button.click();
+        // Verify that the table spinner doesn't appear
+        await expect(page.getByTestId("table-spinner")).not.toBeVisible();
+        // Await all requests to settle
+        await page.waitForLoadState("networkidle");
+        // Iterate the after param for the next request
+        after += 10;
+    }
+
+    // Verify that no paginated requests were made
+    expect(paginatedRequestWasMade).toBe(false);
 });

--- a/apps/web/e2e/performance/applications.spec.ts
+++ b/apps/web/e2e/performance/applications.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import {
+    findGraphQlPaginatedRequest,
+    findGraphQlRequest,
+} from "../utils/requests";
+
+const maxAllowedRequestTime = 0.5;
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/applications");
+});
+
+test("applications should load normally", async ({ page }) => {
+    // Wait for the initial inputs request
+    const inputsRequest = page.waitForRequest(findGraphQlRequest);
+    await inputsRequest;
+
+    // Wait for the spinner to disappear
+    await expect(page.getByTestId("table-spinner")).not.toBeVisible();
+
+    // Get the top pagination buttons
+    const topPagination = page.getByTestId("top-pagination");
+    const paginationButtons = topPagination.getByRole("button");
+    // Get the numbered buttons from 2 to 5
+    const buttonsForPagesTwoToFive = await paginationButtons
+        .filter({ hasText: /^[2-5]$/ })
+        .all();
+
+    // Set initial value for the after param
+    let after = 10;
+
+    // Iterate the buttons from 2 to 5
+    for (const button of buttonsForPagesTwoToFive) {
+        // Intercept the paginated request associated with the button
+        const paginatedRequest = page.waitForRequest((request) =>
+            findGraphQlPaginatedRequest(request, after),
+        );
+
+        // Trigger the request by clicking on the button
+        await button.click();
+        // Measure the start time of the request
+        const startTime = Date.now();
+        // Await the request to settle
+        const request = await paginatedRequest;
+        // Await the response
+        const response = await request.response();
+        // Assert that the request is successful
+        expect(response?.status()).toBe(200);
+        // Measure the end time of the request
+        const endTime = Date.now();
+        // Measure the request time
+        const requestTime = (endTime - startTime) / 1000;
+        // Expect the request to have taken no more than 0.5 seconds
+        expect(requestTime).toBeLessThanOrEqual(maxAllowedRequestTime);
+        // Iterate the after param for the next request
+        after += 10;
+    }
+});

--- a/apps/web/e2e/performance/inputs.spec.ts
+++ b/apps/web/e2e/performance/inputs.spec.ts
@@ -26,9 +26,6 @@ test("inputs should load normally", async ({ page }) => {
     // Set initial value for the after param
     let after = 10;
 
-    // Initialize an empty array to store the request times
-    const requestTimes: number[] = [];
-
     // Iterate the buttons from 2 to 5
     for (const button of buttonsForPagesTwoToFour) {
         // Intercept the paginated request associated with the button
@@ -41,37 +38,15 @@ test("inputs should load normally", async ({ page }) => {
         // Measure the start time of the request
         const startTime = Date.now();
         // Await the request to settle
-        const request = await paginatedRequest;
-        // Await the response
-        const response = await request.response();
-        // Assert that the request is successful
-        expect(response?.status()).toBe(200);
-        // Measure the end time of the request
-        const endTime = Date.now();
-        // Measure the request time
-        const requestTime = (endTime - startTime) / 1000;
-        // Save the request time
-        requestTimes.push(requestTime);
+        await paginatedRequest;
+        // Await the table spinner to be visible
+        await expect(page.getByTestId("inputs-table-spinner")).toBeVisible();
+        // Await the table spinner to be hidden
+        await expect(page.getByTestId("inputs-table-spinner")).not.toBeVisible({
+            timeout: 1000,
+        });
         // Iterate the after param for the next request
         after += 10;
-    }
-
-    // Calculate the combined request time
-    const combinedRequestTime = requestTimes.reduce(
-        (totalTime, requestTime) => {
-            return totalTime + requestTime;
-        },
-        0,
-    );
-
-    // Verify that the combined time of the requests was no more than 2 seconds
-    // Four requests were made so the average time needs to be <= 0.5 seconds per request
-    expect(combinedRequestTime).toBeLessThanOrEqual(2);
-
-    // Verify that none of the requests took more than 1 second to settle
-    // Typically, the paginated requests take between 150 ms to 600 ms depending on the network speed. We consider a request that took more than a second to be flawed in some way.
-    for (const requestTime of requestTimes) {
-        expect(requestTime).toBeLessThanOrEqual(1);
     }
 });
 

--- a/apps/web/e2e/performance/inputs.spec.ts
+++ b/apps/web/e2e/performance/inputs.spec.ts
@@ -4,16 +4,13 @@ import {
     findGraphQlRequest,
 } from "../utils/requests";
 
-const maxAllowedRequestTime = 0.5;
-
 test.beforeEach(async ({ page }) => {
     await page.goto("/inputs");
 });
 
 test("inputs should load normally", async ({ page }) => {
     // Wait for the initial inputs request
-    const inputsRequest = page.waitForRequest(findGraphQlRequest);
-    await inputsRequest;
+    await page.waitForRequest(findGraphQlRequest);
 
     // Wait for the spinner to disappear
     await expect(page.getByTestId("inputs-table-spinner")).not.toBeVisible();
@@ -22,15 +19,18 @@ test("inputs should load normally", async ({ page }) => {
     const topPagination = page.getByTestId("top-pagination");
     const paginationButtons = topPagination.getByRole("button");
     // Get the numbered buttons from 2 to 5
-    const buttonsForPagesTwoToFive = await paginationButtons
+    const buttonsForPagesTwoToFour = await paginationButtons
         .filter({ hasText: /^[2-5]$/ })
         .all();
 
     // Set initial value for the after param
     let after = 10;
 
+    // Initialize an empty array to store the request times
+    const requestTimes: number[] = [];
+
     // Iterate the buttons from 2 to 5
-    for (const button of buttonsForPagesTwoToFive) {
+    for (const button of buttonsForPagesTwoToFour) {
         // Intercept the paginated request associated with the button
         const paginatedRequest = page.waitForRequest((request) =>
             findGraphQlPaginatedRequest(request, after),
@@ -50,9 +50,101 @@ test("inputs should load normally", async ({ page }) => {
         const endTime = Date.now();
         // Measure the request time
         const requestTime = (endTime - startTime) / 1000;
-        // Expect the request to have taken no more than 0.5 seconds
-        expect(requestTime).toBeLessThanOrEqual(maxAllowedRequestTime);
+        // Save the request time
+        requestTimes.push(requestTime);
         // Iterate the after param for the next request
         after += 10;
     }
+
+    // Calculate the combined request time
+    const combinedRequestTime = requestTimes.reduce(
+        (totalTime, requestTime) => {
+            return totalTime + requestTime;
+        },
+        0,
+    );
+
+    // Verify that the combined time of the requests was no more than 2 seconds
+    // Four requests were made so the average time needs to be <= 0.5 seconds per request
+    expect(combinedRequestTime).toBeLessThanOrEqual(2);
+
+    // Verify that none of the requests took more than 1 second to settle
+    // Typically, the paginated requests take between 150 ms to 600 ms depending on the network speed. We consider a request that took more than a second to be flawed in some way.
+    for (const requestTime of requestTimes) {
+        expect(requestTime).toBeLessThanOrEqual(1);
+    }
+});
+
+test("cache should be used for the same requests", async ({ page }) => {
+    // Wait for the initial inputs request
+    await page.waitForRequest(findGraphQlRequest);
+
+    // Wait for the spinner to disappear
+    await expect(page.getByTestId("inputs-table-spinner")).not.toBeVisible();
+
+    // Get the top pagination buttons
+    const topPagination = page.getByTestId("top-pagination");
+    const paginationButtons = topPagination.getByRole("button");
+    // Get the numbered buttons from 2 to 5
+    const buttonsForPagesTwoToFour = await paginationButtons
+        .filter({ hasText: /^[2-4]$/ })
+        .all();
+
+    // Set initial value for the after param
+    let after = 10;
+
+    // Iterate the buttons from 2 to 4
+    for (const button of buttonsForPagesTwoToFour) {
+        // Intercept the paginated request associated with the button
+        const paginatedRequest = page.waitForRequest(
+            (request) => findGraphQlPaginatedRequest(request, after),
+            { timeout: 1000 },
+        );
+
+        // Trigger the request by clicking on the button
+        await button.click();
+        // Await the request to settle
+        const request = await paginatedRequest;
+        // Await the response
+        const response = await request.response();
+        // Assert that the request is successful
+        expect(response?.status()).toBe(200);
+        // Iterate the after param for the next request
+        after += 10;
+    }
+
+    // Reset the after value
+    after = 0;
+
+    // Set the initial flag for verifying if any subsequent requests were made
+    let paginatedRequestWasMade = false;
+
+    // Listen for requests and set the flag to true if any graphql requests are made
+    page.on("request", (request) => {
+        if (request.url().includes("/graphql")) {
+            paginatedRequestWasMade = true;
+        }
+    });
+
+    // Get the numbered buttons from 2 to 5
+    const buttonsForPagesOneToFour = await paginationButtons
+        .filter({ hasText: /^[1-4]$/ })
+        .all();
+
+    // Iterate the buttons from 1 to 5
+    for (const button of buttonsForPagesOneToFour) {
+        // Click on the pagination button
+        await button.click();
+        // Verify that the table spinner doesn't appear
+        await expect(
+            page.getByTestId("inputs-table-spinner"),
+        ).not.toBeVisible();
+        // Await all requests to settle
+        await page.waitForLoadState("networkidle");
+        // Iterate the after param for the next request
+        after += 10;
+    }
+
+    // Verify that no paginated requests were made
+    expect(paginatedRequestWasMade).toBe(false);
 });

--- a/apps/web/e2e/performance/inputs.spec.ts
+++ b/apps/web/e2e/performance/inputs.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import {
+    findGraphQlPaginatedRequest,
+    findGraphQlRequest,
+} from "../utils/requests";
+
+const maxAllowedRequestTime = 0.5;
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("/inputs");
+});
+
+test("inputs should load normally", async ({ page }) => {
+    // Wait for the initial inputs request
+    const inputsRequest = page.waitForRequest(findGraphQlRequest);
+    await inputsRequest;
+
+    // Wait for the spinner to disappear
+    await expect(page.getByTestId("inputs-table-spinner")).not.toBeVisible();
+
+    // Get the top pagination buttons
+    const topPagination = page.getByTestId("top-pagination");
+    const paginationButtons = topPagination.getByRole("button");
+    // Get the numbered buttons from 2 to 5
+    const buttonsForPagesTwoToFive = await paginationButtons
+        .filter({ hasText: /^[2-5]$/ })
+        .all();
+
+    // Set initial value for the after param
+    let after = 10;
+
+    // Iterate the buttons from 2 to 5
+    for (const button of buttonsForPagesTwoToFive) {
+        // Intercept the paginated request associated with the button
+        const paginatedRequest = page.waitForRequest((request) =>
+            findGraphQlPaginatedRequest(request, after),
+        );
+
+        // Trigger the request by clicking on the button
+        await button.click();
+        // Measure the start time of the request
+        const startTime = Date.now();
+        // Await the request to settle
+        const request = await paginatedRequest;
+        // Await the response
+        const response = await request.response();
+        // Assert that the request is successful
+        expect(response?.status()).toBe(200);
+        // Measure the end time of the request
+        const endTime = Date.now();
+        // Measure the request time
+        const requestTime = (endTime - startTime) / 1000;
+        // Expect the request to have taken no more than 0.5 seconds
+        expect(requestTime).toBeLessThanOrEqual(maxAllowedRequestTime);
+        // Iterate the after param for the next request
+        after += 10;
+    }
+});

--- a/apps/web/e2e/transactions/metamask.spec.ts
+++ b/apps/web/e2e/transactions/metamask.spec.ts
@@ -3,7 +3,7 @@ import { test } from "../fixtures/metamask";
 
 test.describe.configure({
     mode: "serial",
-    timeout: 240000,
+    timeout: 360000,
 });
 
 test.describe("Metamask", () => {

--- a/apps/web/e2e/utils/requests.ts
+++ b/apps/web/e2e/utils/requests.ts
@@ -1,0 +1,76 @@
+import { Request } from "@playwright/test";
+
+/**
+ * @description Finds the GraphQL request
+ * @param request
+ * @return boolean
+ */
+export const findGraphQlRequest = (request: Request) => {
+    return request.url().includes("/graphql") && request.method() === "POST";
+};
+
+/**
+ * @description Finds the request for applications filtered by v2 rollups version
+ * @param request
+ * @return boolean
+ */
+export const findApplicationsRequestForRollupsV2 = (request: Request) => {
+    const postData = request.postData();
+    let parsedPostData;
+
+    if (postData) {
+        parsedPostData = JSON.parse(postData);
+    }
+
+    return (
+        findGraphQlRequest(request) &&
+        parsedPostData?.variables?.where?.rollupVersion_in?.length === 1 &&
+        parsedPostData.variables.where.rollupVersion_in[0] === "v2"
+    );
+};
+
+/**
+ * @description Finds the request for inputs filtered by v2 rollups version
+ * @param request
+ * @return boolean
+ */
+export const findInputsRequestForRollupsV2 = (request: Request) => {
+    const postData = request.postData();
+    let parsedPostData;
+
+    if (postData) {
+        parsedPostData = JSON.parse(postData);
+    }
+
+    return (
+        findGraphQlRequest(request) &&
+        parsedPostData?.variables?.where?.AND?.length === 1 &&
+        parsedPostData?.variables?.where?.AND[0].application?.rollupVersion_in
+            ?.length === 1 &&
+        parsedPostData.variables.where.AND[0].application
+            .rollupVersion_in[0] === "v2"
+    );
+};
+
+/**
+ * @description Finds the paginated GraphQL request
+ * @param request
+ * @param after
+ * @return boolean
+ */
+export const findGraphQlPaginatedRequest = (
+    request: Request,
+    after: number,
+) => {
+    const postData = request.postData();
+    let parsedPostData;
+
+    if (postData) {
+        parsedPostData = JSON.parse(postData);
+    }
+
+    return (
+        findGraphQlRequest(request) &&
+        parsedPostData?.variables?.after === after.toString()
+    );
+};

--- a/apps/web/src/components/applications/applications.tsx
+++ b/apps/web/src/components/applications/applications.tsx
@@ -118,10 +118,7 @@ const AllApplications: FC = () => {
                         isLoading={fetching}
                         onChange={setQuery}
                     />
-                    <VersionsFilter
-                        isLoading={fetching && versions.length > 0}
-                        onChange={setVersions}
-                    />
+                    <VersionsFilter onChange={setVersions} />
                 </Flex>
             }
         >

--- a/apps/web/src/components/inputs/inputs.tsx
+++ b/apps/web/src/components/inputs/inputs.tsx
@@ -81,10 +81,7 @@ const Inputs: FC<InputsProps> = ({
                             onChange={setQuery}
                         />
                         {!appVersion && (
-                            <VersionsFilter
-                                isLoading={fetching && versions.length > 0}
-                                onChange={setVersions}
-                            />
+                            <VersionsFilter onChange={setVersions} />
                         )}
                     </Flex>
                 }

--- a/apps/web/src/components/paginated.tsx
+++ b/apps/web/src/components/paginated.tsx
@@ -107,6 +107,7 @@ const Paginated: FC<PaginatedProps> = (props) => {
             >
                 <Box w={{ base: "100%", lg: "50%" }}>{SearchInput}</Box>
                 <Pagination
+                    data-testid="top-pagination"
                     value={activePage}
                     total={totalPages}
                     siblings={isSmallDevice ? 0 : 1}

--- a/apps/web/src/components/versionsFilter.tsx
+++ b/apps/web/src/components/versionsFilter.tsx
@@ -15,12 +15,10 @@ import { splitString } from "../lib/textUtils";
 export type FilterVersion = `${RollupVersion}`;
 
 interface VersionFilterProps {
-    isLoading: boolean;
     onChange: (versions: string[]) => void;
 }
 
-const VersionsFilter: FC<VersionFilterProps> = (props) => {
-    const { isLoading, onChange } = props;
+const VersionsFilter: FC<VersionFilterProps> = ({ onChange }) => {
     const [opened, setOpened] = useState(false);
     const [{ limit, page, query, version }, updateParams] =
         useUrlSearchParams();
@@ -99,11 +97,7 @@ const VersionsFilter: FC<VersionFilterProps> = (props) => {
             onChange={onChangeOpened}
         >
             <Menu.Target>
-                <ActionIcon
-                    size="xl"
-                    data-testid="versions-filter-trigger"
-                    loading={isLoading}
-                >
+                <ActionIcon size="xl" data-testid="versions-filter-trigger">
                     <FilterIcon style={{ width: "60%", height: "60%" }} />
                 </ActionIcon>
             </Menu.Target>

--- a/apps/web/test/components/versionsFilter.test.tsx
+++ b/apps/web/test/components/versionsFilter.test.tsx
@@ -28,7 +28,6 @@ const useUrlSearchParamsMock = vi.mocked(useUrlSearchParams, true);
 
 const Component = withMantineTheme(FilterVersion);
 const defaultProps = {
-    isLoading: false,
     onChange: () => vi.fn(),
 };
 
@@ -132,17 +131,5 @@ describe("Versions Filter Component", () => {
         await waitFor(() =>
             expect(onChangeSpy).toHaveBeenCalledWith(["v1", "v2"]),
         );
-    });
-
-    it("should display spinner while loading", async () => {
-        const mockedUpdateParams = vi.fn();
-        useUrlSearchParamsMock.mockReturnValue([
-            { limit: 10, page: 1, query: "", version: "" },
-            mockedUpdateParams,
-        ]);
-        render(<Component {...defaultProps} isLoading />);
-
-        const trigger = screen.getByTestId("versions-filter-trigger");
-        expect(trigger.getAttribute("data-loading")).toBe("true");
     });
 });


### PR DESCRIPTION
Summary of the changes:

- Added e2e tests for measuring the performance of the `/inputs` and `/applications` pages
  - The tests measure the performance of pages 2 to 5
  - The tests will fail if the combined time for them was more than 2 seconds
  - The tests will fail if any request took more than 1 second
- Added e2e tests for verifying the caching for the `/inputs` and `/applications` pages
- Fix issues with flaky e2e tests for rollups v2 version filtering
- Removed the loading state from the filters button as there were cases where multiple loading states appear on the page:
<img width="1920" height="1080" alt="Screenshot 2025-08-18 at 23 32 41" src="https://github.com/user-attachments/assets/de06ed13-deec-4c25-9456-a0ff6f978a4f" />
