### PR TITLE
chore(web): Update new honeypot address that is used on e2e.

### DIFF
--- a/apps/web/e2e/utils/constants.ts
+++ b/apps/web/e2e/utils/constants.ts
@@ -1,4 +1,4 @@
 export const honeypotV2Sepolia = {
-    address: "0x280d0e06588ab888a3227b269bd578fae8537787",
+    address: "0xb72d7afbe7afd35c82d1d0b3d9c714944ff5b7d8",
     rollupsVersion: "v2",
 } as const;


### PR DESCRIPTION
# Summary
As we bump rollups contracts to latest version and replaced the previous v2.0.0 previous honeypot is not indexed and e2e would use it as a reference. So the changes just update to the new available Cartesi application v2. 