### PR TITLE
feat: ERC-721 deposit

### DIFF
--- a/apps/dave/src/components/send/SendMenu.tsx
+++ b/apps/dave/src/components/send/SendMenu.tsx
@@ -92,7 +92,6 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                     <Text fw="500">ERC-20</Text>
                 </Menu.Item>
                 <Menu.Item
-                    disabled
                     leftSection={<TbCurrencyEthereum size={24} />}
                     onClick={(evt) => {
                         evt.stopPropagation();

--- a/apps/dave/src/components/send/SendModal.tsx
+++ b/apps/dave/src/components/send/SendModal.tsx
@@ -3,12 +3,13 @@ import type { Application } from "@cartesi/viem";
 import { Group, Modal, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { defaultTo, isNil, isNotNil } from "ramda";
-import { type FC } from "react";
+import { useCallback, type FC } from "react";
 import { useConfig } from "wagmi";
 import { BlockExplorerLink } from "../BlockExplorerLink";
 import type { TransactionFormSuccessData } from "../transactions/DepositFormTypes";
 import { ERC1155DepositForm } from "../transactions/ERC1155DepositForm";
 import { ERC20DepositForm } from "../transactions/ERC20DepositForm";
+import { ERC721DepositForm } from "../transactions/ERC721DepositForm";
 import { EtherDepositForm } from "../transactions/EtherDepositForm";
 import { useSendAction, useSendState } from "./hooks";
 import type { TransactionType } from "./SendContexts";
@@ -51,27 +52,30 @@ const SendModal: FC = () => {
     const actions = useSendAction();
     const config = useConfig();
 
-    const onSuccess = ({ receipt, type }: TransactionFormSuccessData) => {
-        const message = receipt?.transactionHash
-            ? {
-                  message: (
-                      <BlockExplorerLink
-                          value={receipt.transactionHash.toString()}
-                          type="tx"
-                          chain={config.chains[0]}
-                      />
-                  ),
-                  title: `${type} transaction completed`,
-              }
-            : { message: `${type} transaction completed.` };
+    const onSuccess = useCallback(
+        ({ receipt, type }: TransactionFormSuccessData) => {
+            const message = receipt?.transactionHash
+                ? {
+                      message: (
+                          <BlockExplorerLink
+                              value={receipt.transactionHash.toString()}
+                              type="tx"
+                              chain={config.chains[0]}
+                          />
+                      ),
+                      title: `${type} transaction completed`,
+                  }
+                : { message: `${type} transaction completed.` };
 
-        notifications.show({
-            withCloseButton: true,
-            autoClose: false,
-            color: "green",
-            ...message,
-        });
-    };
+            notifications.show({
+                withCloseButton: true,
+                autoClose: false,
+                color: "green",
+                ...message,
+            });
+        },
+        [config],
+    );
 
     if (!state) return "";
 
@@ -105,6 +109,11 @@ const SendModal: FC = () => {
             ) : state.transactionType === "deposit_erc1155Batch" ? (
                 <ERC1155DepositForm
                     mode="batch"
+                    application={state.application}
+                    onSuccess={onSuccess}
+                />
+            ) : state.transactionType === "deposit_erc721" ? (
+                <ERC721DepositForm
                     application={state.application}
                     onSuccess={onSuccess}
                 />

--- a/apps/dave/src/components/transactions/ERC721DepositForm/hooks/useERC721Approve.tsx
+++ b/apps/dave/src/components/transactions/ERC721DepositForm/hooks/useERC721Approve.tsx
@@ -1,0 +1,36 @@
+import { type Hex } from "viem";
+import { useWaitForTransactionReceipt } from "wagmi";
+import {
+    useSimulateErc721Approve,
+    useWriteErc721Approve,
+} from "../../../../generated/wagmi";
+
+interface Props {
+    erc721Address: Hex;
+    args: [operator: Hex, tokenId: bigint];
+    isQueryEnabled: boolean;
+}
+
+export const useERC721Approve = ({
+    erc721Address,
+    args,
+    isQueryEnabled,
+}: Props) => {
+    const approvePrepare = useSimulateErc721Approve({
+        address: erc721Address,
+        query: {
+            enabled: isQueryEnabled,
+        },
+        args,
+    });
+    const approve = useWriteErc721Approve();
+    const approveWait = useWaitForTransactionReceipt({
+        hash: approve.data,
+    });
+
+    return {
+        approve,
+        approvePrepare,
+        approveWait,
+    };
+};

--- a/apps/dave/src/components/transactions/ERC721DepositForm/hooks/useERC721PortalDeposit.tsx
+++ b/apps/dave/src/components/transactions/ERC721DepositForm/hooks/useERC721PortalDeposit.tsx
@@ -1,0 +1,43 @@
+import {
+    useSimulateErc721PortalDepositErc721Token,
+    useWriteErc721PortalDepositErc721Token,
+} from "@cartesi/wagmi";
+import type { Hex } from "viem";
+import { useWaitForTransactionReceipt } from "wagmi";
+
+interface Props {
+    contractParams: {
+        args: [
+            erc721Address: Hex,
+            appAddress: Hex,
+            tokenId: bigint,
+            baseLayerData: Hex,
+            execLayerData: Hex,
+        ];
+    };
+    isQueryEnabled: boolean;
+}
+
+export const useERC721PortalDeposit = ({
+    contractParams,
+    isQueryEnabled,
+}: Props) => {
+    const prepare = useSimulateErc721PortalDepositErc721Token({
+        args: contractParams.args,
+        query: {
+            enabled: isQueryEnabled,
+        },
+    });
+
+    const execute = useWriteErc721PortalDepositErc721Token();
+
+    const wait = useWaitForTransactionReceipt({
+        hash: execute.data,
+    });
+
+    return {
+        prepare,
+        execute,
+        wait,
+    };
+};

--- a/apps/dave/src/components/transactions/ERC721DepositForm/hooks/useERC721Reads.tsx
+++ b/apps/dave/src/components/transactions/ERC721DepositForm/hooks/useERC721Reads.tsx
@@ -1,0 +1,49 @@
+import { BaseError, type Hex, erc721Abi } from "viem";
+import { useReadContracts } from "wagmi";
+import useWatchQueryOnBlockChange from "../../hooks/useWatchQueryOnBlockChange";
+
+interface Props {
+    erc721Address: Hex;
+    ownerAddress: Hex;
+}
+
+export const useERC721Reads = ({ erc721Address, ownerAddress }: Props) => {
+    const erc721Contract = {
+        abi: erc721Abi,
+        address: erc721Address,
+    };
+
+    const erc721 = useReadContracts({
+        contracts: [
+            { ...erc721Contract, functionName: "symbol" },
+            {
+                ...erc721Contract,
+                functionName: "balanceOf",
+                args: [ownerAddress!],
+            },
+        ],
+    });
+
+    useWatchQueryOnBlockChange(erc721.queryKey);
+
+    const { isLoading, isSuccess } = erc721;
+    const symbol = erc721.data?.[0].result ?? "";
+    const balance = erc721.data?.[1].result;
+    const errors = erc721.data
+        ? erc721.data
+              .filter((d) => d.error instanceof Error)
+              .map((d) => (d.error as BaseError).shortMessage)
+        : [];
+    const hasPositiveBalance = balance !== undefined && balance > 0;
+
+    return {
+        symbol,
+        balance,
+        errors,
+        hasPositiveBalance,
+        isLoading,
+        isSuccess,
+    };
+};
+
+export type UseERC721ReadsReturn = ReturnType<typeof useERC721Reads>;

--- a/apps/dave/src/components/transactions/ERC721DepositForm/index.tsx
+++ b/apps/dave/src/components/transactions/ERC721DepositForm/index.tsx
@@ -1,0 +1,342 @@
+import type { Application } from "@cartesi/viem";
+import { erc721PortalAddress } from "@cartesi/wagmi";
+import {
+    Button,
+    Collapse,
+    Flex,
+    Group,
+    Loader,
+    NumberInput,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+    Textarea,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useDisclosure } from "@mantine/hooks";
+import { isEmpty } from "ramda";
+import { type FC, useEffect, useMemo, useState } from "react";
+import {
+    TbCheck,
+    TbChevronDown,
+    TbChevronUp,
+    TbPigMoney,
+} from "react-icons/tb";
+import { type Hex, getAddress, isAddress, isHex, zeroAddress } from "viem";
+import { useAccount } from "wagmi";
+import type { TransactionFormSuccessData } from "../DepositFormTypes";
+import TransactionDetails from "../TransactionDetails";
+import { TransactionProgress } from "../TransactionProgress";
+import { transactionState } from "../TransactionState";
+import useTokensOfOwnerByIndex from "../hooks/useTokensOfOwnerByIndex";
+import { useERC721Approve } from "./hooks/useERC721Approve";
+import { useERC721PortalDeposit } from "./hooks/useERC721PortalDeposit";
+import { useERC721Reads } from "./hooks/useERC721Reads";
+
+export interface ERC721DepositFormProps {
+    application: Application;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
+}
+
+export const ERC721DepositForm: FC<ERC721DepositFormProps> = (props) => {
+    const { application, onSuccess } = props;
+    const [advanced, { toggle: toggleAdvanced }] = useDisclosure(false);
+    const { address } = useAccount();
+    const [depositedTokens, setDepositedTokens] = useState<bigint[]>([]);
+
+    const form = useForm({
+        validateInputOnChange: true,
+        initialValues: {
+            application: application.applicationAddress,
+            erc721Address: "",
+            tokenId: "",
+            baseLayerData: "0x",
+            execLayerData: "0x",
+        },
+        validate: {
+            application: (value) => {
+                if (isEmpty(value)) return "Application address is required!";
+                if (!isAddress(value)) return "Invalid application address";
+                return null;
+            },
+            erc721Address: (value) => {
+                if (isEmpty(value)) return "ERC-721 address is required!";
+                if (!isAddress(value)) return "Invalid ERC-721 address";
+                return null;
+            },
+            tokenId: (value) =>
+                value !== "" && Number(value) >= 0 ? null : "Invalid token ID",
+            baseLayerData: (value) =>
+                isHex(value) ? null : "Base data must be a valid hex string!",
+            execLayerData: (value) =>
+                isHex(value) ? null : "Extra data must be a valid hex string!",
+        },
+        transformValues: (values) => ({
+            address: isAddress(values.application)
+                ? getAddress(values.application)
+                : zeroAddress,
+            erc721Address: isAddress(values.erc721Address)
+                ? getAddress(values.erc721Address)
+                : zeroAddress,
+            erc721ContractAddress: isAddress(values.erc721Address)
+                ? getAddress(values.erc721Address)
+                : undefined,
+            tokenIdBigInt:
+                values.tokenId !== "" ? BigInt(values.tokenId) : undefined,
+            baseLayerData: values.baseLayerData
+                ? (values.baseLayerData as Hex)
+                : "0x",
+            execLayerData: values.execLayerData
+                ? (values.execLayerData as Hex)
+                : "0x",
+        }),
+    });
+
+    const {
+        address: applicationAddress,
+        erc721Address,
+        erc721ContractAddress,
+        baseLayerData,
+        execLayerData,
+        tokenIdBigInt,
+    } = form.getTransformedValues();
+
+    const erc721 = useERC721Reads({
+        erc721Address: erc721ContractAddress!,
+        ownerAddress: address!,
+    });
+
+    const {
+        symbol,
+        balance,
+        errors: erc721Errors,
+        hasPositiveBalance,
+    } = erc721;
+
+    const { approve, approvePrepare, approveWait } = useERC721Approve({
+        erc721Address,
+        args: [erc721PortalAddress, tokenIdBigInt!],
+        isQueryEnabled: tokenIdBigInt !== undefined && hasPositiveBalance,
+    });
+
+    const {
+        prepare: depositPrepare,
+        execute: deposit,
+        wait: depositWait,
+    } = useERC721PortalDeposit({
+        contractParams: {
+            args: [
+                erc721Address,
+                applicationAddress,
+                tokenIdBigInt!,
+                baseLayerData,
+                execLayerData,
+            ],
+        },
+        isQueryEnabled:
+            tokenIdBigInt !== undefined &&
+            hasPositiveBalance &&
+            !form.errors.erc721Address &&
+            !form.errors.application &&
+            isHex(baseLayerData) &&
+            isHex(execLayerData) &&
+            approveWait.status === "success",
+    });
+
+    const needApproval = tokenIdBigInt !== undefined && hasPositiveBalance;
+    const canDeposit =
+        hasPositiveBalance && tokenIdBigInt !== undefined && tokenIdBigInt >= 0;
+
+    const tokensOfOwnerByIndex = useTokensOfOwnerByIndex(
+        erc721ContractAddress!,
+        address!,
+        depositedTokens,
+    );
+
+    // const { data, status, error } = approvePrepare;
+
+    const { disabled: approveDisabled, loading: approveLoading } =
+        transactionState(approvePrepare, approve, approveWait, true);
+    const { disabled: depositDisabled, loading: depositLoading } =
+        transactionState(depositPrepare, deposit, depositWait, true);
+    const isDepositDisabled =
+        depositDisabled ||
+        !canDeposit ||
+        !form.isValid() ||
+        approveWait.status !== "success";
+    const isApproveDisabled =
+        approveDisabled || !needApproval || !isDepositDisabled;
+
+    const txDetails = useMemo(
+        () => [
+            {
+                legend: "Application Address",
+                text: application.applicationAddress,
+            },
+            {
+                legend: "Portal Address",
+                text: erc721PortalAddress,
+            },
+        ],
+        [application.applicationAddress],
+    );
+
+    useEffect(() => {
+        if (tokensOfOwnerByIndex.tokenIds.length === 0) {
+            form.setFieldValue("tokenId", "");
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tokensOfOwnerByIndex]);
+
+    useEffect(() => {
+        if (depositWait.isSuccess) {
+            onSuccess({ receipt: depositWait.data, type: "ERC-721" });
+            setDepositedTokens((tokens) => [
+                ...tokens,
+                tokenIdBigInt as bigint,
+            ]);
+            form.reset();
+            approve.reset();
+            deposit.reset();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [depositWait, tokenIdBigInt, onSuccess]);
+
+    return (
+        <form data-testid="erc721-deposit-form">
+            <Stack>
+                <TransactionDetails details={txDetails} />
+                <TextInput
+                    label="ERC-721"
+                    description="The ERC-721 smart contract address"
+                    placeholder="0x"
+                    withAsterisk
+                    rightSection={erc721.isLoading && <Loader size="xs" />}
+                    {...form.getInputProps("erc721Address")}
+                    error={erc721Errors[0] || form.errors.erc721Address}
+                    data-testid="erc721Address"
+                />
+                <Collapse in={erc721.isSuccess && erc721Errors.length == 0}>
+                    <Stack>
+                        {tokensOfOwnerByIndex.tokenIds.length > 0 ? (
+                            <Select
+                                label="Token ID"
+                                description="Token ID to deposit"
+                                placeholder="Token ID"
+                                withAsterisk
+                                data-testid="token-id-select"
+                                data={tokensOfOwnerByIndex.tokenIds.map(
+                                    (tokenId) => ({
+                                        value: String(tokenId),
+                                        label: String(tokenId),
+                                    }),
+                                )}
+                                onChange={(nextValue) => {
+                                    form.setFieldValue(
+                                        "tokenId",
+                                        nextValue ?? "",
+                                    );
+                                    approve.reset();
+                                    deposit.reset();
+                                }}
+                            />
+                        ) : (
+                            <NumberInput
+                                label="Token ID"
+                                description="Token ID to deposit"
+                                placeholder="Token ID"
+                                allowNegative={false}
+                                withAsterisk
+                                data-testid="token-id-input"
+                                disabled={!hasPositiveBalance}
+                                {...form.getInputProps("tokenId")}
+                            />
+                        )}
+
+                        <Flex
+                            mt="-sm"
+                            justify={"space-between"}
+                            direction={"row"}
+                        >
+                            <Flex rowGap={6} c="dark.2">
+                                <Text id="token-balance" fz="xs" mx={4}>
+                                    Balance:{" "}
+                                    {balance === undefined
+                                        ? ""
+                                        : `${Number(balance)} ${symbol}`}
+                                </Text>
+                            </Flex>
+                        </Flex>
+                    </Stack>
+                </Collapse>
+                <Collapse in={advanced}>
+                    <Textarea
+                        label="Base data"
+                        data-testid="base-data-input"
+                        description="Base execution layer data handled by the application"
+                        mb={16}
+                        {...form.getInputProps("baseLayerData")}
+                    />
+
+                    <Textarea
+                        label="Extra data"
+                        data-testid="extra-data-input"
+                        description="Extra execution layer data handled by the application"
+                        {...form.getInputProps("execLayerData")}
+                    />
+                </Collapse>
+                <Collapse in={approve.isPending || approveWait.isLoading}>
+                    <TransactionProgress
+                        prepare={approvePrepare}
+                        execute={approve}
+                        wait={approveWait}
+                        confirmationMessage="Approve transaction confirmed"
+                    />
+                </Collapse>
+                <Collapse in={!deposit.isIdle && !isDepositDisabled}>
+                    <TransactionProgress
+                        prepare={depositPrepare}
+                        execute={deposit}
+                        wait={depositWait}
+                    />
+                </Collapse>
+                <Group justify="right">
+                    <Button
+                        leftSection={
+                            advanced ? <TbChevronUp /> : <TbChevronDown />
+                        }
+                        size="xs"
+                        visibleFrom="sm"
+                        variant="transparent"
+                        onClick={toggleAdvanced}
+                    >
+                        Advanced
+                    </Button>
+                    <Button
+                        variant="filled"
+                        disabled={isApproveDisabled}
+                        leftSection={<TbCheck />}
+                        loading={approveLoading}
+                        onClick={() =>
+                            approve.writeContract(approvePrepare.data!.request)
+                        }
+                    >
+                        Approve
+                    </Button>
+                    <Button
+                        variant="filled"
+                        disabled={isDepositDisabled}
+                        leftSection={<TbPigMoney />}
+                        loading={depositLoading}
+                        onClick={() =>
+                            deposit.writeContract(depositPrepare.data!.request)
+                        }
+                    >
+                        Deposit
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};


### PR DESCRIPTION
# Summary
Code changes to add support for ERC-721 deposits. Code ported from the current rollups-explorer with refactoring to adapt to new data structures and remove unnecessary pieces.

A test can be performed using the latest Cartesi CLI, ensuring the mock is disabled (default). Also, a devnet deploy of an ERC-721 NFT is necessary.

PS: Later, I will create an issue or two to improve the token ownership feedback when the contract does not implement the [`enumeration extension`](https://eips.ethereum.org/EIPS/eip-721#:~:text=enumeration%20extension), so that non-owned NFT ids will not just keep everything disabled **without a clear reason**. Also, revisit the hook that made calls to the `tokenOfOwnerByIndex ` method when the extension is implemented by the contract.