### PR TITLE
feat: Bump rollups-contracts to v2.1.1

### DIFF
--- a/packages/rollups-wagmi/deployments/ApplicationFactory.json
+++ b/packages/rollups-wagmi/deployments/ApplicationFactory.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc7006f70875BaDe89032001262A846D3Ee160051",
+  "address": "0x26E758238CB6eC5aB70ce0dd52aF2d7b82e1972E",
   "abi": [
     {
       "type": "function",
@@ -153,12 +153,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0x39c05a189bd69011782ddff4b94f1151bee0ece3324aa333e9f9f60a51f4be54",
+  "deployTxnHash": "0x67dfc6a8c42e182391d40c8bf873e9ba75e3e21eca129d926694cd83697dfa0b",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/dapp/ApplicationFactory.sol",
   "contractName": "ApplicationFactory",
   "deployedOn": "deploy.ApplicationFactory",
-  "gasUsed": 1241858,
-  "gasCost": "1307280719"
+  "gasUsed": 1262970,
+  "gasCost": "1307313057"
 }

--- a/packages/rollups-wagmi/deployments/AuthorityFactory.json
+++ b/packages/rollups-wagmi/deployments/AuthorityFactory.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xC7003566dD09Aa0fC0Ce201aC2769aFAe3BF0051",
+  "address": "0x5a3368b30174d389aFd205a46bAd35BBE6709b8a",
   "abi": [
     {
       "type": "function",
@@ -99,12 +99,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0x932b4010ea2dc99c79a2f7e462965ee451c346047a107796793d159a4380c5ae",
+  "deployTxnHash": "0xede56fb5c146bf29f43be527ad8926f4626204a4df2f9e2a651e0253733ef8d1",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/consensus/authority/AuthorityFactory.sol",
   "contractName": "AuthorityFactory",
   "deployedOn": "deploy.AuthorityFactory",
-  "gasUsed": 529911,
-  "gasCost": "1272050621"
+  "gasUsed": 542096,
+  "gasCost": "1272133318"
 }

--- a/packages/rollups-wagmi/deployments/ERC1155BatchPortal.json
+++ b/packages/rollups-wagmi/deployments/ERC1155BatchPortal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc700A2e5531E720a2434433b6ccf4c0eA2400051",
+  "address": "0xe246Abb974B307490d9C6932F48EbE79de72338A",
   "abi": [
     {
       "type": "constructor",
@@ -65,15 +65,15 @@
     }
   ],
   "constructorArgs": [
-    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
+    "0x1b51e2992A2755Ba4D6F7094032DF91991a0Cfac"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0x80b3b6038ad0caede6191b27a812c67264e6d63a801441cdcdadab0586bc657b",
+  "deployTxnHash": "0x6c5e02bfa08e988b0de5d5933b3cc5dc42b10839b749b43956eb9eb27350ef5f",
   "deployTxnBlockNumber": "3",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/portals/ERC1155BatchPortal.sol",
   "contractName": "ERC1155BatchPortal",
   "deployedOn": "deploy.ERC1155BatchPortal",
-  "gasUsed": 297734,
-  "gasCost": "1767332330"
+  "gasUsed": 297614,
+  "gasCost": "1767331280"
 }

--- a/packages/rollups-wagmi/deployments/ERC1155SinglePortal.json
+++ b/packages/rollups-wagmi/deployments/ERC1155SinglePortal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc700A261279aFC6F755A3a67D86ae43E2eBD0051",
+  "address": "0x18558398Dd1a8cE20956287a4Da7B76aE7A96662",
   "abi": [
     {
       "type": "constructor",
@@ -65,15 +65,15 @@
     }
   ],
   "constructorArgs": [
-    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
+    "0x1b51e2992A2755Ba4D6F7094032DF91991a0Cfac"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0x0543316cf5e81703f6b9759cfb2c2be233e77b1eba6a92d56c9b52f87c880fc3",
+  "deployTxnHash": "0x8161d908ce23b8c7d92d1a1fb9493c31cdb5efe744f778f53c48c8a6de7ed933",
   "deployTxnBlockNumber": "4",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/portals/ERC1155SinglePortal.sol",
   "contractName": "ERC1155SinglePortal",
   "deployedOn": "deploy.ERC1155SinglePortal",
-  "gasUsed": 256590,
-  "gasCost": "1673319630"
+  "gasUsed": 256470,
+  "gasCost": "1673317942"
 }

--- a/packages/rollups-wagmi/deployments/ERC20Portal.json
+++ b/packages/rollups-wagmi/deployments/ERC20Portal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc700D6aDd016eECd59d989C028214Eaa0fCC0051",
+  "address": "0xACA6586A0Cf05bD831f2501E7B4aea550dA6562D",
   "abi": [
     {
       "type": "constructor",
@@ -60,15 +60,15 @@
     }
   ],
   "constructorArgs": [
-    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
+    "0x1b51e2992A2755Ba4D6F7094032DF91991a0Cfac"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0xecb4581f3880441c9f23649ac4f1fcc0805e5499ae90504e6c5331873f1aba2e",
+  "deployTxnHash": "0x46795f37e8c798262b939bc3e8e0dc1d39bbf1b2e13ea0b07b9cd85c25cd484d",
   "deployTxnBlockNumber": "5",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/portals/ERC20Portal.sol",
   "contractName": "ERC20Portal",
   "deployedOn": "deploy.ERC20Portal",
-  "gasUsed": 216064,
-  "gasCost": "1590594402"
+  "gasUsed": 215968,
+  "gasCost": "1590592249"
 }

--- a/packages/rollups-wagmi/deployments/ERC721Portal.json
+++ b/packages/rollups-wagmi/deployments/ERC721Portal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc700d52F5290e978e9CAe7D1E092935263b60051",
+  "address": "0x9E8851dadb2b77103928518846c4678d48b5e371",
   "abi": [
     {
       "type": "constructor",
@@ -60,15 +60,15 @@
     }
   ],
   "constructorArgs": [
-    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
+    "0x1b51e2992A2755Ba4D6F7094032DF91991a0Cfac"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0x41cd6b2726b240a9e6a00990a260e578e142c9ec1ec429a35fd2b2a9a3e3a25d",
+  "deployTxnHash": "0xe7b46a2e3d7b1ef3b560adc010ae55abb1319b39e2a4914f8988307eca3268f3",
   "deployTxnBlockNumber": "6",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/portals/ERC721Portal.sol",
   "contractName": "ERC721Portal",
   "deployedOn": "deploy.ERC721Portal",
-  "gasUsed": 253126,
-  "gasCost": "1517833487"
+  "gasUsed": 253006,
+  "gasCost": "1517831127"
 }

--- a/packages/rollups-wagmi/deployments/EtherPortal.json
+++ b/packages/rollups-wagmi/deployments/EtherPortal.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc70076a466789B595b50959cdc261227F0D70051",
+  "address": "0xA632c5c05812c6a6149B7af5C56117d1D2603828",
   "abi": [
     {
       "type": "constructor",
@@ -50,15 +50,15 @@
     }
   ],
   "constructorArgs": [
-    "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051"
+    "0x1b51e2992A2755Ba4D6F7094032DF91991a0Cfac"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0xca315ebb01393b8fdf13cbcab8fe77e49b323919245f58f8dd42a75735b13cd8",
+  "deployTxnHash": "0xa5e80ea1e7a00dd0dd28b918d9dbb23ef212ca3c3ba69a62bab81c5fa5c4ebe8",
   "deployTxnBlockNumber": "7",
-  "deployTimestamp": "1748610368",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/portals/EtherPortal.sol",
   "contractName": "EtherPortal",
   "deployedOn": "deploy.EtherPortal",
-  "gasUsed": 193966,
-  "gasCost": "1454196611"
+  "gasUsed": 193858,
+  "gasCost": "1454194023"
 }

--- a/packages/rollups-wagmi/deployments/InputBox.json
+++ b/packages/rollups-wagmi/deployments/InputBox.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051",
+  "address": "0x1b51e2992A2755Ba4D6F7094032DF91991a0Cfac",
   "abi": [
     {
       "type": "function",
@@ -130,12 +130,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0x6362936bea9a78f1d079aabf8200ed60f6ada33c6c2800d7ae01203430eabcaf",
+  "deployTxnHash": "0x6ccdc1eee82de92b7ed6c318bef8aadd374288bb758af0281517cd607488659d",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1748610369",
+  "deployTimestamp": "1762263204",
   "sourceName": "src/inputs/InputBox.sol",
   "contractName": "InputBox",
   "deployedOn": "deploy.InputBox",
-  "gasUsed": 234148,
+  "gasUsed": 234004,
   "gasCost": "2000000000"
 }

--- a/packages/rollups-wagmi/deployments/QuorumFactory.json
+++ b/packages/rollups-wagmi/deployments/QuorumFactory.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xC7003CAb437640b91C3351B98e9e8aA413410051",
+  "address": "0x1e75aa69026B6e368Ba7d663552F1dADaf1740F9",
   "abi": [
     {
       "type": "function",
@@ -99,12 +99,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0x260299cc5a8f37230a64d38aabdc9228afdf8a3823689afda758bcdb0fecebc3",
+  "deployTxnHash": "0x14fb782399ec4f37cfab2c3d691a50b4cae40e2e3a72fa5c8393ad36cdf974d0",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/consensus/quorum/QuorumFactory.sol",
   "contractName": "QuorumFactory",
   "deployedOn": "deploy.QuorumFactory",
-  "gasUsed": 723857,
-  "gasCost": "1398156191"
+  "gasUsed": 735827,
+  "gasCost": "1398153513"
 }

--- a/packages/rollups-wagmi/deployments/SafeERC20Transfer.json
+++ b/packages/rollups-wagmi/deployments/SafeERC20Transfer.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc700903d822E108a93B21F69A0a6475F42930051",
+  "address": "0xb7C2bcAA4437425cfcE9d233bFf15EF461273D63",
   "abi": [
     {
       "type": "function",
@@ -38,12 +38,12 @@
   ],
   "constructorArgs": [],
   "linkedLibraries": {},
-  "deployTxnHash": "0xd5e15e94f4b4c0c979fa77ee305b943179e809103b9f09d4e95aab23631a8467",
+  "deployTxnHash": "0x8b4d952ac758f40901638f2589a44466c95d59e6f8995f64f2cd250454f342fa",
   "deployTxnBlockNumber": "1",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/delegatecall/SafeERC20Transfer.sol",
   "contractName": "SafeERC20Transfer",
   "deployedOn": "deploy.SafeERC20Transfer",
-  "gasUsed": 116606,
-  "gasCost": "1350788402"
+  "gasUsed": 116474,
+  "gasCost": "1350825759"
 }

--- a/packages/rollups-wagmi/deployments/SelfHostedApplicationFactory.json
+++ b/packages/rollups-wagmi/deployments/SelfHostedApplicationFactory.json
@@ -1,5 +1,5 @@
 {
-  "address": "0xc700285Ab555eeB5201BC00CFD4b2CC8DED90051",
+  "address": "0x870240e83b1181b419f18303D4ccC56574De2931",
   "abi": [
     {
       "type": "constructor",
@@ -143,16 +143,16 @@
     }
   ],
   "constructorArgs": [
-    "0xC7003566dD09Aa0fC0Ce201aC2769aFAe3BF0051",
-    "0xc7006f70875BaDe89032001262A846D3Ee160051"
+    "0x5a3368b30174d389aFd205a46bAd35BBE6709b8a",
+    "0x26E758238CB6eC5aB70ce0dd52aF2d7b82e1972E"
   ],
   "linkedLibraries": {},
-  "deployTxnHash": "0x0efd61480362fb377d6689fb29fe9fd88edf03c9e8a579ca7bb86f3b70051aa6",
+  "deployTxnHash": "0x03775318aa6f36b45fe4536924777e5da98fd41047e72d5e01cf00d4a793ac47",
   "deployTxnBlockNumber": "3",
-  "deployTimestamp": "1748610367",
+  "deployTimestamp": "1762263203",
   "sourceName": "src/dapp/SelfHostedApplicationFactory.sol",
   "contractName": "SelfHostedApplicationFactory",
   "deployedOn": "deploy.SelfHostedApplicationFactory",
-  "gasUsed": 350222,
-  "gasCost": "1183172451"
+  "gasUsed": 350138,
+  "gasCost": "1209427757"
 }

--- a/packages/rollups-wagmi/package.json
+++ b/packages/rollups-wagmi/package.json
@@ -21,7 +21,7 @@
         "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
         "codegen": "wagmi generate",
         "lint": "eslint",
-        "cannon:inspect": "cannon inspect cartesi-rollups:2.0.0 --write-deployments ./deployments",
+        "cannon:inspect": "cannon inspect cartesi-rollups:2.1.0 --write-deployments ./deployments",
         "dev": "tsup --watch"
     },
     "dependencies": {
@@ -32,7 +32,7 @@
     },
     "devDependencies": {
         "@cartesi/rollups": "^1.2.0",
-        "@cartesi/rollups-v2": "npm:@cartesi/rollups@2.0.0",
+        "@cartesi/rollups-v2": "npm:@cartesi/rollups@2.1.1",
         "@cartesi/tsconfig": "workspace:*",
         "@sunodo/wagmi-plugin-hardhat-deploy": "^0.4.0",
         "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,8 +569,8 @@ importers:
         specifier: ^1.2.0
         version: 1.4.0
       '@cartesi/rollups-v2':
-        specifier: npm:@cartesi/rollups@2.0.0
-        version: '@cartesi/rollups@2.0.0'
+        specifier: npm:@cartesi/rollups@2.1.1
+        version: '@cartesi/rollups@2.1.1'
       '@cartesi/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -1636,8 +1636,8 @@ packages:
   '@cartesi/rollups@1.4.0':
     resolution: {integrity: sha512-remwnm4Rgkhzoc3F2YQw4nXJk0ggvmwdgGQxF5Gps7Ej3zY2qLCUS7OscMX5P9RFjpWnJ7mtlEXydVaUR4XXrQ==}
 
-  '@cartesi/rollups@2.0.0':
-    resolution: {integrity: sha512-41Dtq73wD5JTepuryUiXumjMNx/e5AlOROKlao4/A0rG34R8emblnTGwvMaMpzKd+USDk2M/aLtIPZ6tnDXD/g==}
+  '@cartesi/rollups@2.1.1':
+    resolution: {integrity: sha512-1k+8gEp6VL6pGr0hlUTqK1hEIvBmRKUBodU3259e7rpR7ECaTLUV08C+P4efnXrz5Zj2SYWF8QZuFUVMxsMBVA==}
 
   '@cartesi/rpc@2.0.0-alpha.17':
     resolution: {integrity: sha512-hD+ROXq0YMBZwNp6FlR5gYpzU6Am7Ug3lhIyD7OrP6/SVzmJC5u6Q7PY5kSPf6xrGGoE9U0tVAWl0tQWWYMv5w==}
@@ -11449,7 +11449,7 @@ snapshots:
       '@cartesi/util': 6.3.0
       '@openzeppelin/contracts': 4.9.2
 
-  '@cartesi/rollups@2.0.0': {}
+  '@cartesi/rollups@2.1.1': {}
 
   '@cartesi/rpc@2.0.0-alpha.17':
     dependencies:


### PR DESCRIPTION
# Summary
Rollups-wagmi will continue to generate code to interact with rollups version v1.x and also for the new v2.1.0 (cannon). All operations will interact with latest v2 deployed contracts. 

PS: All interaction with v2.0.0 (previous cannon deployment) contracts were removed.