### PR TITLE
feat: ERC-1155 deposit (single / batch)

### DIFF
--- a/apps/dave/package.json
+++ b/apps/dave/package.json
@@ -10,6 +10,8 @@
         "start": "next start",
         "lint": "eslint .",
         "storybook": "storybook dev -p 6006",
+        "codegen": "run-s gen:wagmi",
+        "gen:wagmi": "wagmi generate",
         "build-storybook": "storybook build",
         "format:check": "prettier \"**/*.{ts,tsx}\" --check",
         "format": "prettier --write \"**/*.{ts,tsx,md}\""
@@ -50,6 +52,7 @@
         "@types/ramda": "^0.31.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "@wagmi/cli": "^2.1.2",
         "eslint": "catalog:",
         "eslint-config-cartesi": "workspace:*",
         "eslint-plugin-react-refresh": "^0.4.21",

--- a/apps/dave/src/app/layout.tsx
+++ b/apps/dave/src/app/layout.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { ColorSchemeScript, mantineHtmlProps } from "@mantine/core";
 import "@mantine/core/styles.css";
 import "@mantine/notifications/styles.css";
@@ -10,24 +9,6 @@ import { Providers } from "../providers/Providers";
 
 interface RootLayoutProps {
     children: ReactNode;
-}
-
-/**
- * This is a workaround to solve a problem when react-dom-client.development
- * is trying to stringify bigints.
- *
- * refer to issue {@link https://github.com/facebook/react/issues/35004}
- * a PR is currently open here {@link https://github.com/facebook/react/pull/35013}
- */
-if (process.env.NODE_ENV === "development") {
-    Object.defineProperty(BigInt.prototype, "toJSON", {
-        writable: false,
-        enumerable: true,
-        configurable: false,
-        value() {
-            return this.toString();
-        },
-    });
 }
 
 const RootLayout: FC<RootLayoutProps> = ({ children }) => {

--- a/apps/dave/src/components/send/SendMenu.tsx
+++ b/apps/dave/src/components/send/SendMenu.tsx
@@ -103,7 +103,6 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                     <Text fw="500">ERC-721</Text>
                 </Menu.Item>
                 <Menu.Item
-                    disabled
                     leftSection={<TbCurrencyEthereum size={24} />}
                     onClick={(evt) => {
                         evt.stopPropagation();
@@ -114,7 +113,6 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                     <Text fw="500">ERC-1155 (Single)</Text>
                 </Menu.Item>
                 <Menu.Item
-                    disabled
                     leftSection={<TbCurrencyEthereum size={24} />}
                     onClick={(evt) => {
                         evt.stopPropagation();

--- a/apps/dave/src/components/send/SendModal.tsx
+++ b/apps/dave/src/components/send/SendModal.tsx
@@ -7,6 +7,7 @@ import { type FC } from "react";
 import { useConfig } from "wagmi";
 import { BlockExplorerLink } from "../BlockExplorerLink";
 import type { TransactionFormSuccessData } from "../transactions/DepositFormTypes";
+import { ERC1155DepositForm } from "../transactions/ERC1155DepositForm";
 import { ERC20DepositForm } from "../transactions/ERC20DepositForm";
 import { EtherDepositForm } from "../transactions/EtherDepositForm";
 import { useSendAction, useSendState } from "./hooks";
@@ -92,6 +93,18 @@ const SendModal: FC = () => {
                 />
             ) : state.transactionType === "deposit_erc20" ? (
                 <ERC20DepositForm
+                    application={state.application}
+                    onSuccess={onSuccess}
+                />
+            ) : state.transactionType === "deposit_erc1155Single" ? (
+                <ERC1155DepositForm
+                    mode="single"
+                    application={state.application}
+                    onSuccess={onSuccess}
+                />
+            ) : state.transactionType === "deposit_erc1155Batch" ? (
+                <ERC1155DepositForm
+                    mode="batch"
                     application={state.application}
                     onSuccess={onSuccess}
                 />

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/AdvancedFields.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/AdvancedFields.tsx
@@ -1,0 +1,31 @@
+import { Collapse, Textarea } from "@mantine/core";
+import { type FC } from "react";
+import { useFormContext } from "./context";
+
+interface Props {
+    display: boolean;
+}
+
+const AdvancedFields: FC<Props> = ({ display }) => {
+    const form = useFormContext();
+
+    return (
+        <Collapse in={display}>
+            <Textarea
+                data-testid="base-layer-data-input"
+                label="Base layer data"
+                description="Additional data to be interpreted by the base layer"
+                {...form.getInputProps("baseLayerData")}
+            />
+
+            <Textarea
+                data-testid="execution-layer-data-input"
+                label="Execution layer data"
+                description="Additional data to be interpreted by the execution layer"
+                {...form.getInputProps("execLayerData")}
+            />
+        </Collapse>
+    );
+};
+
+export default AdvancedFields;

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/DepositBatchReview.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/DepositBatchReview.tsx
@@ -1,0 +1,96 @@
+import {
+    Accordion,
+    Button,
+    Collapse,
+    Indicator,
+    Table,
+    Title,
+    rem,
+} from "@mantine/core";
+import { pathOr, reject } from "ramda";
+import { TbTrash } from "react-icons/tb";
+import { type DepositData, useFormContext } from "./context";
+
+const DepositBatchReview = () => {
+    const form = useFormContext();
+    const deposits: DepositData[] = pathOr([], ["values", "batch"], form);
+
+    const rows = deposits.map((deposit, idx) => (
+        <Table.Tr
+            key={deposit.id}
+            data-testid={`${idx}-${deposit.tokenId}-${deposit.amount}`}
+        >
+            <Table.Td>{deposit.tokenId.toString()}</Table.Td>
+            <Table.Td>{deposit.name ?? "Not defined"}</Table.Td>
+            <Table.Td>{deposit.amount.toString()}</Table.Td>
+            <Table.Td>
+                <Button
+                    size="compact-sm"
+                    color="red"
+                    onClick={() => {
+                        const newVal = reject(
+                            (i: DepositData) => i.id === deposit.id,
+                            deposits,
+                        );
+                        form.setFieldValue("batch", newVal);
+                    }}
+                >
+                    <TbTrash />
+                </Button>
+            </Table.Td>
+        </Table.Tr>
+    ));
+
+    return (
+        <Collapse in={deposits.length > 0}>
+            <Accordion variant="contained" chevronPosition="right" py="sm">
+                <Indicator label={deposits.length} size={rem(21)}>
+                    <Accordion.Item
+                        value="deposits-review"
+                        key="deposits-review"
+                    >
+                        <Accordion.Control>
+                            <Title order={4}>Deposits for review</Title>
+                        </Accordion.Control>
+
+                        <Accordion.Panel>
+                            <Table
+                                horizontalSpacing="xl"
+                                highlightOnHover
+                                data-testid="batch-review-table"
+                            >
+                                <Table.Thead>
+                                    <Table.Tr>
+                                        <Table.Th
+                                            style={{ whiteSpace: "nowrap" }}
+                                        >
+                                            Id
+                                        </Table.Th>
+                                        <Table.Th
+                                            style={{ whiteSpace: "nowrap" }}
+                                        >
+                                            Name
+                                        </Table.Th>
+                                        <Table.Th
+                                            style={{ whiteSpace: "nowrap" }}
+                                        >
+                                            Amount
+                                        </Table.Th>
+                                        <Table.Th
+                                            style={{ whiteSpace: "nowrap" }}
+                                        >
+                                            Action
+                                        </Table.Th>
+                                    </Table.Tr>
+                                </Table.Thead>
+                                <Table.Tbody>{rows}</Table.Tbody>
+                            </Table>
+                        </Accordion.Panel>
+                    </Accordion.Item>
+                </Indicator>
+            </Accordion>
+        </Collapse>
+    );
+};
+
+export default DepositBatchReview;

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/DepositFormBatch.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/DepositFormBatch.tsx
@@ -1,0 +1,374 @@
+import { erc1155BatchPortalAddress } from "@cartesi/wagmi";
+import {
+    Autocomplete,
+    Button,
+    Collapse,
+    Group,
+    Loader,
+    Stack,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { isEmpty, isNotNil, pipe, reduce, transpose } from "ramda";
+import { isNotNilOrEmpty } from "ramda-adjunct";
+import { type FC, useEffect, useMemo } from "react";
+import {
+    TbCheck,
+    TbChevronDown,
+    TbChevronUp,
+    TbPigMoney,
+} from "react-icons/tb";
+import {
+    BaseError,
+    type Hex,
+    getAddress,
+    isAddress,
+    isHex,
+    parseUnits,
+    zeroAddress,
+} from "viem";
+import { useAccount } from "wagmi";
+import {
+    erc1155Abi,
+    useReadErc1155BalanceOf,
+    useReadErc1155IsApprovedForAll,
+    useReadErc1155SupportsInterface,
+} from "../../../generated/wagmi";
+import { interfaceIdForERC1155 } from "../ERC165Identifiers";
+import TransactionDetails from "../TransactionDetails";
+import { TransactionProgress } from "../TransactionProgress";
+import { transactionState } from "../TransactionState";
+import useWatchQueryOnBlockChange from "../hooks/useWatchQueryOnBlockChange";
+import AdvancedFields from "./AdvancedFields";
+import DepositBatchReview from "./DepositBatchReview";
+import TokenFields from "./TokenFields";
+import {
+    type BatchTuple,
+    type DepositData,
+    type DepositDataTuple,
+    FormProvider,
+    useForm,
+} from "./context";
+import { useERC1155ApproveForAll } from "./hooks/useERC1155ApproveForAll";
+import { useERC1155BatchPortalDeposit } from "./hooks/useERC1155BatchPortalDeposit";
+import { type ERC1155DepositFormProps } from "./types";
+import {
+    amountValidation,
+    applicationValidation,
+    batchValidation,
+    erc1155AddressValidation,
+    hexValidation,
+    isValidContractInterface,
+    tokenIdValidation,
+} from "./validations";
+
+type Props = Omit<ERC1155DepositFormProps, "mode">;
+
+const reducer = reduce<DepositData, DepositDataTuple[]>(
+    (acc, curr) => [...acc, [curr.tokenId, curr.amount]],
+    [] as DepositDataTuple[],
+);
+
+const splitBatchInOrder = pipe(reducer, (l) => transpose(l) as BatchTuple);
+
+const DepositFormBatch: FC<Props> = (props) => {
+    const { application, onSuccess } = props;
+
+    const [advanced, { toggle: toggleAdvanced }] = useDisclosure(false);
+    // connected account
+    const { address } = useAccount();
+
+    const form = useForm({
+        validateInputOnChange: true,
+        initialValues: {
+            mode: "batch",
+            application: application.applicationAddress,
+            erc1155Address: "",
+            tokenId: "",
+            amount: "",
+            execLayerData: "0x",
+            baseLayerData: "0x",
+            decimals: 0,
+            balance: 0n,
+            batch: undefined,
+        },
+        validate: {
+            application: applicationValidation,
+            erc1155Address: erc1155AddressValidation,
+            tokenId: tokenIdValidation,
+            amount: amountValidation,
+            execLayerData: hexValidation,
+            baseLayerData: hexValidation,
+            batch: batchValidation,
+        },
+        transformValues: (values) => ({
+            applicationAddress: isAddress(values.application)
+                ? getAddress(values.application)
+                : zeroAddress,
+            erc1155Address: isAddress(values.erc1155Address)
+                ? getAddress(values.erc1155Address)
+                : zeroAddress,
+            tokenId:
+                values.tokenId !== "" &&
+                Number.isInteger(Number(values.tokenId))
+                    ? BigInt(Number(values.tokenId))
+                    : undefined,
+            amount:
+                values.amount !== ""
+                    ? parseUnits(values.amount.toString(), values.decimals)
+                    : undefined,
+            batchAsLists:
+                values.batch && !isEmpty(values.batch)
+                    ? splitBatchInOrder(values.batch)
+                    : undefined,
+            execLayerData: values.execLayerData as Hex,
+            baseLayerData: values.baseLayerData as Hex,
+        }),
+    });
+
+    const {
+        applicationAddress,
+        erc1155Address,
+        amount,
+        tokenId,
+        baseLayerData,
+        execLayerData,
+        batchAsLists,
+    } = form.getTransformedValues();
+
+    const erc1155Contract = {
+        abi: erc1155Abi,
+        address: erc1155Address !== zeroAddress ? erc1155Address : undefined,
+    } as const;
+
+    const balanceOf = useReadErc1155BalanceOf({
+        address: erc1155Contract.address,
+        args: [getAddress(address!), tokenId!],
+        query: {
+            enabled: tokenId !== undefined,
+        },
+    });
+
+    const supportsInterface = useReadErc1155SupportsInterface({
+        address: erc1155Contract.address,
+        args: [interfaceIdForERC1155],
+        query: {
+            enabled: erc1155Contract.address !== undefined,
+        },
+    });
+
+    const { isLoading: isCheckingContractInterface } = supportsInterface;
+    const isValidContractResult = isValidContractInterface(supportsInterface);
+
+    const approvedForAll = useReadErc1155IsApprovedForAll({
+        address: erc1155Contract.address,
+        args: [getAddress(address!), erc1155BatchPortalAddress],
+        query: {
+            enabled:
+                isValidContractResult.isValid && !isCheckingContractInterface,
+        },
+    });
+
+    useWatchQueryOnBlockChange(approvedForAll.queryKey);
+
+    const { data: accountBalance, isLoading: isCheckingBalance } = balanceOf;
+    const { data: isApproved, isLoading: isCheckingApproval } = approvedForAll;
+
+    const erc1155Errors = [approvedForAll, balanceOf]
+        .filter((d) => d.isError)
+        .map((d) => (d.error as BaseError).shortMessage);
+
+    // prepare approve transaction
+    const { approve, approvePrepare, approveWait } = useERC1155ApproveForAll({
+        erc1155Address,
+        args: [erc1155BatchPortalAddress, true],
+        isQueryEnabled:
+            isNotNil(accountBalance) &&
+            isNotNil(amount) &&
+            amount > 0 &&
+            amount <= accountBalance,
+    });
+
+    const [tokenIds, amounts] = batchAsLists ?? [];
+    const { deposit, depositPrepare, depositWait } =
+        useERC1155BatchPortalDeposit({
+            contractParams: {
+                args: [
+                    erc1155Address,
+                    applicationAddress,
+                    tokenIds!,
+                    amounts!,
+                    baseLayerData,
+                    execLayerData,
+                ],
+            },
+            isQueryEnabled:
+                isNotNilOrEmpty(tokenIds) &&
+                isNotNilOrEmpty(amounts) &&
+                !form.errors.application &&
+                !form.errors.erc1155Address &&
+                !form.errors.batch &&
+                isHex(execLayerData) &&
+                isHex(baseLayerData) &&
+                isApproved === true,
+        });
+
+    const hasDeposits = isNotNilOrEmpty(tokenIds) && isNotNilOrEmpty(amounts);
+    const extraDataIsValid =
+        form.isValid("execLayerData") && form.isValid("baseLayerData");
+
+    const canDeposit = hasDeposits && isApproved && extraDataIsValid;
+    const needApproval = hasDeposits && !isApproved;
+
+    const { loading: approveLoading } = transactionState(
+        approvePrepare,
+        approve,
+        approveWait,
+        true,
+    );
+    const { disabled: depositDisabled, loading: depositLoading } =
+        transactionState(depositPrepare, deposit, depositWait, true);
+    const txDetails = useMemo(
+        () => [
+            {
+                legend: "Application Address",
+                text: application.applicationAddress,
+            },
+            {
+                legend: "Portal Address",
+                text: erc1155BatchPortalAddress,
+            },
+        ],
+        [application.applicationAddress],
+    );
+
+    useEffect(() => {
+        if (depositWait.isSuccess) {
+            onSuccess({ receipt: depositWait.data, type: "ERC-1155" });
+            form.reset();
+            approve.reset();
+            deposit.reset();
+        }
+    }, [
+        depositWait.isSuccess,
+        onSuccess,
+        approve,
+        deposit,
+        form,
+        depositWait.data,
+    ]);
+
+    return (
+        <FormProvider form={form}>
+            <form data-testid="erc1155-batch-deposit-form">
+                <Stack>
+                    <TransactionDetails details={txDetails} />
+                    <Autocomplete
+                        label="ERC-1155"
+                        description="The ERC-1155 smart contract address"
+                        placeholder="0x"
+                        data={[]}
+                        withAsterisk
+                        data-testid="erc1155Address"
+                        rightSection={
+                            (isCheckingContractInterface ||
+                                isCheckingApproval ||
+                                isCheckingBalance) && <Loader size="xs" />
+                        }
+                        {...form.getInputProps("erc1155Address")}
+                        error={
+                            isValidContractResult.errorMessage ||
+                            erc1155Errors[0] ||
+                            form.errors.erc1155Address
+                        }
+                        onChange={(nextValue) => {
+                            const formattedValue = nextValue.substring(
+                                nextValue.indexOf("0x"),
+                            );
+                            form.setFieldValue(
+                                "erc1155Address",
+                                formattedValue,
+                            );
+                            form.setFieldValue("amount", "");
+                            form.setFieldValue("tokenId", "");
+                            form.setFieldValue("batch", undefined);
+                        }}
+                    />
+
+                    <TokenFields
+                        balanceOf={balanceOf}
+                        display={
+                            erc1155Address !== zeroAddress &&
+                            !isCheckingContractInterface &&
+                            isValidContractResult.isValid &&
+                            isAddress(erc1155Address)
+                        }
+                    />
+
+                    <DepositBatchReview />
+
+                    <AdvancedFields display={advanced} />
+
+                    <Collapse in={!approve.isIdle || approveWait.isLoading}>
+                        <TransactionProgress
+                            prepare={approvePrepare}
+                            execute={approve}
+                            wait={approveWait}
+                            confirmationMessage="Approve transaction confirmed"
+                        />
+                    </Collapse>
+                    <Collapse in={!deposit.isIdle}>
+                        <TransactionProgress
+                            prepare={depositPrepare}
+                            execute={deposit}
+                            wait={depositWait}
+                        />
+                    </Collapse>
+
+                    <Group justify="right">
+                        <Button
+                            leftSection={
+                                advanced ? <TbChevronUp /> : <TbChevronDown />
+                            }
+                            size="xs"
+                            visibleFrom="sm"
+                            variant="transparent"
+                            onClick={toggleAdvanced}
+                        >
+                            Advanced
+                        </Button>
+                        <Button
+                            variant="filled"
+                            disabled={!needApproval}
+                            leftSection={<TbCheck />}
+                            loading={isCheckingApproval || approveLoading}
+                            onClick={() =>
+                                approve.writeContract(
+                                    approvePrepare.data!.request,
+                                )
+                            }
+                        >
+                            {!isCheckingApproval && isApproved
+                                ? "Approved"
+                                : "Approve"}
+                        </Button>
+                        <Button
+                            variant="filled"
+                            disabled={depositDisabled || !canDeposit}
+                            leftSection={<TbPigMoney />}
+                            loading={canDeposit && depositLoading}
+                            onClick={() =>
+                                deposit.writeContract(
+                                    depositPrepare.data!.request,
+                                )
+                            }
+                        >
+                            Deposit
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </FormProvider>
+    );
+};
+
+export default DepositFormBatch;

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/DepositFormSingle.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/DepositFormSingle.tsx
@@ -1,0 +1,354 @@
+import { erc1155SinglePortalAddress } from "@cartesi/wagmi";
+import {
+    Autocomplete,
+    Button,
+    Collapse,
+    Group,
+    Loader,
+    Stack,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { isNotNil } from "ramda";
+import { type FC, useEffect, useMemo } from "react";
+import {
+    TbCheck,
+    TbChevronDown,
+    TbChevronUp,
+    TbPigMoney,
+} from "react-icons/tb";
+import {
+    BaseError,
+    type Hex,
+    getAddress,
+    isAddress,
+    isHex,
+    parseUnits,
+    zeroAddress,
+} from "viem";
+import { useAccount } from "wagmi";
+import {
+    erc1155Abi,
+    useReadErc1155BalanceOf,
+    useReadErc1155IsApprovedForAll,
+    useReadErc1155SupportsInterface,
+} from "../../../generated/wagmi";
+import { interfaceIdForERC1155 } from "../ERC165Identifiers";
+import TransactionDetails from "../TransactionDetails";
+import { TransactionProgress } from "../TransactionProgress";
+import { transactionState } from "../TransactionState";
+import useWatchQueryOnBlockChange from "../hooks/useWatchQueryOnBlockChange";
+import AdvancedFields from "./AdvancedFields";
+import TokenFields from "./TokenFields";
+import { FormProvider, useForm } from "./context";
+import { useERC1155ApproveForAll } from "./hooks/useERC1155ApproveForAll";
+import { useERC1155SinglePortalDeposit } from "./hooks/useERC1155SinglePortalDeposit";
+import { type ERC1155DepositFormProps } from "./types";
+import {
+    amountValidation,
+    applicationValidation,
+    erc1155AddressValidation,
+    hexValidation,
+    isValidContractInterface,
+    tokenIdValidation,
+} from "./validations";
+
+type Props = Omit<ERC1155DepositFormProps, "mode">;
+
+const DepositFormSingle: FC<Props> = (props) => {
+    const { application, onSuccess } = props;
+
+    const [advanced, { toggle: toggleAdvanced }] = useDisclosure(false);
+    // connected account
+    const { address } = useAccount();
+
+    const form = useForm({
+        validateInputOnChange: true,
+        initialValues: {
+            mode: "single",
+            application: application.applicationAddress,
+            erc1155Address: "",
+            tokenId: "",
+            amount: "",
+            execLayerData: "0x",
+            baseLayerData: "0x",
+            decimals: 0,
+            balance: 0n,
+        },
+        validate: {
+            application: applicationValidation,
+            erc1155Address: erc1155AddressValidation,
+            tokenId: tokenIdValidation,
+            amount: amountValidation,
+            execLayerData: hexValidation,
+            baseLayerData: hexValidation,
+        },
+        transformValues: (values) => ({
+            applicationAddress: isAddress(values.application)
+                ? getAddress(values.application)
+                : zeroAddress,
+            erc1155Address: isAddress(values.erc1155Address)
+                ? getAddress(values.erc1155Address)
+                : zeroAddress,
+            tokenId:
+                values.tokenId !== "" &&
+                Number.isInteger(Number(values.tokenId))
+                    ? BigInt(Number(values.tokenId))
+                    : undefined,
+            amount:
+                values.amount !== ""
+                    ? parseUnits(values.amount.toString(), values.decimals)
+                    : undefined,
+            execLayerData: values.execLayerData as Hex,
+            baseLayerData: values.baseLayerData as Hex,
+        }),
+    });
+
+    const {
+        applicationAddress,
+        erc1155Address,
+        amount,
+        tokenId,
+        baseLayerData,
+        execLayerData,
+    } = form.getTransformedValues();
+
+    const erc1155Contract = {
+        abi: erc1155Abi,
+        address: erc1155Address !== zeroAddress ? erc1155Address : undefined,
+    } as const;
+
+    const balanceOf = useReadErc1155BalanceOf({
+        address: erc1155Contract.address,
+        args: [getAddress(address!), tokenId!],
+        query: {
+            enabled: tokenId !== undefined,
+        },
+    });
+
+    const supportsInterface = useReadErc1155SupportsInterface({
+        address: erc1155Contract.address,
+        args: [interfaceIdForERC1155],
+        query: {
+            enabled: erc1155Contract.address !== undefined,
+        },
+    });
+
+    const { isLoading: isCheckingContractInterface } = supportsInterface;
+    const validContractResult = isValidContractInterface(supportsInterface);
+
+    const approvedForAll = useReadErc1155IsApprovedForAll({
+        address: erc1155Contract.address,
+        args: [getAddress(address!), erc1155SinglePortalAddress],
+        query: {
+            enabled:
+                validContractResult.isValid && !isCheckingContractInterface,
+        },
+    });
+
+    useWatchQueryOnBlockChange(approvedForAll.queryKey);
+
+    const { data: accountBalance, isLoading: isCheckingBalance } = balanceOf;
+    const { data: isApproved, isLoading: isCheckingApproval } = approvedForAll;
+
+    const erc1155Errors = [approvedForAll, balanceOf]
+        .filter((d) => d.isError)
+        .map((d) => (d.error as BaseError).shortMessage);
+
+    // prepare approve transaction
+    const { approve, approvePrepare, approveWait } = useERC1155ApproveForAll({
+        erc1155Address,
+        args: [erc1155SinglePortalAddress, true],
+        isQueryEnabled:
+            isNotNil(accountBalance) &&
+            isNotNil(amount) &&
+            amount > 0 &&
+            amount <= accountBalance,
+    });
+
+    // prepare deposit transaction
+    const { deposit, depositPrepare, depositWait } =
+        useERC1155SinglePortalDeposit({
+            contractParams: {
+                args: [
+                    erc1155Address!,
+                    applicationAddress,
+                    tokenId!,
+                    amount!,
+                    baseLayerData,
+                    execLayerData,
+                ],
+            },
+            isQueryEnabled:
+                tokenId !== undefined &&
+                amount !== undefined &&
+                accountBalance !== undefined &&
+                amount <= accountBalance &&
+                !form.errors.application &&
+                !form.errors.erc1155Address &&
+                isHex(execLayerData) &&
+                isHex(baseLayerData) &&
+                isApproved == true,
+        });
+
+    const canDeposit =
+        accountBalance !== undefined &&
+        amount !== undefined &&
+        amount > 0 &&
+        amount <= accountBalance &&
+        isApproved;
+
+    const { loading: approveLoading } = transactionState(
+        approvePrepare,
+        approve,
+        approveWait,
+        true,
+    );
+    const { disabled: depositDisabled, loading: depositLoading } =
+        transactionState(depositPrepare, deposit, depositWait, true);
+
+    const txDetails = useMemo(
+        () => [
+            {
+                legend: "Application Address",
+                text: application.applicationAddress,
+            },
+            {
+                legend: "Portal Address",
+                text: erc1155SinglePortalAddress,
+            },
+        ],
+        [application.applicationAddress],
+    );
+
+    useEffect(() => {
+        if (depositWait.isSuccess) {
+            onSuccess({ receipt: depositWait.data, type: "ERC-1155" });
+            form.reset();
+            approve.reset();
+            deposit.reset();
+        }
+    }, [
+        depositWait.isSuccess,
+        onSuccess,
+        approve,
+        deposit,
+        form,
+        depositWait.data,
+    ]);
+
+    return (
+        <FormProvider form={form}>
+            <form data-testid="erc1155-deposit-form">
+                <Stack>
+                    <TransactionDetails details={txDetails} />
+                    <Autocomplete
+                        label="ERC-1155"
+                        description="The ERC-1155 smart contract address"
+                        placeholder="0x"
+                        data={[]}
+                        withAsterisk
+                        data-testid="erc1155Address"
+                        rightSection={
+                            (isCheckingContractInterface ||
+                                isCheckingApproval ||
+                                isCheckingBalance) && <Loader size="xs" />
+                        }
+                        {...form.getInputProps("erc1155Address")}
+                        error={
+                            validContractResult.errorMessage ||
+                            erc1155Errors[0] ||
+                            form.errors.erc1155Address
+                        }
+                        onChange={(nextValue) => {
+                            const formattedValue = nextValue.substring(
+                                nextValue.indexOf("0x"),
+                            );
+                            form.setFieldValue(
+                                "erc1155Address",
+                                formattedValue,
+                            );
+                            form.setFieldValue("amount", "");
+                            form.setFieldValue("tokenId", "");
+                        }}
+                    />
+
+                    <TokenFields
+                        balanceOf={balanceOf}
+                        display={
+                            erc1155Address !== zeroAddress &&
+                            !isCheckingContractInterface &&
+                            validContractResult.isValid &&
+                            isAddress(erc1155Address)
+                        }
+                    />
+
+                    <AdvancedFields display={advanced} />
+
+                    <Collapse in={!approve.isIdle || approveWait.isLoading}>
+                        <TransactionProgress
+                            prepare={approvePrepare}
+                            execute={approve}
+                            wait={approveWait}
+                            confirmationMessage="Approve transaction confirmed"
+                        />
+                    </Collapse>
+                    <Collapse in={!deposit.isIdle}>
+                        <TransactionProgress
+                            prepare={depositPrepare}
+                            execute={deposit}
+                            wait={depositWait}
+                        />
+                    </Collapse>
+
+                    <Group justify="right">
+                        <Button
+                            leftSection={
+                                advanced ? <TbChevronUp /> : <TbChevronDown />
+                            }
+                            size="xs"
+                            visibleFrom="sm"
+                            variant="transparent"
+                            onClick={toggleAdvanced}
+                        >
+                            Advanced
+                        </Button>
+                        <Button
+                            variant="filled"
+                            disabled={isApproved || !form.isValid()}
+                            leftSection={<TbCheck />}
+                            loading={isCheckingApproval || approveLoading}
+                            onClick={() =>
+                                approve.writeContract(
+                                    approvePrepare.data!.request,
+                                )
+                            }
+                        >
+                            {!isCheckingApproval && isApproved
+                                ? "Approved"
+                                : "Approve"}
+                        </Button>
+                        <Button
+                            variant="filled"
+                            disabled={
+                                depositDisabled ||
+                                !canDeposit ||
+                                !form.isValid()
+                            }
+                            leftSection={<TbPigMoney />}
+                            loading={canDeposit && depositLoading}
+                            onClick={() =>
+                                deposit.writeContract(
+                                    depositPrepare.data!.request,
+                                )
+                            }
+                        >
+                            Deposit
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </FormProvider>
+    );
+};
+
+export default DepositFormSingle;

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/TokenFields.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/TokenFields.tsx
@@ -1,0 +1,343 @@
+import {
+    Accordion,
+    Avatar,
+    Button,
+    Collapse,
+    type DefaultMantineColor,
+    Flex,
+    Group,
+    JsonInput,
+    Loader,
+    Notification,
+    NumberFormatter,
+    NumberInput,
+    Stack,
+    Text,
+    TextInput,
+} from "@mantine/core";
+import {
+    allPass,
+    complement,
+    equals,
+    hasPath,
+    is,
+    isNil,
+    isNotNil,
+    or,
+    pathOr,
+} from "ramda";
+import { type FC, useEffect } from "react";
+import { type Address, toHex, zeroAddress } from "viem";
+import { type Config } from "wagmi";
+import {
+    useReadErc1155BalanceOf,
+    useReadErc1155Uri,
+} from "../../../generated/wagmi";
+import { type Mode, useFormContext } from "./context";
+import {
+    type State,
+    type TokenMetadataResult,
+    useGetTokenMetadata,
+} from "./hooks/useGetTokenMetadata";
+
+type BalanceOf = ReturnType<
+    typeof useReadErc1155BalanceOf<
+        "balanceOf",
+        [Address, bigint],
+        Config,
+        bigint
+    >
+>;
+
+interface Props {
+    balanceOf: BalanceOf;
+    display: boolean;
+}
+
+const notIdle = complement(equals<State>("idle"));
+const notFetching = complement(equals<State>("fetching"));
+const hasResult = allPass([notFetching, notIdle]);
+
+interface MetadataViewProps {
+    tokenMetadata: TokenMetadataResult;
+}
+interface MessageProps {
+    color?: DefaultMantineColor;
+    title: string;
+    content?: string;
+}
+
+const Message: FC<MessageProps> = ({ title, content, color }) => {
+    return (
+        <Notification
+            color={color ?? "blue"}
+            title={title}
+            withCloseButton={false}
+        >
+            {content && <Text size="xs">{content}</Text>}
+        </Notification>
+    );
+};
+
+/**
+ * Messages to display based on the State
+ * in the token-metadata-result. Tracking only the ones of interest.
+ */
+const feedbackByState: Partial<Record<State, string>> = {
+    http_network_error: "We could not fetch the metadata.",
+    not_http: "The URI is valid, but it is not an HTTP protocol.",
+    errored: "Something is wrong with the URI returned by the contract.",
+} as const;
+
+const MetadataView: FC<MetadataViewProps> = ({ tokenMetadata }) => {
+    const { state, url, data } = tokenMetadata;
+    const message = feedbackByState[state];
+    const name = pathOr("", ["name"], data);
+    const description = pathOr("", ["description"], data);
+    const image = pathOr("", ["image"], data);
+    const dataAsString = is(Object, data)
+        ? JSON.stringify(data, null, " ")
+        : data;
+
+    return (
+        <>
+            {isNotNil(message) && (
+                <Message
+                    title={message}
+                    content={or(url, "URI is not defined.")}
+                />
+            )}
+
+            {state === "success" && (
+                <Accordion
+                    chevronPosition="right"
+                    variant="contained"
+                    py="sm"
+                    data-testid="metadata-view"
+                >
+                    <Accordion.Item
+                        key={tokenMetadata.state}
+                        value={tokenMetadata.state}
+                    >
+                        <Accordion.Control>
+                            <Group wrap="nowrap">
+                                <Avatar
+                                    src={image}
+                                    radius="xl"
+                                    size="lg"
+                                    data-testid="metadata-view-img"
+                                >
+                                    {name ?? "TK"}
+                                </Avatar>
+                                <div>
+                                    <Text>{name}</Text>
+                                    <Text
+                                        size="sm"
+                                        c="dimmed"
+                                        fw={400}
+                                        lineClamp={2}
+                                    >
+                                        {description}
+                                    </Text>
+                                </div>
+                            </Group>
+                        </Accordion.Control>
+                        <Accordion.Panel>
+                            <JsonInput
+                                autosize
+                                maxRows={10}
+                                readOnly
+                                contentEditable={false}
+                                value={dataAsString}
+                            />
+                        </Accordion.Panel>
+                    </Accordion.Item>
+                </Accordion>
+            )}
+        </>
+    );
+};
+
+interface AddToBatchListProps {
+    name?: string;
+    tokenId?: bigint;
+    amount?: bigint;
+}
+
+const AddToBatchList: FC<AddToBatchListProps> = ({ name, tokenId, amount }) => {
+    const form = useFormContext();
+    const batchErrorMsg = pathOr(null, ["errors", "batch"], form);
+
+    const noErrors = isNil(form.errors.amount) && isNil(form.errors.tokenId);
+    const canAddToList =
+        tokenId !== undefined && amount !== undefined && noErrors;
+
+    return (
+        <>
+            <Button
+                disabled={!canAddToList}
+                onClick={() => {
+                    const newEntry = {
+                        amount: amount!,
+                        tokenId: tokenId!,
+                        name,
+                        id: toHex(Date.now()),
+                    };
+
+                    form.setValues((prev) => {
+                        return {
+                            batch: [...(prev.batch ?? []), newEntry],
+                            tokenId: "",
+                            amount: "",
+                        };
+                    });
+                }}
+            >
+                ADD TO DEPOSIT LIST
+            </Button>
+
+            <Text c="red" size="xs">
+                {batchErrorMsg}
+            </Text>
+        </>
+    );
+};
+
+const TokenFields: FC<Props> = ({ balanceOf, display }) => {
+    const form = useFormContext();
+    const mode = pathOr<Mode>("single", ["values", "mode"], form);
+    const { erc1155Address, tokenId, amount } = form.getTransformedValues();
+    const { data: accountBalance, isLoading: isCheckingBalance } = balanceOf;
+
+    const { data: uri } = useReadErc1155Uri({
+        address: erc1155Address !== zeroAddress ? erc1155Address : undefined,
+        args: [tokenId!],
+        query: {
+            enabled: tokenId !== undefined,
+        },
+    });
+
+    const metadataResult = useGetTokenMetadata(uri, tokenId);
+
+    const hasMetaResult = hasResult(metadataResult.state);
+    const decimals = pathOr(0, ["decimals"], metadataResult.data);
+    const name = pathOr("", ["name"], metadataResult.data);
+    const symbol = pathOr("", ["symbol"], metadataResult.data);
+
+    useEffect(() => {
+        form.setFieldValue("decimals", decimals);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [decimals]);
+
+    useEffect(() => {
+        if (accountBalance) form.setFieldValue("balance", accountBalance);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [accountBalance]);
+
+    return (
+        <Collapse in={display}>
+            <Stack>
+                <TextInput
+                    type="number"
+                    min={0}
+                    step={1}
+                    label="Token id"
+                    description="Token identifier to deposit"
+                    placeholder="1"
+                    withAsterisk
+                    data-testid="token-id-input"
+                    rightSection={
+                        metadataResult.state === "fetching" && (
+                            <Loader size="xs" />
+                        )
+                    }
+                    {...form.getInputProps("tokenId")}
+                />
+                <NumberInput
+                    disabled={
+                        hasPath(["errors", "tokenId"], form) || !hasMetaResult
+                    }
+                    allowDecimal={decimals > 0}
+                    decimalScale={decimals}
+                    hideControls
+                    min={0}
+                    label="Amount"
+                    description="Amount of tokens to deposit"
+                    placeholder="0"
+                    withAsterisk
+                    data-testid="amount-input"
+                    rightSectionProps={{
+                        style: { width: "auto", paddingRight: "0.5rem" },
+                    }}
+                    rightSection={
+                        metadataResult.state === "fetching" ? (
+                            <Loader size="xs" />
+                        ) : (
+                            <Text> {symbol || name} </Text>
+                        )
+                    }
+                    {...form.getInputProps("amount")}
+                />
+
+                {!form.errors.tokenId && (
+                    <>
+                        <Flex
+                            mt="-sm"
+                            justify={"space-between"}
+                            direction={"row"}
+                        >
+                            <Flex rowGap={6} c={"dimmed"} align="flex-start">
+                                <Text fz="xs">Balance:</Text>
+                                <Text id="token-balance" fz="xs" mx={4}>
+                                    {isCheckingBalance
+                                        ? "Checking balance..."
+                                        : ""}
+                                    <NumberFormatter
+                                        thousandSeparator
+                                        value={or(accountBalance, 0).toString()}
+                                    />
+                                </Text>
+                                {accountBalance !== undefined &&
+                                    accountBalance > 0 && (
+                                        <Button
+                                            h="auto"
+                                            p={2}
+                                            size="xs"
+                                            variant="transparent"
+                                            onClick={() =>
+                                                form.setFieldValue(
+                                                    "amount",
+                                                    accountBalance?.toString(),
+                                                )
+                                            }
+                                            data-testid="max-amount"
+                                        >
+                                            Max
+                                        </Button>
+                                    )}
+                            </Flex>
+
+                            <Text fz="xs" c="dimmed">
+                                Decimals: {decimals}
+                            </Text>
+                        </Flex>
+                    </>
+                )}
+                {mode === "batch" && (
+                    <AddToBatchList
+                        name={name}
+                        amount={amount}
+                        tokenId={tokenId}
+                    />
+                )}
+                <Stack>
+                    <MetadataView tokenMetadata={metadataResult} />
+                </Stack>
+            </Stack>
+        </Collapse>
+    );
+};
+
+TokenFields.displayName = "TokenFields";
+
+export default TokenFields;

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/context.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/context.tsx
@@ -1,0 +1,46 @@
+import { createFormContext } from "@mantine/form";
+import type { Address, Hex } from "viem";
+
+export type DepositData = {
+    tokenId: bigint;
+    name?: string;
+    amount: bigint;
+    id: Hex;
+};
+
+type Amounts = bigint[];
+type TokenIds = bigint[];
+
+export type DepositDataTuple = [bigint, bigint];
+export type BatchTuple = [TokenIds, Amounts];
+
+export type Mode = "single" | "batch";
+export interface FormValues {
+    mode: Mode;
+    application: string;
+    erc1155Address: string;
+    tokenId: string;
+    amount: string;
+    execLayerData: Hex;
+    baseLayerData: Hex;
+    decimals: number;
+    balance: bigint;
+    batch?: DepositData[];
+}
+
+export interface TransformedValues {
+    applicationAddress: Address;
+    erc1155Address: Address;
+    tokenId?: bigint;
+    amount?: bigint;
+    execLayerData: Hex;
+    baseLayerData: Hex;
+    batchAsLists?: BatchTuple;
+}
+
+type TransformValues = (a: FormValues) => TransformedValues;
+
+export const [FormProvider, useFormContext, useForm] = createFormContext<
+    FormValues,
+    TransformValues
+>();

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/hooks/useERC1155ApproveForAll.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/hooks/useERC1155ApproveForAll.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { type Hex, erc1155Abi } from "viem";
+import {
+    type UseSimulateContractReturnType,
+    useWaitForTransactionReceipt,
+} from "wagmi";
+import {
+    useSimulateErc1155SetApprovalForAll,
+    useWriteErc1155SetApprovalForAll,
+} from "../../../../generated/wagmi";
+
+interface Props {
+    erc1155Address: Hex;
+    args: [operator: Hex, allowed: boolean];
+    isQueryEnabled: boolean;
+}
+
+interface UseERC1155ApproveForAllReturn {
+    approvePrepare: UseSimulateContractReturnType<
+        typeof erc1155Abi,
+        "setApprovalForAll"
+    >;
+    approve: ReturnType<typeof useWriteErc1155SetApprovalForAll>;
+    approveWait: ReturnType<typeof useWaitForTransactionReceipt>;
+}
+
+/*
+ * Generate wagmi calls based on the parameters passed down.
+ * @parameters {Props}
+ * @returns
+ */
+export const useERC1155ApproveForAll = ({
+    erc1155Address,
+    args,
+    isQueryEnabled,
+}: Props): UseERC1155ApproveForAllReturn => {
+    const approvePrepare = useSimulateErc1155SetApprovalForAll({
+        address: erc1155Address,
+        args: args,
+        query: {
+            enabled: isQueryEnabled,
+        },
+    });
+
+    const approve = useWriteErc1155SetApprovalForAll();
+    const approveWait = useWaitForTransactionReceipt({
+        hash: approve.data,
+    });
+
+    return {
+        approvePrepare,
+        approve,
+        approveWait,
+    };
+};

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/hooks/useERC1155BatchPortalDeposit.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/hooks/useERC1155BatchPortalDeposit.tsx
@@ -1,0 +1,55 @@
+"use client";
+import {
+    useSimulateErc1155BatchPortalDepositBatchErc1155Token,
+    useWriteErc1155BatchPortalDepositBatchErc1155Token,
+} from "@cartesi/wagmi";
+import type { Hex } from "viem";
+import { useWaitForTransactionReceipt } from "wagmi";
+
+interface Props {
+    contractParams: {
+        args: [
+            erc1155Address: Hex,
+            appAddress: Hex,
+            tokenIds: bigint[],
+            amounts: bigint[],
+            baseLayerData: Hex,
+            execLayerData: Hex,
+        ];
+    };
+    isQueryEnabled: boolean;
+}
+
+/**
+ * Generate wagmi calls based on the parameters passed down.
+ * simulate contract call will not run until it is defined.
+ * @parameters {Props}
+ * @returns
+ */
+export const useERC1155BatchPortalDeposit = ({
+    contractParams,
+    isQueryEnabled,
+}: Props) => {
+    const depositPrepare =
+        useSimulateErc1155BatchPortalDepositBatchErc1155Token({
+            args: contractParams.args,
+            query: {
+                enabled: isQueryEnabled,
+            },
+        });
+
+    const deposit = useWriteErc1155BatchPortalDepositBatchErc1155Token();
+
+    const depositWait = useWaitForTransactionReceipt({
+        hash: deposit.data,
+        query: {
+            enabled: isQueryEnabled,
+        },
+    });
+
+    return {
+        depositPrepare,
+        deposit,
+        depositWait,
+    };
+};

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/hooks/useERC1155SinglePortalDeposit.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/hooks/useERC1155SinglePortalDeposit.tsx
@@ -1,0 +1,52 @@
+"use client";
+import {
+    useSimulateErc1155SinglePortalDepositSingleErc1155Token,
+    useWriteErc1155SinglePortalDepositSingleErc1155Token,
+} from "@cartesi/wagmi";
+import { type Hex } from "viem";
+import { useWaitForTransactionReceipt } from "wagmi";
+
+interface Props {
+    contractParams: {
+        args: [
+            erc1155Address: Hex,
+            appAddress: Hex,
+            tokenId: bigint,
+            amount: bigint,
+            baseLayerData: Hex,
+            execLayerData: Hex,
+        ];
+    };
+    isQueryEnabled: boolean;
+}
+
+/**
+ * Generate wagmi calls based on the parameters passed down.
+ * simulate contract call will not run until it is defined.
+ * @parameters {Props}
+ * @returns
+ */
+export const useERC1155SinglePortalDeposit = ({
+    contractParams,
+    isQueryEnabled,
+}: Props) => {
+    const depositPrepare =
+        useSimulateErc1155SinglePortalDepositSingleErc1155Token({
+            args: contractParams.args,
+            query: {
+                enabled: isQueryEnabled,
+            },
+        });
+
+    const deposit = useWriteErc1155SinglePortalDepositSingleErc1155Token();
+
+    const depositWait = useWaitForTransactionReceipt({
+        hash: deposit.data,
+    });
+
+    return {
+        depositPrepare,
+        deposit,
+        depositWait,
+    };
+};

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/hooks/useGetTokenMetadata.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/hooks/useGetTokenMetadata.tsx
@@ -1,0 +1,178 @@
+"use client";
+import { cond, isNil, isNotNil } from "ramda";
+import { useEffect, useState } from "react";
+
+export type UseGetTokenMetadata = (
+    uri?: string,
+    tokenId?: bigint,
+) => TokenMetadataResult;
+
+interface PrepareUrlResult {
+    validURL: boolean;
+    isHttp: boolean;
+    error?: TypeError;
+    result?: URL;
+    url: string;
+}
+
+type TokenMetadata = Record<string, unknown>;
+
+interface FetchResult {
+    data?: TokenMetadata;
+    error?: Error;
+}
+
+export type State =
+    | "idle"
+    | "fetching"
+    | "success"
+    | "errored"
+    | "not_http"
+    | "http_network_error";
+
+export interface TokenMetadataResult {
+    state: State;
+    /** Tells if the URI returned is defined using the http protocol. */
+    isHttp?: boolean;
+    /** Parsed URL based on EIP-1155 standard @link{https://eips.ethereum.org/EIPS/eip-1155#metadata} */
+    url?: string;
+    /** A wide type to support the returned JSON based on EIP-1155 @link{https://eips.ethereum.org/EIPS/eip-1155#erc-1155-metadata-uri-json-schema}*/
+    data?: TokenMetadata;
+    /** Any error returned during fetch phase.*/
+    error?: Error;
+}
+
+interface MetaCache {
+    [key: string]: TokenMetadataResult;
+}
+
+const prepareUrl = (uri: string, id: bigint): PrepareUrlResult => {
+    const regex = /\{id\}/;
+    try {
+        const url = uri.replace(regex, id.toString());
+        const result = new URL(url);
+        return {
+            validURL: true,
+            isHttp: result.protocol.includes("http"),
+            result,
+            url,
+        };
+    } catch (error: unknown) {
+        return {
+            validURL: false,
+            isHttp: false,
+            error: error as TypeError,
+            url: uri,
+        };
+    }
+};
+
+const fetchMetadata = async (
+    result: PrepareUrlResult,
+    signal: AbortSignal,
+): Promise<FetchResult> => {
+    if (!result.validURL || !result.isHttp) return {};
+
+    return fetch(result.url, { signal })
+        .then(async (r) => {
+            if (r.ok) {
+                return r
+                    .json()
+                    .then((data: Record<string, unknown>) => ({ data }));
+            }
+            const errorMessage = await r
+                .text()
+                .catch(() => `Status: ${r.status}`);
+            return { error: new Error(errorMessage) };
+        })
+        .catch((e: Error) => ({ error: e }));
+};
+
+type DeriveStateProps = {
+    urlResult: PrepareUrlResult;
+    fetchResult: FetchResult;
+};
+
+const deriveState = cond<DeriveStateProps[], State>([
+    [
+        ({ urlResult, fetchResult }) =>
+            urlResult.isHttp && isNil(fetchResult.error),
+        () => "success",
+    ],
+    [
+        ({ urlResult }) => urlResult.validURL && !urlResult.isHttp,
+        () => "not_http",
+    ],
+    [
+        ({ urlResult, fetchResult }) =>
+            urlResult.isHttp && isNotNil(fetchResult.error),
+        () => "http_network_error",
+    ],
+    [
+        ({ fetchResult, urlResult }) =>
+            isNotNil(fetchResult.error) || isNotNil(urlResult.error),
+        () => "errored",
+    ],
+    [() => true, () => "idle"],
+]);
+
+export const useGetTokenMetadata: UseGetTokenMetadata = (uri, id) => {
+    const [cache, setCache] = useState<MetaCache>({});
+    const [result, setResult] = useState<TokenMetadataResult>({
+        state: "idle",
+    });
+
+    useEffect(() => {
+        if (isNil(uri) || isNil(id)) {
+            setResult(() => ({ state: "idle" }));
+            return;
+        }
+
+        const update = async (uri: string, id: bigint, signal: AbortSignal) => {
+            const urlResult = prepareUrl(uri, id);
+            const fetchResult = await fetchMetadata(urlResult, signal);
+
+            if (isNil(fetchResult.error)) {
+                setCache((cache) => {
+                    cache[uri + id] = result;
+                    return cache;
+                });
+            }
+
+            if (fetchResult.error?.name === "AbortError") {
+                console.log(`Request to ${urlResult.url} aborted.`);
+                return;
+            }
+
+            const result = {
+                state: deriveState({ fetchResult, urlResult }),
+                error: fetchResult.error,
+                data: fetchResult.data,
+                isHttp: urlResult.isHttp,
+                url: urlResult.url,
+            };
+
+            setResult(result);
+        };
+
+        if (uri !== undefined && id !== undefined) {
+            const abortController = new AbortController();
+            const cached = cache[uri + id];
+            if (cached !== undefined) {
+                setResult(cached);
+            } else {
+                setResult(() => ({ state: "fetching" }));
+                update(uri, id, abortController.signal);
+            }
+
+            return () => {
+                console.log(`calling abort on ${id}`);
+                abortController.abort(
+                    `Token id ${id} metadata request aborted.`,
+                );
+            };
+        }
+    }, [uri, id, cache]);
+
+    return result;
+};

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/index.tsx
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/index.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { type FC } from "react";
+import DepositFormBatch from "./DepositFormBatch";
+import DepositFormSingle from "./DepositFormSingle";
+import { type ERC1155DepositFormProps } from "./types";
+
+export const ERC1155DepositForm: FC<ERC1155DepositFormProps> = (props) => {
+    return (
+        <>
+            {props.mode === "single" ? (
+                <DepositFormSingle
+                    key="erc-1155-single"
+                    application={props.application}
+                    onSuccess={props.onSuccess}
+                />
+            ) : props.mode === "batch" ? (
+                <DepositFormBatch
+                    key="erc-1155-batch"
+                    application={props.application}
+                    onSuccess={props.onSuccess}
+                />
+            ) : null}
+        </>
+    );
+};

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/types.ts
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/types.ts
@@ -1,0 +1,8 @@
+import type { Application } from "@cartesi/viem";
+import type { TransactionFormSuccessData } from "../DepositFormTypes";
+
+export interface ERC1155DepositFormProps {
+    mode: "single" | "batch";
+    application: Application;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
+}

--- a/apps/dave/src/components/transactions/ERC1155DepositForm/validations.ts
+++ b/apps/dave/src/components/transactions/ERC1155DepositForm/validations.ts
@@ -1,0 +1,124 @@
+import {
+    T,
+    anyPass,
+    complement,
+    cond,
+    isEmpty,
+    isNil,
+    map,
+    pipe,
+    reduce,
+} from "ramda";
+import { isAddress, isHex } from "viem";
+import type { Config } from "wagmi";
+import { useReadErc1155SupportsInterface } from "../../../generated/wagmi";
+import type { DepositData, FormValues } from "./context";
+
+const isNotNumberOrInteger = anyPass<(val: number) => boolean>([
+    Number.isNaN,
+    complement(Number.isInteger),
+]);
+
+export const tokenIdValidation = (value: string) => {
+    if (isEmpty(value)) return "Token id is required!";
+
+    const tokenId = Number(value);
+    if (isNotNumberOrInteger(tokenId))
+        return "Token id should be an integer value!";
+
+    return null;
+};
+
+export const erc1155AddressValidation = (value: string) => {
+    if (isEmpty(value)) return `ERC1155 address is required`;
+    if (!isAddress(value)) {
+        return `Invalid ERC1155 address`;
+    }
+    return null;
+};
+
+export const applicationValidation = (value: string) => {
+    if (isEmpty(value)) return `Application address is required.`;
+    if (!isAddress(value)) {
+        return `Invalid Application address`;
+    }
+    return null;
+};
+
+const sumBatchFor = (tokenId: bigint) =>
+    pipe(
+        map<DepositData, bigint>((d) =>
+            d.tokenId === tokenId ? d.amount : BigInt(0),
+        ),
+        reduce((acc, curr) => acc + curr, BigInt(0)),
+    );
+
+export const amountValidation = (value: string, values: FormValues) => {
+    const amount = BigInt(value);
+    if (amount === 0n) return "Invalid amount.";
+
+    if (amount > values.balance)
+        return "The amount should be smaller or equal to your balance.";
+
+    if (values.mode === "batch") {
+        const sum = sumBatchFor(BigInt(values.tokenId));
+        const totalAmount = sum(values.batch ?? []) + amount;
+        if (totalAmount > values.balance)
+            return `You are above your balance for token id ${values.tokenId}. Delete an entry on review or change your amount.`;
+    }
+
+    return null;
+};
+
+export const hexValidation = (value: string) => {
+    return isHex(value) ? null : "Invalid hex string";
+};
+
+export const batchValidation = (value?: DepositData[]) => {
+    if (isNil(value)) return null;
+
+    if (isEmpty(value))
+        return "At least one deposit should be added. Or consider using the single deposit version.";
+
+    return null;
+};
+
+type SupportsInterfaceReturn = ReturnType<
+    typeof useReadErc1155SupportsInterface<
+        "supportsInterface",
+        readonly [`0x${string}`],
+        Config,
+        boolean
+    >
+>;
+
+const notValidContract =
+    "This is not an ERC-1155 contract. Check the address." as const;
+
+type IsValidContractInterfaceReturn =
+    | {
+          isValid: boolean;
+          errorMessage: typeof notValidContract;
+      }
+    | {
+          isValid: boolean;
+          errorMessage?: string;
+      };
+
+type IsValidContractInterface = (
+    result: SupportsInterfaceReturn,
+) => IsValidContractInterfaceReturn;
+
+export const isValidContractInterface: IsValidContractInterface = cond([
+    [
+        (result: SupportsInterfaceReturn) =>
+            result.status === "error" && !result.data,
+        () => ({ isValid: false, errorMessage: notValidContract }),
+    ],
+    [
+        (result: SupportsInterfaceReturn) =>
+            result.status === "success" && result.data === false,
+        () => ({ isValid: false, errorMessage: notValidContract }),
+    ],
+    [T, () => ({ isValid: true })],
+]);

--- a/apps/dave/src/components/transactions/ERC165Identifiers.ts
+++ b/apps/dave/src/components/transactions/ERC165Identifiers.ts
@@ -1,0 +1,1 @@
+export const interfaceIdForERC1155 = "0xd9b67a26" as const;

--- a/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20Approve.tsx
+++ b/apps/dave/src/components/transactions/ERC20DepositForm/hooks/useERC20Approve.tsx
@@ -1,10 +1,9 @@
-import { erc20Abi, type Hex } from "viem";
+import { type Hex } from "viem";
+import { useWaitForTransactionReceipt } from "wagmi";
 import {
-    useSimulateContract,
-    type UseSimulateContractReturnType,
-    useWaitForTransactionReceipt,
-    useWriteContract,
-} from "wagmi";
+    useSimulateErc20Approve,
+    useWriteErc20Approve,
+} from "../../../../generated/wagmi";
 
 interface Props {
     erc20Address: Hex;
@@ -13,8 +12,8 @@ interface Props {
 }
 
 interface UseERC20ApproveReturn {
-    approvePrepare: UseSimulateContractReturnType<typeof erc20Abi, "approve">;
-    approve: ReturnType<typeof useWriteContract>;
+    approvePrepare: ReturnType<typeof useSimulateErc20Approve>;
+    approve: ReturnType<typeof useWriteErc20Approve>;
     approveWait: ReturnType<typeof useWaitForTransactionReceipt>;
 }
 
@@ -23,9 +22,7 @@ export const useERC20Approve = ({
     erc20Address,
     isQueryEnabled,
 }: Props): UseERC20ApproveReturn => {
-    const approvePrepare = useSimulateContract({
-        abi: erc20Abi,
-        functionName: "approve",
+    const approvePrepare = useSimulateErc20Approve({
         address: erc20Address,
         args,
         query: {
@@ -33,7 +30,7 @@ export const useERC20Approve = ({
         },
     });
 
-    const approve = useWriteContract();
+    const approve = useWriteErc20Approve();
     const approveWait = useWaitForTransactionReceipt({
         hash: approve.data,
     });

--- a/apps/dave/src/providers/Providers.tsx
+++ b/apps/dave/src/providers/Providers.tsx
@@ -13,6 +13,24 @@ import DataProvider from "./DataProvider";
 import { StyleProvider } from "./StyleProvider";
 import WalletProvider from "./WalletProvider";
 
+/**
+ * This is a workaround to solve a problem when react-dom-client.development
+ * is trying to stringify bigints.
+ *
+ * refer to issue {@link https://github.com/facebook/react/issues/35004}
+ * a PR is currently open here {@link https://github.com/facebook/react/pull/35013}
+ */
+if (process.env.NODE_ENV === "development") {
+    Object.defineProperty(BigInt.prototype, "toJSON", {
+        writable: false,
+        enumerable: true,
+        configurable: false,
+        value() {
+            return this.toString();
+        },
+    });
+}
+
 type ProviderProps = { children: ReactNode };
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "/";

--- a/apps/dave/wagmi.config.ts
+++ b/apps/dave/wagmi.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "@wagmi/cli";
+import { react } from "@wagmi/cli/plugins";
+import { erc1155Abi, erc20Abi, erc721Abi } from "viem";
+
+type Config = ReturnType<typeof defineConfig>;
+
+const config: Config = defineConfig({
+    out: "src/generated/wagmi/index.tsx",
+    contracts: [
+        {
+            name: "erc20",
+            abi: erc20Abi,
+        },
+        {
+            name: "erc721",
+            abi: erc721Abi,
+        },
+        {
+            abi: erc1155Abi,
+            name: "ERC1155",
+        },
+    ],
+    plugins: [react()],
+});
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,13 +143,13 @@ importers:
         version: 10.1.7(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@storybook/addon-docs':
         specifier: ^10.1.5
-        version: 10.1.7(@types/react@19.2.7)(esbuild@0.25.10)(rollup@4.52.0)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack@5.103.0(esbuild@0.25.10))
+        version: 10.1.7(@types/react@19.2.7)(esbuild@0.19.12)(rollup@4.52.0)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack@5.103.0(esbuild@0.19.12))
       '@storybook/addon-onboarding':
         specifier: ^10.1.5
         version: 10.1.7(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@storybook/nextjs':
         specifier: ^10.1.5
-        version: 10.1.7(esbuild@0.25.10)(next@16.1.4(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(type-fest@4.41.0)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack-hot-middleware@2.26.1)(webpack@5.103.0(esbuild@0.25.10))
+        version: 10.1.7(esbuild@0.19.12)(next@16.1.4(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(type-fest@4.41.0)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack-hot-middleware@2.26.1)(webpack@5.103.0(esbuild@0.19.12))
       '@types/humanize-duration':
         specifier: ^3.27.4
         version: 3.27.4
@@ -165,6 +165,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.7)
+      '@wagmi/cli':
+        specifier: ^2.1.2
+        version: 2.1.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)
       eslint:
         specifier: 'catalog:'
         version: 9.39.1(jiti@2.6.1)
@@ -9120,6 +9123,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp@0.8.4:
     resolution: {integrity: sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==}
@@ -9931,9 +9935,6 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
-  web-solc@0.5.1:
-    resolution: {integrity: sha512-Z/hBplZq1+4i4bYeIeD9N3vP1BLUBXpSDa4h0Ipm2Z2cHv7x7DtZ2zFb0E1L1VZo4BF+OJGVtGlT+nTUXGgncQ==}
-
   web-streams-polyfill@3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
@@ -9996,6 +9997,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -13481,7 +13483,7 @@ snapshots:
     dependencies:
       playwright: 1.57.0
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.103.0(esbuild@0.25.10))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.103.0(esbuild@0.19.12))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.47.0
@@ -13491,7 +13493,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
     optionalDependencies:
       type-fest: 4.41.0
       webpack-hot-middleware: 2.26.1
@@ -14207,10 +14209,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
 
-  '@storybook/addon-docs@10.1.7(@types/react@19.2.7)(esbuild@0.25.10)(rollup@4.52.0)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack@5.103.0(esbuild@0.25.10))':
+  '@storybook/addon-docs@10.1.7(@types/react@19.2.7)(esbuild@0.19.12)(rollup@4.52.0)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack@5.103.0(esbuild@0.19.12))':
     dependencies:
       '@mdx-js/react': 3.0.1(@types/react@19.2.7)(react@19.2.3)
-      '@storybook/csf-plugin': 10.1.7(esbuild@0.25.10)(rollup@4.52.0)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack@5.103.0(esbuild@0.25.10))
+      '@storybook/csf-plugin': 10.1.7(esbuild@0.19.12)(rollup@4.52.0)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack@5.103.0(esbuild@0.19.12))
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@storybook/react-dom-shim': 10.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       react: 19.2.3
@@ -14264,23 +14266,23 @@ snapshots:
       ts-dedent: 2.2.0
       vite: 7.1.6(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1)
 
-  '@storybook/builder-webpack5@10.1.7(esbuild@0.25.10)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))':
+  '@storybook/builder-webpack5@10.1.7(esbuild@0.19.12)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))':
     dependencies:
       '@storybook/core-webpack': 10.1.7(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@vitest/mocker': 3.2.4(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 7.1.2(webpack@5.103.0(esbuild@0.25.10))
+      css-loader: 7.1.2(webpack@5.103.0(esbuild@0.19.12))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.103.0(esbuild@0.25.10))
-      html-webpack-plugin: 5.6.5(webpack@5.103.0(esbuild@0.25.10))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.103.0(esbuild@0.19.12))
+      html-webpack-plugin: 5.6.5(webpack@5.103.0(esbuild@0.19.12))
       magic-string: 0.30.17
       storybook: 10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
-      style-loader: 4.0.0(webpack@5.103.0(esbuild@0.25.10))
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.10)(webpack@5.103.0(esbuild@0.25.10))
+      style-loader: 4.0.0(webpack@5.103.0(esbuild@0.19.12))
+      terser-webpack-plugin: 5.3.16(esbuild@0.19.12)(webpack@5.103.0(esbuild@0.19.12))
       ts-dedent: 2.2.0
-      webpack: 5.103.0(esbuild@0.25.10)
-      webpack-dev-middleware: 6.1.3(webpack@5.103.0(esbuild@0.25.10))
+      webpack: 5.103.0(esbuild@0.19.12)
+      webpack-dev-middleware: 6.1.3(webpack@5.103.0(esbuild@0.19.12))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -14338,15 +14340,15 @@ snapshots:
       storybook: 10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.1.7(esbuild@0.25.10)(rollup@4.52.0)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack@5.103.0(esbuild@0.25.10))':
+  '@storybook/csf-plugin@10.1.7(esbuild@0.19.12)(rollup@4.52.0)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack@5.103.0(esbuild@0.19.12))':
     dependencies:
       storybook: 10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.25.10
+      esbuild: 0.19.12
       rollup: 4.52.0
       vite: 7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1)
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   '@storybook/csf-plugin@9.1.7(storybook@9.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.6(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1)))':
     dependencies:
@@ -14365,7 +14367,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@storybook/nextjs@10.1.7(esbuild@0.25.10)(next@16.1.4(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(type-fest@4.41.0)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack-hot-middleware@2.26.1)(webpack@5.103.0(esbuild@0.25.10))':
+  '@storybook/nextjs@10.1.7(esbuild@0.19.12)(next@16.1.4(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(type-fest@4.41.0)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))(webpack-hot-middleware@2.26.1)(webpack@5.103.0(esbuild@0.19.12))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
@@ -14380,33 +14382,33 @@ snapshots:
       '@babel/preset-react': 7.28.5(@babel/core@7.28.4)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.4)
       '@babel/runtime': 7.28.4
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.103.0(esbuild@0.25.10))
-      '@storybook/builder-webpack5': 10.1.7(esbuild@0.25.10)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))
-      '@storybook/preset-react-webpack': 10.1.7(esbuild@0.25.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.103.0(esbuild@0.19.12))
+      '@storybook/builder-webpack5': 10.1.7(esbuild@0.19.12)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.3)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.44.0)(tsx@4.20.3)(yaml@2.8.1))
+      '@storybook/preset-react-webpack': 10.1.7(esbuild@0.19.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)
       '@storybook/react': 10.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)
       '@types/semver': 7.5.6
-      babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.103.0(esbuild@0.25.10))
-      css-loader: 6.11.0(webpack@5.103.0(esbuild@0.25.10))
+      babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.103.0(esbuild@0.19.12))
+      css-loader: 6.11.0(webpack@5.103.0(esbuild@0.19.12))
       image-size: 2.0.2
       loader-utils: 3.3.1
       next: 16.1.4(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.103.0(esbuild@0.25.10))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.103.0(esbuild@0.19.12))
       postcss: 8.5.6
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.103.0(esbuild@0.25.10))
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.103.0(esbuild@0.19.12))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 16.0.6(webpack@5.103.0(esbuild@0.25.10))
+      sass-loader: 16.0.6(webpack@5.103.0(esbuild@0.19.12))
       semver: 7.7.3
       storybook: 10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
-      style-loader: 3.3.4(webpack@5.103.0(esbuild@0.25.10))
+      style-loader: 3.3.4(webpack@5.103.0(esbuild@0.19.12))
       styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.3)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -14427,10 +14429,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@10.1.7(esbuild@0.25.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@10.1.7(esbuild@0.19.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)':
     dependencies:
       '@storybook/core-webpack': 10.1.7(storybook@10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.103.0(esbuild@0.25.10))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.103.0(esbuild@0.19.12))
       '@types/semver': 7.5.6
       magic-string: 0.30.17
       react: 19.2.3
@@ -14440,7 +14442,7 @@ snapshots:
       semver: 7.7.3
       storybook: 10.1.7(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       tsconfig-paths: 4.2.0
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14450,7 +14452,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.103.0(esbuild@0.25.10))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.103.0(esbuild@0.19.12))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
@@ -14460,7 +14462,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -14826,7 +14828,7 @@ snapshots:
       '@usecannon/web-solc': 0.5.1
       acorn: 8.15.0
       axios: 1.10.0(debug@4.4.3)
-      axios-retry: 4.5.0(axios@1.10.0(debug@4.4.3))
+      axios-retry: 4.5.0(axios@1.10.0)
       buffer: 6.0.3
       chalk: 4.1.2
       debug: 4.4.3
@@ -14884,9 +14886,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@usecannon/web-solc@0.5.1':
-    dependencies:
-      web-solc: 0.5.1
+  '@usecannon/web-solc@0.5.1': {}
 
   '@vanilla-extract/css@1.17.3':
     dependencies:
@@ -15066,7 +15066,7 @@ snapshots:
       ora: 6.3.1
       pathe: 1.1.2
       picocolors: 1.1.1
-      prettier: 3.6.2
+      prettier: 3.7.4
       viem: 2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     optionalDependencies:
@@ -15075,7 +15075,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@wagmi/connectors@6.1.0(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.1.0(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@base-org/account': 1.1.1(@types/react@19.1.13)(bufferutil@4.0.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.1.13)(bufferutil@4.0.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -15083,10 +15083,10 @@ snapshots:
       '@metamask/sdk': 0.33.1(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.19(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+      porto: 0.2.19(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       viem: 2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
@@ -15188,7 +15188,6 @@ snapshots:
       - immer
       - react
       - use-sync-external-store
-    optional: true
 
   '@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12))':
     dependencies:
@@ -16406,7 +16405,7 @@ snapshots:
 
   axe-core@4.11.0: {}
 
-  axios-retry@4.5.0(axios@1.10.0(debug@4.4.3)):
+  axios-retry@4.5.0(axios@1.10.0):
     dependencies:
       axios: 1.10.0(debug@4.4.3)
       is-retry-allowed: 2.2.0
@@ -16423,12 +16422,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
 
-  babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.103.0(esbuild@0.25.10)):
+  babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       '@babel/core': 7.28.4
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.4):
     dependencies:
@@ -17131,7 +17130,7 @@ snapshots:
       randombytes: 2.1.0
       randomfill: 1.0.4
 
-  css-loader@6.11.0(webpack@5.103.0(esbuild@0.25.10)):
+  css-loader@6.11.0(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -17142,9 +17141,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
-  css-loader@7.1.2(webpack@5.103.0(esbuild@0.25.10)):
+  css-loader@7.1.2(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -17155,7 +17154,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   css-select@4.3.0:
     dependencies:
@@ -18163,7 +18162,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.103.0(esbuild@0.25.10)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -18178,7 +18177,7 @@ snapshots:
       semver: 7.7.3
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   form-data@4.0.3:
     dependencies:
@@ -18531,7 +18530,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.44.0
 
-  html-webpack-plugin@5.6.5(webpack@5.103.0(esbuild@0.25.10)):
+  html-webpack-plugin@5.6.5(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -18539,7 +18538,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -19632,7 +19631,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.103.0(esbuild@0.25.10)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -19659,7 +19658,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   node-releases@2.0.19: {}
 
@@ -20215,9 +20214,9 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.19(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
+  porto@0.2.19(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.10.2
       idb-keyval: 6.2.1
       mipd: 0.0.7(typescript@5.9.3)
@@ -20271,14 +20270,14 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.1
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.103.0(esbuild@0.25.10)):
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       postcss: 8.5.6
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - typescript
 
@@ -21024,11 +21023,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.6(webpack@5.103.0(esbuild@0.25.10)):
+  sass-loader@16.0.6(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   saxes@6.0.0:
     dependencies:
@@ -21533,13 +21532,13 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  style-loader@3.3.4(webpack@5.103.0(esbuild@0.25.10)):
+  style-loader@3.3.4(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
-  style-loader@4.0.0(webpack@5.103.0(esbuild@0.25.10)):
+  style-loader@4.0.0(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   styled-jsx@5.1.6(@babel/core@7.28.4)(react@19.2.3):
     dependencies:
@@ -21617,16 +21616,16 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.10)(webpack@5.103.0(esbuild@0.25.10)):
+  terser-webpack-plugin@5.3.16(esbuild@0.19.12)(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.0
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
     optionalDependencies:
-      esbuild: 0.25.10
+      esbuild: 0.19.12
 
   terser@5.44.0:
     dependencies:
@@ -22517,7 +22516,7 @@ snapshots:
   wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.90.12(react@19.2.3)
-      '@wagmi/connectors': 6.1.0(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
+      '@wagmi/connectors': 6.1.0(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.18.2(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.1.13)(bufferutil@4.0.8)(encoding@0.1.13)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(@types/react@19.1.13)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.41.2(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.3
       use-sync-external-store: 1.4.0(react@19.2.3)
@@ -22591,10 +22590,6 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  web-solc@0.5.1:
-    dependencies:
-      semver: 7.7.3
-
   web-streams-polyfill@3.2.1: {}
 
   webcrypto-core@1.7.7:
@@ -22615,7 +22610,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-dev-middleware@6.1.3(webpack@5.103.0(esbuild@0.25.10)):
+  webpack-dev-middleware@6.1.3(webpack@5.103.0(esbuild@0.19.12)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -22623,7 +22618,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.103.0(esbuild@0.25.10)
+      webpack: 5.103.0(esbuild@0.19.12)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -22639,7 +22634,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.103.0(esbuild@0.25.10):
+  webpack@5.103.0(esbuild@0.19.12):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -22663,7 +22658,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.10)(webpack@5.103.0(esbuild@0.25.10))
+      terser-webpack-plugin: 5.3.16(esbuild@0.19.12)(webpack@5.103.0(esbuild@0.19.12))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -22929,7 +22924,6 @@ snapshots:
       '@types/react': 19.1.13
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
-    optional: true
 
   zustand@5.0.0(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,19 +3,20 @@ packages:
     - packages/*
 
 catalog:
+    "@tanstack/react-query": ^5.90.12
     eslint: ^9.39.1
     prettier: ^3.7.4
+    react: ^19.2.3
+    react-dom: ^19.2.3
     typescript: ^5.9.3
     viem: ^2.41.2
     wagmi: ^2.18.2
-    "@tanstack/react-query": ^5.90.12
-    react: "^19.2.3"
-    "react-dom": "^19.2.3"
 
 onlyBuiltDependencies:
     - "@parcel/watcher"
     - "@vercel/speed-insights"
     - bufferutil
+    - core-js-pure
     - esbuild
     - keccak
     - protobufjs

--- a/turbo.json
+++ b/turbo.json
@@ -41,7 +41,11 @@
             "cache": false
         },
         "codegen": {
-            "outputs": ["src/graphql/**", "src/contracts.ts"]
+            "outputs": [
+                "src/graphql/**",
+                "src/contracts.ts",
+                "src/generated/**"
+            ]
         },
         "dev": {
             "dependsOn": ["codegen"],

--- a/turbo.json
+++ b/turbo.json
@@ -32,9 +32,11 @@
             ]
         },
         "build-storybook": {
+            "dependsOn": ["codegen"],
             "outputs": ["dist/**", "storybook-static/**"]
         },
         "storybook": {
+            "dependsOn": ["codegen"],
             "outputs": ["dist/**", "storybook-static/**"]
         },
         "clean": {


### PR DESCRIPTION
# Summary

Code changes to add support for ERC-1155 deposits, single and batch. Code ported from the current rollups-explorer with refactoring to adapt to new data structures and remove unnecessary pieces.

A test can be performed using the latest Cartesi CLI, ensuring the mock is disabled (default). Also, a devnet deploy of an ERC-1155 multi-token is necessary. 

**PS:** Also, a quick refactoring in the ERC-20 was done, as the project now generates wagmi utility hooks for ERC-20, ERC-721, and ERC-1155 contracts.