### PR TITLE
feat: ERC-20 deposit

### DIFF
--- a/apps/dave/src/app/layout.tsx
+++ b/apps/dave/src/app/layout.tsx
@@ -12,6 +12,24 @@ interface RootLayoutProps {
     children: ReactNode;
 }
 
+/**
+ * This is a workaround to solve a problem when react-dom-client.development
+ * is trying to stringify bigints.
+ *
+ * refer to issue {@link https://github.com/facebook/react/issues/35004}
+ * a PR is currently open here {@link https://github.com/facebook/react/pull/35013}
+ */
+if (process.env.NODE_ENV === "development") {
+    Object.defineProperty(BigInt.prototype, "toJSON", {
+        writable: false,
+        enumerable: true,
+        configurable: false,
+        value() {
+            return this.toString();
+        },
+    });
+}
+
 const RootLayout: FC<RootLayoutProps> = ({ children }) => {
     return (
         <html lang="en" {...mantineHtmlProps}>

--- a/apps/dave/src/components/send/SendMenu.tsx
+++ b/apps/dave/src/components/send/SendMenu.tsx
@@ -82,7 +82,6 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                     <Text fw="500">Ethereum</Text>
                 </Menu.Item>
                 <Menu.Item
-                    disabled
                     leftSection={<TbCurrencyEthereum size={24} />}
                     onClick={(evt) => {
                         evt.stopPropagation();

--- a/apps/dave/src/components/send/SendModal.tsx
+++ b/apps/dave/src/components/send/SendModal.tsx
@@ -7,6 +7,7 @@ import { type FC } from "react";
 import { useConfig } from "wagmi";
 import { BlockExplorerLink } from "../BlockExplorerLink";
 import type { TransactionFormSuccessData } from "../transactions/DepositFormTypes";
+import { ERC20DepositForm } from "../transactions/ERC20DepositForm";
 import { EtherDepositForm } from "../transactions/EtherDepositForm";
 import { useSendAction, useSendState } from "./hooks";
 import type { TransactionType } from "./SendContexts";
@@ -86,6 +87,11 @@ const SendModal: FC = () => {
         >
             {state.transactionType === "deposit_eth" ? (
                 <EtherDepositForm
+                    application={state.application}
+                    onSuccess={onSuccess}
+                />
+            ) : state.transactionType === "deposit_erc20" ? (
+                <ERC20DepositForm
                     application={state.application}
                     onSuccess={onSuccess}
                 />

--- a/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20Approve.tsx
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20Approve.tsx
@@ -1,0 +1,47 @@
+import { erc20Abi, type Hex } from "viem";
+import {
+    useSimulateContract,
+    type UseSimulateContractReturnType,
+    useWaitForTransactionReceipt,
+    useWriteContract,
+} from "wagmi";
+
+interface Props {
+    erc20Address: Hex;
+    args: [spender: Hex, amount: bigint];
+    isQueryEnabled: boolean;
+}
+
+interface UseERC20ApproveReturn {
+    approvePrepare: UseSimulateContractReturnType<typeof erc20Abi, "approve">;
+    approve: ReturnType<typeof useWriteContract>;
+    approveWait: ReturnType<typeof useWaitForTransactionReceipt>;
+}
+
+export const useERC20Approve = ({
+    args,
+    erc20Address,
+    isQueryEnabled,
+}: Props): UseERC20ApproveReturn => {
+    const approvePrepare = useSimulateContract({
+        abi: erc20Abi,
+        functionName: "approve",
+        address: erc20Address,
+        args,
+        query: {
+            enabled: isQueryEnabled,
+        },
+    });
+
+    // const approve = useWriteErc20Approve();
+    const approve = useWriteContract();
+    const approveWait = useWaitForTransactionReceipt({
+        hash: approve.data,
+    });
+
+    return {
+        approvePrepare,
+        approve,
+        approveWait,
+    };
+};

--- a/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20Approve.tsx
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20Approve.tsx
@@ -33,7 +33,6 @@ export const useERC20Approve = ({
         },
     });
 
-    // const approve = useWriteErc20Approve();
     const approve = useWriteContract();
     const approveWait = useWaitForTransactionReceipt({
         hash: approve.data,

--- a/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20PortalDeposit.tsx
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20PortalDeposit.tsx
@@ -1,0 +1,48 @@
+import {
+    useSimulateErc20PortalDepositErc20Tokens,
+    useWriteErc20PortalDepositErc20Tokens,
+} from "@cartesi/wagmi";
+import { type Hex } from "viem";
+import { useWaitForTransactionReceipt } from "wagmi";
+
+interface Props {
+    contractParams: {
+        args: [
+            erc20Address: Hex,
+            appAddress: Hex,
+            amount: bigint,
+            execLayerData: Hex,
+        ];
+    };
+    isQueryEnabled: boolean;
+}
+
+/**
+ * Generate wagmi calls based on the parameters passed down.
+ * simulate contract call will not run until the query-enabled params is true.
+ * @parameters {Props}
+ * @returns
+ */
+export const useERC20PortalDeposit = ({
+    contractParams,
+    isQueryEnabled,
+}: Props) => {
+    const prepare = useSimulateErc20PortalDepositErc20Tokens({
+        args: contractParams.args,
+        query: {
+            enabled: isQueryEnabled,
+        },
+    });
+
+    const execute = useWriteErc20PortalDepositErc20Tokens();
+
+    const wait = useWaitForTransactionReceipt({
+        hash: execute.data,
+    });
+
+    return {
+        prepare,
+        execute,
+        wait,
+    };
+};

--- a/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20Reads.tsx
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20Reads.tsx
@@ -1,0 +1,82 @@
+import { isNotNilOrEmpty } from "ramda-adjunct";
+import { type Hex, erc20Abi, getAddress } from "viem";
+import { BaseError, useReadContracts } from "wagmi";
+import useWatchQueryOnBlockChange from "../../hooks/useWatchQueryOnBlockChange";
+
+interface Props {
+    erc20Address: Hex;
+    spenderAddress: Hex;
+    ownerAddress: Hex;
+}
+
+/**
+ * The read will only go into the wire when all required
+ * addresses are not nil.
+ * It will fetch information about the target ERC-20 contract address
+ * in conjuction with the owner and spender. So the information returned are
+ * balance, decimals, symbol and current allowance.
+ *
+ * @param props {Props}
+ * @returns
+ */
+export const useERC20Reads = ({
+    erc20Address,
+    spenderAddress,
+    ownerAddress,
+}: Props) => {
+    const erc20Contract = {
+        abi: erc20Abi,
+        address: erc20Address,
+    };
+
+    const erc20 = useReadContracts({
+        query: {
+            enabled:
+                isNotNilOrEmpty(erc20Address) &&
+                isNotNilOrEmpty(spenderAddress) &&
+                isNotNilOrEmpty(ownerAddress),
+        },
+        contracts: [
+            { ...erc20Contract, functionName: "decimals" },
+            { ...erc20Contract, functionName: "symbol" },
+            {
+                ...erc20Contract,
+                functionName: "allowance",
+                args: [getAddress(ownerAddress!), spenderAddress],
+            },
+            {
+                ...erc20Contract,
+                functionName: "balanceOf",
+                args: [ownerAddress!],
+            },
+        ],
+    });
+
+    useWatchQueryOnBlockChange(erc20.queryKey);
+
+    const { isFetching, isLoading, isSuccess } = erc20;
+    const decimals = erc20.data?.[0].result as number | undefined;
+    const symbol = erc20.data?.[1].result as string | undefined;
+    const allowance = erc20.data?.[2].result as bigint | undefined;
+    const balance = erc20.data?.[3].result as bigint | undefined;
+    const errors = erc20.data
+        ? erc20.data
+              .filter((d) => d.error instanceof Error)
+              .map((d) => {
+                  return (d.error as BaseError).shortMessage;
+              })
+        : [];
+
+    return {
+        symbol,
+        allowance,
+        balance,
+        decimals,
+        errors,
+        isFetching,
+        isLoading,
+        isSuccess,
+    };
+};
+
+export type UseERC20ReadsReturn = ReturnType<typeof useERC20Reads>;

--- a/apps/dave/src/components/transactions/ERC20DepositForm/index.tsx
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/index.tsx
@@ -1,0 +1,328 @@
+import type { Application } from "@cartesi/viem";
+import {
+    Autocomplete,
+    Button,
+    Collapse,
+    Flex,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    TextInput,
+    Textarea,
+    UnstyledButton,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useDisclosure } from "@mantine/hooks";
+import { isEmpty } from "ramda";
+import { isNotNil, isNotNilOrEmpty } from "ramda-adjunct";
+import { type FC, useEffect } from "react";
+import {
+    TbCheck,
+    TbChevronDown,
+    TbChevronUp,
+    TbPigMoney,
+} from "react-icons/tb";
+import {
+    type Hex,
+    formatUnits,
+    getAddress,
+    isAddress,
+    isHex,
+    parseUnits,
+    zeroAddress,
+} from "viem";
+import { useAccount } from "wagmi";
+import { type TransactionFormSuccessData } from "../DepositFormTypes";
+
+import { erc20PortalAddress } from "@cartesi/wagmi";
+import { TransactionProgress } from "../TransactionProgress";
+import { transactionState } from "../TransactionState";
+import { useERC20Approve } from "./hooks/useERC20Approve";
+import { useERC20PortalDeposit } from "./hooks/useERC20PortalDeposit";
+import { useERC20Reads } from "./hooks/useERC20Reads";
+import type { FormValues, TransformValues } from "./types";
+import { isApprovalNeeded, isReadyToDeposit } from "./utils";
+
+export interface ERC20DepositFormProps {
+    application: Application;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
+}
+
+export const ERC20DepositForm: FC<ERC20DepositFormProps> = (props) => {
+    const { application, onSuccess } = props;
+
+    const [advanced, { toggle: toggleAdvanced }] = useDisclosure(false);
+
+    // connected account
+    const { address } = useAccount();
+
+    const form = useForm<FormValues, TransformValues>({
+        validateInputOnChange: true,
+        initialValues: {
+            application: application.applicationAddress,
+            erc20Address: "",
+            amount: "",
+            execLayerData: "0x",
+        },
+        validate: {
+            application: (value) => {
+                if (isEmpty(value)) return `Application address is required!`;
+                if (!isAddress(value)) {
+                    return `Invalid Application address`;
+                }
+                return null;
+            },
+            erc20Address: (value) => {
+                if (isEmpty(value)) return `ERC20 address is required!`;
+                if (!isAddress(value)) {
+                    return `Invalid ERC20 address`;
+                }
+                return null;
+            },
+            amount: (value) =>
+                value !== "" && Number(value) > 0 ? null : "Invalid amount",
+            execLayerData: (value) =>
+                isHex(value) ? null : "Invalid hex string",
+        },
+        transformValues: (values) => ({
+            address: isAddress(values.application)
+                ? getAddress(values.application)
+                : zeroAddress,
+            erc20Address: isAddress(values.erc20Address)
+                ? getAddress(values.erc20Address)
+                : zeroAddress,
+            erc20ContractAddress: isAddress(values.erc20Address)
+                ? getAddress(values.erc20Address)
+                : undefined,
+            amountBigInt:
+                values.amount !== "" && isNotNil(values.decimals)
+                    ? parseUnits(values.amount, values.decimals)
+                    : undefined,
+            execLayerData: values.execLayerData
+                ? (values.execLayerData as Hex)
+                : "0x",
+        }),
+    });
+
+    const {
+        address: applicationAddress,
+        erc20Address,
+        erc20ContractAddress,
+        execLayerData,
+        amountBigInt,
+    } = form.getTransformedValues();
+
+    // query token information in a multicall
+    const erc20 = useERC20Reads({
+        erc20Address: erc20ContractAddress!,
+        spenderAddress: erc20PortalAddress!,
+        ownerAddress: address!,
+    });
+
+    const { allowance, balance, errors: erc20Errors, symbol, decimals } = erc20;
+    // prepare approve transaction
+    const { approve, approvePrepare, approveWait } = useERC20Approve({
+        args: [erc20PortalAddress!, amountBigInt!],
+        erc20Address,
+        isQueryEnabled:
+            isNotNilOrEmpty(erc20PortalAddress) &&
+            amountBigInt !== undefined &&
+            allowance !== undefined &&
+            amountBigInt > 0 &&
+            amountBigInt > allowance,
+    });
+
+    // prepare deposit transaction
+    const {
+        prepare: depositPrepare,
+        execute: deposit,
+        wait: depositWait,
+    } = useERC20PortalDeposit({
+        contractParams: {
+            args: [
+                erc20Address,
+                applicationAddress,
+                amountBigInt!,
+                execLayerData,
+            ],
+        },
+        isQueryEnabled:
+            form.isValid() &&
+            amountBigInt !== undefined &&
+            balance !== undefined &&
+            allowance !== undefined &&
+            amountBigInt <= balance &&
+            amountBigInt <= allowance,
+    });
+
+    // true if current allowance is less than the amount to deposit
+    const needApproval = isApprovalNeeded({
+        erc20Reads: erc20,
+        amount: amountBigInt,
+    });
+    const canDeposit = isReadyToDeposit({
+        erc20Reads: erc20,
+        amount: amountBigInt,
+    });
+
+    const { disabled: approveDisabled, loading: approveLoading } =
+        transactionState(approvePrepare, approve, approveWait, false);
+    const { disabled: depositDisabled, loading: depositLoading } =
+        transactionState(depositPrepare, deposit, depositWait, true);
+
+    useEffect(() => {
+        if (depositWait.isSuccess) {
+            onSuccess({ receipt: depositWait.data, type: "ERC-20" });
+            form.reset();
+            approve.reset();
+            deposit.reset();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [depositWait, onSuccess]);
+
+    return (
+        <form data-testid="erc20-deposit-form">
+            <Stack>
+                <Autocomplete
+                    label="ERC-20"
+                    description="The ERC-20 smart contract address"
+                    placeholder="0x"
+                    data={[]}
+                    withAsterisk
+                    data-testid="erc20address-input"
+                    rightSection={erc20.isLoading && <Loader size="xs" />}
+                    {...form.getInputProps("erc20Address")}
+                    error={erc20Errors[0] || form.errors.erc20Address}
+                    onChange={(nextValue) => {
+                        const formattedValue = nextValue.substring(
+                            nextValue.indexOf("0x"),
+                        );
+                        form.setFieldValue("erc20Address", formattedValue);
+                    }}
+                />
+
+                <Collapse in={erc20.isSuccess && erc20Errors.length == 0}>
+                    <Stack>
+                        <TextInput
+                            type="number"
+                            min={0}
+                            step={1}
+                            label="Amount"
+                            description="Amount of tokens to deposit"
+                            placeholder="0"
+                            rightSectionWidth={60}
+                            rightSection={<Text>{symbol}</Text>}
+                            withAsterisk
+                            data-testid="amount-input"
+                            {...form.getInputProps("amount")}
+                        />
+                        <Flex
+                            mt="-sm"
+                            justify={"space-between"}
+                            direction={"row"}
+                        >
+                            <Flex rowGap={6} c={"dark.2"}>
+                                <Text fz="xs">Balance:</Text>
+                                <Text id="token-balance" fz="xs" mx={4}>
+                                    {" "}
+                                    {balance !== undefined && decimals
+                                        ? formatUnits(balance, decimals)
+                                        : ""}
+                                </Text>
+                                {balance !== undefined &&
+                                    balance > 0 &&
+                                    decimals && (
+                                        <UnstyledButton
+                                            fz={"xs"}
+                                            c={"cyan"}
+                                            onClick={() => {
+                                                form.setFieldValue(
+                                                    "amount",
+                                                    formatUnits(
+                                                        balance,
+                                                        decimals,
+                                                    ),
+                                                );
+                                            }}
+                                            data-testid="max-button"
+                                        >
+                                            Max
+                                        </UnstyledButton>
+                                    )}
+                            </Flex>
+                            <Flex rowGap={6} c={"dark.2"}>
+                                <Text size="xs">Allowance:</Text>
+                                <Text ml={4} fz="xs">
+                                    {allowance != undefined && decimals
+                                        ? formatUnits(allowance, decimals)
+                                        : ""}
+                                </Text>
+                            </Flex>
+                        </Flex>
+                    </Stack>
+                </Collapse>
+                <Collapse in={advanced}>
+                    <Textarea
+                        label="Extra data"
+                        data-testid="extra-data-input"
+                        description="Extra execution layer data handled by the application"
+                        {...form.getInputProps("execLayerData")}
+                    />
+                </Collapse>
+                <Collapse in={approve.isPending || approveWait.isLoading}>
+                    <TransactionProgress
+                        prepare={approvePrepare}
+                        execute={approve}
+                        wait={approveWait}
+                        confirmationMessage="Approve transaction confirmed"
+                    />
+                </Collapse>
+                <Collapse in={!deposit.isIdle}>
+                    <TransactionProgress
+                        prepare={depositPrepare}
+                        execute={deposit}
+                        wait={depositWait}
+                    />
+                </Collapse>
+                <Group justify="right">
+                    <Button
+                        leftSection={
+                            advanced ? <TbChevronUp /> : <TbChevronDown />
+                        }
+                        size="xs"
+                        visibleFrom="sm"
+                        variant="transparent"
+                        onClick={toggleAdvanced}
+                    >
+                        Advanced
+                    </Button>
+                    <Button
+                        variant="filled"
+                        disabled={approveDisabled || !needApproval}
+                        leftSection={<TbCheck />}
+                        loading={approveLoading}
+                        onClick={() =>
+                            approve.writeContract(approvePrepare.data!.request)
+                        }
+                    >
+                        Approve
+                    </Button>
+                    <Button
+                        variant="filled"
+                        disabled={
+                            depositDisabled || !canDeposit || !form.isValid()
+                        }
+                        leftSection={<TbPigMoney />}
+                        loading={depositLoading}
+                        onClick={() =>
+                            deposit.writeContract(depositPrepare.data!.request)
+                        }
+                    >
+                        Deposit
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};

--- a/apps/dave/src/components/transactions/ERC20DepositForm/index.tsx
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/index.tsx
@@ -16,7 +16,7 @@ import { useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
 import { isEmpty } from "ramda";
 import { isNotNil, isNotNilOrEmpty } from "ramda-adjunct";
-import { type FC, useEffect } from "react";
+import { type FC, useEffect, useMemo } from "react";
 import {
     TbCheck,
     TbChevronDown,
@@ -36,6 +36,7 @@ import { useAccount } from "wagmi";
 import { type TransactionFormSuccessData } from "../DepositFormTypes";
 
 import { erc20PortalAddress } from "@cartesi/wagmi";
+import TransactionDetails from "../TransactionDetails";
 import { TransactionProgress } from "../TransactionProgress";
 import { transactionState } from "../TransactionState";
 import { useERC20Approve } from "./hooks/useERC20Approve";
@@ -170,6 +171,24 @@ export const ERC20DepositForm: FC<ERC20DepositFormProps> = (props) => {
         transactionState(approvePrepare, approve, approveWait, false);
     const { disabled: depositDisabled, loading: depositLoading } =
         transactionState(depositPrepare, deposit, depositWait, true);
+    const transactionDetails = useMemo(
+        () => [
+            {
+                legend: "Application Address",
+                text: application.applicationAddress,
+            },
+            { legend: "Portal Address", text: erc20PortalAddress },
+        ],
+        [application.applicationAddress],
+    );
+
+    useEffect(() => {
+        const { decimals: formDecimal } = form.getValues();
+        if (decimals !== formDecimal) {
+            form.setFieldValue("decimals", decimals);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [decimals]);
 
     useEffect(() => {
         if (depositWait.isSuccess) {
@@ -184,6 +203,7 @@ export const ERC20DepositForm: FC<ERC20DepositFormProps> = (props) => {
     return (
         <form data-testid="erc20-deposit-form">
             <Stack>
+                <TransactionDetails details={transactionDetails} />
                 <Autocomplete
                     label="ERC-20"
                     description="The ERC-20 smart contract address"

--- a/apps/dave/src/components/transactions/ERC20DepositForm/types.ts
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/types.ts
@@ -1,0 +1,19 @@
+import { type Hex } from "viem";
+
+export interface FormValues {
+    application: string;
+    amount: string;
+    execLayerData: string;
+    erc20Address: string;
+    decimals?: number;
+}
+
+export interface TransformedValues {
+    address: Hex;
+    execLayerData: Hex;
+    erc20Address: Hex;
+    erc20ContractAddress: Hex | undefined;
+    amountBigInt: bigint | undefined;
+}
+
+export type TransformValues = (v: FormValues) => TransformedValues;

--- a/apps/dave/src/components/transactions/ERC20DepositForm/utils.ts
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/utils.ts
@@ -1,0 +1,28 @@
+import { type UseERC20ReadsReturn } from "./hooks/useERC20Reads";
+
+type ERC20ChecksProps = {
+    erc20Reads: UseERC20ReadsReturn;
+    amount: bigint | undefined;
+};
+
+export const isApprovalNeeded = ({ erc20Reads, amount }: ERC20ChecksProps) => {
+    return (
+        erc20Reads.allowance !== undefined &&
+        erc20Reads.decimals !== undefined &&
+        amount !== undefined &&
+        amount > 0 &&
+        erc20Reads.allowance < amount
+    );
+};
+
+export const isReadyToDeposit = ({ erc20Reads, amount }: ERC20ChecksProps) => {
+    return (
+        erc20Reads.allowance !== undefined &&
+        erc20Reads.balance !== undefined &&
+        erc20Reads.decimals !== undefined &&
+        amount !== undefined &&
+        amount > 0 &&
+        amount <= erc20Reads.allowance &&
+        amount <= erc20Reads.balance
+    );
+};

--- a/apps/dave/src/components/transactions/EtherDepositForm/index.tsx
+++ b/apps/dave/src/components/transactions/EtherDepositForm/index.tsx
@@ -1,19 +1,9 @@
 "use client";
 import { type Application } from "@cartesi/viem";
 import { etherPortalAddress } from "@cartesi/wagmi";
-import {
-    Badge,
-    Collapse,
-    Fieldset,
-    Stack,
-    Switch,
-    Text,
-    VisuallyHidden,
-} from "@mantine/core";
+import { Stack } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { useDisclosure } from "@mantine/hooks";
-import { type FC, useEffect } from "react";
-import { TbEye, TbEyeClosed } from "react-icons/tb";
+import { type FC, useEffect, useMemo } from "react";
 import {
     type Hex,
     getAddress,
@@ -25,6 +15,7 @@ import {
 import { useAccount } from "wagmi";
 import { type TransactionFormSuccessData } from "../DepositFormTypes";
 import { useAccountBalance } from "../hooks/useAccountBalance";
+import TransactionDetails from "../TransactionDetails";
 import EtherDepositSection from "./EtherDepositSection";
 import { type FormValues, type TransformValues } from "./types";
 
@@ -36,7 +27,6 @@ interface EthDepositFormProps {
 export const EtherDepositForm: FC<EthDepositFormProps> = (props) => {
     const { application, onSuccess } = props;
     const { chain } = useAccount();
-    const [showDetails, handlers] = useDisclosure(false);
     const accountBalance = useAccountBalance();
 
     const form = useForm<FormValues, TransformValues>({
@@ -88,6 +78,17 @@ export const EtherDepositForm: FC<EthDepositFormProps> = (props) => {
         }),
     });
 
+    const details = useMemo(
+        () => [
+            {
+                legend: "Application Address",
+                text: application.applicationAddress,
+            },
+            { legend: "Portal Address", text: etherPortalAddress },
+        ],
+        [application.applicationAddress],
+    );
+
     const onDepositSuccess = (data: TransactionFormSuccessData) => {
         onSuccess(data);
         form.reset();
@@ -107,38 +108,7 @@ export const EtherDepositForm: FC<EthDepositFormProps> = (props) => {
     return (
         <form data-testid="ether-deposit-form">
             <Stack>
-                <Switch
-                    size="md"
-                    label="Tx details"
-                    labelPosition="left"
-                    checked={showDetails}
-                    onChange={handlers.toggle}
-                    onLabel={
-                        <>
-                            <VisuallyHidden>Tx Details Visible</VisuallyHidden>
-                            <TbEye size="1rem" />
-                        </>
-                    }
-                    offLabel={
-                        <>
-                            <VisuallyHidden>Tx Details Hidden</VisuallyHidden>
-
-                            <TbEyeClosed size="1rem" />
-                        </>
-                    }
-                />
-                <Collapse in={showDetails}>
-                    <Stack gap="xs" style={{ overflowWrap: "break-word" }}>
-                        <Fieldset legend={<Badge>Application Address</Badge>}>
-                            <Text c="dimmed">
-                                {application.applicationAddress}
-                            </Text>
-                        </Fieldset>
-                        <Fieldset legend={<Badge>Portal Address</Badge>}>
-                            <Text c="dimmed">{etherPortalAddress}</Text>
-                        </Fieldset>
-                    </Stack>
-                </Collapse>
+                <TransactionDetails details={details} />
                 <EtherDepositSection form={form} onSuccess={onDepositSuccess} />
             </Stack>
         </form>

--- a/apps/dave/src/components/transactions/TransactionDetails.tsx
+++ b/apps/dave/src/components/transactions/TransactionDetails.tsx
@@ -1,0 +1,65 @@
+import {
+    Badge,
+    Collapse,
+    Fieldset,
+    Stack,
+    Switch,
+    Text,
+    VisuallyHidden,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { isValidElement, type FC, type ReactNode } from "react";
+import { TbEye, TbEyeClosed } from "react-icons/tb";
+
+type Detail = { text: ReactNode; legend: string };
+
+type TransactionDetailsProps = {
+    details: Detail[];
+};
+
+const TransactionDetails: FC<TransactionDetailsProps> = ({ details }) => {
+    const [showDetails, handlers] = useDisclosure(false);
+    return (
+        <>
+            <Switch
+                size="md"
+                label="Tx details"
+                labelPosition="left"
+                checked={showDetails}
+                onChange={handlers.toggle}
+                onLabel={
+                    <>
+                        <VisuallyHidden>Tx Details Visible</VisuallyHidden>
+                        <TbEye size="1rem" />
+                    </>
+                }
+                offLabel={
+                    <>
+                        <VisuallyHidden>Tx Details Hidden</VisuallyHidden>
+
+                        <TbEyeClosed size="1rem" />
+                    </>
+                }
+            />
+            <Collapse in={showDetails} keepMounted>
+                <Stack gap="xs" style={{ overflowWrap: "break-word" }}>
+                    {details.map((detail, i) => (
+                        <Fieldset
+                            key={i}
+                            legend={<Badge>{detail.legend}</Badge>}
+                            p={{ base: "xs", sm: "md" }}
+                        >
+                            {isValidElement(detail.text) ? (
+                                detail.text
+                            ) : (
+                                <Text c="dimmed">{detail.text}</Text>
+                            )}
+                        </Fieldset>
+                    ))}
+                </Stack>
+            </Collapse>
+        </>
+    );
+};
+
+export default TransactionDetails;

--- a/apps/dave/src/components/transactions/TransactionState.ts
+++ b/apps/dave/src/components/transactions/TransactionState.ts
@@ -1,0 +1,22 @@
+import type {
+    TransactionStageStatus,
+    TransactionWaitStatus,
+} from "./TransactionStatus";
+
+export const transactionState = (
+    prepare: TransactionWaitStatus,
+    execute: TransactionStageStatus,
+    wait: TransactionWaitStatus,
+    disableOnSuccess: boolean = true,
+) => {
+    const loading =
+        prepare.fetchStatus === "fetching" ||
+        execute.status === "pending" ||
+        wait.fetchStatus === "fetching";
+
+    const disabled =
+        prepare.error !== null ||
+        (disableOnSuccess && wait.status === "success");
+
+    return { loading, disabled };
+};


### PR DESCRIPTION
# Summary
Code changes to add support for ERC-20 deposits. A big chunk of code was ported from the current rollups-explorer, with refactorings to target the data structures returned by the rollups-node API and to use cartesi/viem and cartesi/wagmi.

A test can be performed using the latest Cartesi CLI, ensuring the mock is disabled (default). Also, a devnet deploy of a simple ERC-20 token is necessary.