### PR TITLE
chore: bump tenkeylabs/dappwright plugin

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,7 +57,7 @@
     "devDependencies": {
         "@cartesi/tsconfig": "workspace:*",
         "@playwright/test": "^1.51.0",
-        "@tenkeylabs/dappwright": "^2.11.2",
+        "@tenkeylabs/dappwright": "^2.11.4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,8 +299,8 @@ importers:
         specifier: ^1.51.0
         version: 1.54.1
       '@tenkeylabs/dappwright':
-        specifier: ^2.11.2
-        version: 2.11.2(playwright-core@1.54.1)
+        specifier: ^2.11.4
+        version: 2.12.0(playwright-core@1.54.1)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -3069,8 +3069,8 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tenkeylabs/dappwright@2.11.2':
-    resolution: {integrity: sha512-ITIY1yKqSMoupuu3kKvUMdXOWUg4+T5O5NZLQKIuAf84zk7oxoIjIAgV2Go5QGynQTpSZhKK7o7YmE93PKPWtQ==}
+  '@tenkeylabs/dappwright@2.12.0':
+    resolution: {integrity: sha512-AVGT827BFjNWqz6epsXeAy6Tref8K0iviuogIrAdokPXaVj/8te6Pf+F9dKF0Xy6eE3oXEbqD5+SCZyvb0FQSQ==}
     engines: {node: '>=20'}
     peerDependencies:
       playwright-core: '>1.0'
@@ -12035,7 +12035,7 @@ snapshots:
       '@tanstack/query-core': 5.90.10
       react: 19.2.1
 
-  '@tenkeylabs/dappwright@2.11.2(playwright-core@1.54.1)':
+  '@tenkeylabs/dappwright@2.12.0(playwright-core@1.54.1)':
     dependencies:
       node-stream-zip: 1.15.0
       playwright-core: 1.54.1


### PR DESCRIPTION
### Summary
The current plugin was causing an error where it was not able to find the metamask-extension plugin (log: `Version 12.23.0 not found!`). Bumping the version includes the use of the newer version `12.23.1`. 



**PS**: Sometimes it may have a rate-limiting problem when downloading the extension as it uses _api.github.com_. An authenticated request increases the rate-limit as described [here](https://github.com/cartesi/rollups-explorer/actions/runs/20137134721/job/57795068173#step:8:394) in the build error log. 😉 