### PR TITLE
#378 Fix issue with RPC requests

### DIFF
--- a/packages/ui/src/hooks/useWatchQueryOnBlockChange.ts
+++ b/packages/ui/src/hooks/useWatchQueryOnBlockChange.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useBlockNumber } from "wagmi";
-import { isEqual } from "../utils";
+import { equals } from "ramda";
 
 export default function useWatchQueryOnBlockChange(
     queryKey: readonly unknown[],
@@ -13,7 +13,7 @@ export default function useWatchQueryOnBlockChange(
 
     useEffect(() => {
         if (
-            !isEqual(queryKey, lastQueryKey.current) ||
+            !equals(queryKey, lastQueryKey.current) ||
             blockNumber !== lastBlockNumber.current
         ) {
             lastQueryKey.current = queryKey;

--- a/packages/ui/src/hooks/useWatchQueryOnBlockChange.ts
+++ b/packages/ui/src/hooks/useWatchQueryOnBlockChange.ts
@@ -1,22 +1,16 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useBlockNumber } from "wagmi";
-import { equals } from "ramda";
 
 export default function useWatchQueryOnBlockChange(
     queryKey: readonly unknown[],
 ) {
     const queryClient = useQueryClient();
     const { data: blockNumber } = useBlockNumber({ watch: true });
-    const lastQueryKey = useRef<readonly unknown[] | null>(null);
-    const lastBlockNumber = useRef<bigint | undefined>(undefined);
+    const lastBlockNumber = useRef<bigint | undefined>(blockNumber);
 
     useEffect(() => {
-        if (
-            !equals(queryKey, lastQueryKey.current) ||
-            blockNumber !== lastBlockNumber.current
-        ) {
-            lastQueryKey.current = queryKey;
+        if (blockNumber !== lastBlockNumber.current) {
             lastBlockNumber.current = blockNumber;
             void queryClient.invalidateQueries({ queryKey });
         }

--- a/packages/ui/src/hooks/useWatchQueryOnBlockChange.ts
+++ b/packages/ui/src/hooks/useWatchQueryOnBlockChange.ts
@@ -1,14 +1,24 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useBlockNumber } from "wagmi";
+import { isEqual } from "../utils";
 
 export default function useWatchQueryOnBlockChange(
     queryKey: readonly unknown[],
 ) {
     const queryClient = useQueryClient();
     const { data: blockNumber } = useBlockNumber({ watch: true });
+    const lastQueryKey = useRef(queryKey);
+    const lastBlockNumber = useRef(blockNumber);
 
     useEffect(() => {
-        queryClient.invalidateQueries({ queryKey });
+        if (
+            !isEqual(queryKey, lastQueryKey.current) ||
+            blockNumber !== lastBlockNumber.current
+        ) {
+            lastQueryKey.current = queryKey;
+            lastBlockNumber.current = blockNumber;
+            void queryClient.invalidateQueries({ queryKey });
+        }
     }, [blockNumber, queryClient, queryKey]);
 }

--- a/packages/ui/src/hooks/useWatchQueryOnBlockChange.ts
+++ b/packages/ui/src/hooks/useWatchQueryOnBlockChange.ts
@@ -8,8 +8,8 @@ export default function useWatchQueryOnBlockChange(
 ) {
     const queryClient = useQueryClient();
     const { data: blockNumber } = useBlockNumber({ watch: true });
-    const lastQueryKey = useRef(queryKey);
-    const lastBlockNumber = useRef(blockNumber);
+    const lastQueryKey = useRef<readonly unknown[] | null>(null);
+    const lastBlockNumber = useRef<bigint | undefined>(undefined);
 
     useEffect(() => {
         if (

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,9 +1,0 @@
-/**
- * @description Checks if two values are equal by using JSON.stringify comparison
- * @param valueA
- * @param valueB
- * @return boolean
- */
-export const isEqual = <T>(valueA: T, valueB: T) => {
-    return JSON.stringify(valueA) === JSON.stringify(valueB);
-};

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @description Checks if two values are equal by using JSON.stringify comparison
+ * @param valueA
+ * @param valueB
+ * @return boolean
+ */
+export const isEqual = <T>(valueA: T, valueB: T) => {
+    return JSON.stringify(valueA) === JSON.stringify(valueB);
+};

--- a/packages/ui/test/hooks/useWatchQueryOnBlockChange.test.ts
+++ b/packages/ui/test/hooks/useWatchQueryOnBlockChange.test.ts
@@ -37,7 +37,7 @@ describe("useWatchQueryOnBlockChange hook", () => {
         );
     });
 
-    it('should not reinvoke "invalidateQueries" function if query key and block number are the same', async () => {
+    it('should not invoke "invalidateQueries" function if query key and block number are the same', async () => {
         const queryKey = ["query-key"];
         let invalidateQueriesMock = vi.fn(() => Promise.resolve());
         useQueryClientMock.mockReturnValue({
@@ -63,7 +63,7 @@ describe("useWatchQueryOnBlockChange hook", () => {
         );
     });
 
-    it('should not reinvoke "invalidateQueries" function if query key has changed but block number is the same', async () => {
+    it('should not invoke "invalidateQueries" function if query key has changed but block number is the same', async () => {
         const queryKey = ["query-key"];
         let invalidateQueriesMock = vi.fn(() => Promise.resolve());
         useQueryClientMock.mockReturnValue({
@@ -89,7 +89,7 @@ describe("useWatchQueryOnBlockChange hook", () => {
         );
     });
 
-    it('should reinvoke "invalidateQueries" function if block number has changed', async () => {
+    it('should invoke "invalidateQueries" function if block number has changed', async () => {
         const queryKey = ["query-key"];
         let invalidateQueriesMock = vi.fn(() => Promise.resolve());
         useQueryClientMock.mockReturnValue({

--- a/packages/ui/test/hooks/useWatchQueryOnBlockChange.test.ts
+++ b/packages/ui/test/hooks/useWatchQueryOnBlockChange.test.ts
@@ -60,7 +60,7 @@ describe("useWatchQueryOnBlockChange hook", () => {
             invalidateQueries: invalidateQueriesMock,
         } as any);
 
-        rerender({ queryKey });
+        rerender({ queryKey: ["query-key"] });
 
         await waitFor(() =>
             expect(invalidateQueriesMock).toHaveBeenCalledTimes(0),

--- a/packages/ui/test/hooks/useWatchQueryOnBlockChange.test.ts
+++ b/packages/ui/test/hooks/useWatchQueryOnBlockChange.test.ts
@@ -38,4 +38,32 @@ describe("useWatchQueryOnBlockChange hook", () => {
             }),
         );
     });
+
+    it('should not reinvoke "invalidateQueries" function if query key and block number are the same', async () => {
+        const queryKey = ["query-key"];
+        let invalidateQueriesMock = vi.fn(() => Promise.resolve());
+        useQueryClientMock.mockReturnValue({
+            invalidateQueries: invalidateQueriesMock,
+        } as any);
+        const { rerender } = renderHook(() =>
+            useWatchQueryOnBlockChange(queryKey),
+        );
+
+        await waitFor(() =>
+            expect(invalidateQueriesMock).toHaveBeenCalledWith({
+                queryKey,
+            }),
+        );
+
+        invalidateQueriesMock = vi.fn(() => Promise.resolve());
+        useQueryClientMock.mockReturnValue({
+            invalidateQueries: invalidateQueriesMock,
+        } as any);
+
+        rerender({ queryKey });
+
+        await waitFor(() =>
+            expect(invalidateQueriesMock).toHaveBeenCalledTimes(0),
+        );
+    });
 });


### PR DESCRIPTION
The query key returned from `useReadContracts` had unstable reference that caused a re-invocation loop for `useWatchQueryOnBlockChange`. I fixed it by verifying the uniqueness of the query and block number in that hook.