### PR TITLE
feat: add send generic input

### DIFF
--- a/apps/dave/src/components/send/SendContexts.tsx
+++ b/apps/dave/src/components/send/SendContexts.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { Application } from "@cartesi/viem";
 import { createContext, type ActionDispatch } from "react";
+import type { DbSpecification } from "../specification/types";
 
 // Actions
 type CloseModal = { type: "close_modal" };
@@ -15,10 +16,14 @@ export type DepositType =
 export type TransactionType = DepositType | InputType;
 
 type Deposit = { type: DepositType; payload: { application: Application } };
-type GenericInput = { type: InputType; payload: { application: Application } };
+type GenericInput = {
+    type: InputType;
+    payload: { application: Application; specifications: DbSpecification[] };
+};
 
 type SendState = {
     application: Application;
+    specifications: DbSpecification[];
     transactionType: TransactionType;
     timestamp: number;
 } | null;

--- a/apps/dave/src/components/send/SendMenu.tsx
+++ b/apps/dave/src/components/send/SendMenu.tsx
@@ -3,17 +3,22 @@ import type { Application } from "@cartesi/viem";
 import { Button, Group, Menu, Text } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useChainModal, useConnectModal } from "@rainbow-me/rainbowkit";
-import { isNil } from "ramda";
+import { filter, isNil } from "ramda";
 import type { FC } from "react";
 import { TbCoins, TbCurrencyEthereum, TbInbox, TbSend } from "react-icons/tb";
 import { useAccount } from "wagmi";
 import { useSelectedNodeConnection } from "../connection/hooks";
+import { useSpecification } from "../specification/hooks/useSpecification";
+import type { DbSpecification } from "../specification/types";
 import { useSendAction } from "./hooks";
 
 type SendMenuProps = { application: Application };
 
+const jsonAbiOnly = (spec: DbSpecification) => spec.mode === "json_abi";
+
 const SendMenu: FC<SendMenuProps> = ({ application }) => {
     const selectedConnection = useSelectedNodeConnection();
+    const { listSpecifications } = useSpecification();
     const [opened, handlers] = useDisclosure(false);
     const actions = useSendAction();
     const account = useAccount();
@@ -54,11 +59,14 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
 
             <Menu.Dropdown>
                 <Menu.Item
-                    disabled
                     leftSection={<TbInbox size={24} />}
                     onClick={(evt) => {
                         evt.stopPropagation();
-                        actions.sendGenericInput(application);
+                        const specifications = filter(
+                            jsonAbiOnly,
+                            listSpecifications() ?? [],
+                        );
+                        actions.sendGenericInput(application, specifications);
                         handlers.close();
                     }}
                 >

--- a/apps/dave/src/components/send/SendModal.tsx
+++ b/apps/dave/src/components/send/SendModal.tsx
@@ -11,6 +11,10 @@ import { ERC1155DepositForm } from "../transactions/ERC1155DepositForm";
 import { ERC20DepositForm } from "../transactions/ERC20DepositForm";
 import { ERC721DepositForm } from "../transactions/ERC721DepositForm";
 import { EtherDepositForm } from "../transactions/EtherDepositForm";
+import {
+    GenericInputForm,
+    type GenericInputFormSpecification,
+} from "../transactions/GenericInputForm";
 import { useSendAction, useSendState } from "./hooks";
 import type { TransactionType } from "./SendContexts";
 
@@ -115,6 +119,14 @@ const SendModal: FC = () => {
             ) : state.transactionType === "deposit_erc721" ? (
                 <ERC721DepositForm
                     application={state.application}
+                    onSuccess={onSuccess}
+                />
+            ) : state.transactionType === "generic_input" ? (
+                <GenericInputForm
+                    application={state.application}
+                    specifications={
+                        state.specifications as GenericInputFormSpecification[]
+                    }
                     onSuccess={onSuccess}
                 />
             ) : null}

--- a/apps/dave/src/components/send/SendProvider.tsx
+++ b/apps/dave/src/components/send/SendProvider.tsx
@@ -13,10 +13,17 @@ const sendReducer: SendReducer = (state, action) => {
         case "deposit_erc721":
         case "deposit_erc1155Single":
         case "deposit_erc1155Batch":
+            return {
+                transactionType: action.type,
+                application: action.payload.application,
+                specifications: [],
+                timestamp: Date.now(),
+            };
         case "generic_input":
             return {
                 transactionType: action.type,
                 application: action.payload.application,
+                specifications: action.payload.specifications,
                 timestamp: Date.now(),
             };
         case "close_modal":

--- a/apps/dave/src/components/send/hooks.tsx
+++ b/apps/dave/src/components/send/hooks.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { Application } from "@cartesi/viem";
 import { useContext } from "react";
+import type { DbSpecification } from "../specification/types";
 import { SendActionContext, SendStateContext } from "./SendContexts";
 
 export const useSendState = () => {
@@ -27,8 +28,14 @@ export const useSendAction = () => {
                 type: "deposit_erc1155Batch",
                 payload: { application },
             }),
-        sendGenericInput: (application: Application) =>
-            dispatch({ type: "generic_input", payload: { application } }),
+        sendGenericInput: (
+            application: Application,
+            specifications: DbSpecification[],
+        ) =>
+            dispatch({
+                type: "generic_input",
+                payload: { application, specifications },
+            }),
         closeModal: () => dispatch({ type: "close_modal" }),
     };
 };

--- a/apps/dave/src/components/transactions/GenericInputForm/AbiFields.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/AbiFields.tsx
@@ -1,0 +1,163 @@
+"use client";
+import {
+    Flex,
+    Group,
+    SegmentedControl,
+    Select,
+    Text,
+    Textarea,
+    Tooltip,
+} from "@mantine/core";
+import type { FC } from "react";
+import { TbHelp } from "react-icons/tb";
+import { AbiFunctionName } from "./AbiFunctionName";
+import { AbiFunctionParams } from "./AbiFunctionParams";
+import { AbiParameter } from "./AbiParameter";
+import { useFormContext } from "./context";
+import type {
+    FormAbiMethod,
+    FormSpecification,
+    SpecificationMode,
+} from "./types";
+import { resetAbiFunctionParams } from "./utils";
+
+export interface AbiFieldsProps {
+    specifications: FormSpecification[];
+}
+
+export const AbiFields: FC<AbiFieldsProps> = ({ specifications }) => {
+    const form = useFormContext();
+    const { abiMethod, specificationMode } = form.getTransformedValues();
+    const specificationOptions = specifications.map((s) => ({
+        value: s.id,
+        label: s.name,
+    }));
+    const hasSpecifications = specifications.length > 0;
+
+    return (
+        <>
+            <Select
+                label="ABI method"
+                description="Select how to attach an ABI"
+                data-testid="abi-method-select"
+                allowDeselect={false}
+                withAsterisk
+                data={[
+                    {
+                        value: "existing",
+                        label: "ABI from an existing JSON_ABI specification",
+                        disabled: !hasSpecifications,
+                    },
+                    { value: "new", label: "New ABI" },
+                ]}
+                {...form.getInputProps("abiMethod")}
+                onChange={(nextValue) => {
+                    form.setFieldValue("abiMethod", nextValue as FormAbiMethod);
+                    form.setFieldValue("specificationId", "");
+                    form.setFieldValue("abiFunctionName", "");
+                    form.setFieldValue("humanAbi", "");
+                    form.setFieldValue("abiParam", "");
+                    form.setFieldValue("savedAbiParam", "");
+                    form.setFieldValue("specificationMode", "json_abi");
+                    resetAbiFunctionParams(form, []);
+                }}
+            />
+
+            {abiMethod === "new" ? (
+                <>
+                    <SegmentedControl
+                        aria-label="Specification Mode"
+                        data={[
+                            {
+                                label: "JSON ABI",
+                                value: "json_abi",
+                            },
+                            {
+                                label: "ABI Parameters",
+                                value: "abi_params",
+                            },
+                        ]}
+                        {...form.getInputProps("specificationMode")}
+                        onChange={(nextValue) => {
+                            form.setFieldValue(
+                                "specificationMode",
+                                nextValue as SpecificationMode,
+                            );
+
+                            form.setFieldValue("specificationId", "");
+                            form.setFieldValue("abiFunctionName", "");
+                            form.setFieldValue("humanAbi", "");
+                            form.setFieldValue("abiParam", "");
+                            form.setFieldValue("savedAbiParam", "");
+                            resetAbiFunctionParams(form, []);
+                        }}
+                    />
+
+                    {specificationMode === "json_abi" ? (
+                        <Textarea
+                            data-testid="json-abi-textarea"
+                            resize="vertical"
+                            description="Define signatures in Human readable format"
+                            placeholder="function balanceOf(address owner) view returns (uint256) event Transfer(address indexed from, address indexed to, uint256 amount)"
+                            rows={5}
+                            label={
+                                <Group justify="flex-start" gap="3">
+                                    <Text size="sm">ABI</Text>
+                                    <Tooltip
+                                        multiline
+                                        label="Define the signature without wrapping it on quotes nor adding comma at the end to separate. Just hit enter and keep defining your signatures"
+                                        withArrow
+                                        w="300"
+                                    >
+                                        <Flex direction="column-reverse">
+                                            <TbHelp />
+                                        </Flex>
+                                    </Tooltip>
+                                </Group>
+                            }
+                            {...form.getInputProps("humanAbi")}
+                            onChange={(event) => {
+                                const nextValue = event.target.value;
+                                form.setFieldValue("humanAbi", nextValue);
+                                form.validateField("humanAbi");
+                                form.setFieldValue("abiFunctionName", "");
+                            }}
+                        />
+                    ) : (
+                        <AbiParameter />
+                    )}
+                </>
+            ) : (
+                <Select
+                    label="Specifications"
+                    description="Available JSON_ABI specifications"
+                    placeholder="Select specification"
+                    data={specificationOptions}
+                    allowDeselect={false}
+                    withAsterisk
+                    {...form.getInputProps("specificationId")}
+                    onChange={(nextValue) => {
+                        form.setFieldValue(
+                            "specificationId",
+                            nextValue as string,
+                        );
+                        form.setFieldValue("abiFunctionName", "");
+                        resetAbiFunctionParams(form, []);
+                    }}
+                />
+            )}
+
+            <AbiFunctionName />
+            <AbiFunctionParams />
+
+            <Textarea
+                label="Hex value"
+                description="Encoded hex value for the application"
+                readOnly
+                value={
+                    form.isValid() ? form.getInputProps("rawInput").value : "0x"
+                }
+            />
+        </>
+    );
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/AbiFunctionName.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/AbiFunctionName.tsx
@@ -1,0 +1,125 @@
+"use client";
+import { Alert, Combobox, Input, InputBase, useCombobox } from "@mantine/core";
+import { useCallback } from "react";
+import { TbAlertCircle } from "react-icons/tb";
+import type { AbiFunction } from "viem";
+import { useFormContext } from "./context";
+import { FunctionSignature } from "./FunctionSignature";
+import type { AbiInputParam, GenericFormAbiFunction } from "./types";
+import { resetAbiFunctionParams } from "./utils";
+
+export const AbiFunctionName = () => {
+    const form = useFormContext();
+    const { abiMethod, abiFunction, selectedSpecification, specificationMode } =
+        form.getTransformedValues();
+    const combobox = useCombobox({
+        onDropdownClose: () => combobox.resetSelectedOption(),
+    });
+    const specificationFunctions = (
+        (selectedSpecification?.abi as GenericFormAbiFunction[]) ?? []
+    ).filter((item) => item.type === "function");
+
+    const onChangeAbiFunctionName = useCallback(
+        (abiFunctionName: string) => {
+            combobox.closeDropdown();
+            form.setFieldValue("abiFunctionName", abiFunctionName);
+
+            const nextAbiFunction = (
+                (selectedSpecification?.abi as AbiFunction[]) ?? []
+            ).find((abiFunction) => abiFunction.name === abiFunctionName);
+
+            if (nextAbiFunction) {
+                resetAbiFunctionParams(
+                    form,
+                    nextAbiFunction.inputs as AbiInputParam[],
+                );
+            }
+        },
+        [combobox, form, selectedSpecification],
+    );
+
+    return (
+        <>
+            {(abiMethod === "existing" || specificationMode === "json_abi") &&
+                selectedSpecification && (
+                    <>
+                        {specificationFunctions.length > 0 ? (
+                            <Combobox
+                                store={combobox}
+                                onOptionSubmit={onChangeAbiFunctionName}
+                            >
+                                <Combobox.Target>
+                                    <InputBase
+                                        component="button"
+                                        type="button"
+                                        pointer
+                                        label="ABI Function"
+                                        description="Available ABI functions"
+                                        rightSection={<Combobox.Chevron />}
+                                        rightSectionPointerEvents="none"
+                                        withAsterisk
+                                        {...form.getInputProps(
+                                            "abiFunctionName",
+                                        )}
+                                        style={{ overflow: "hidden" }}
+                                        onClick={() =>
+                                            combobox.toggleDropdown()
+                                        }
+                                    >
+                                        {abiFunction ? (
+                                            <FunctionSignature
+                                                abiFunction={abiFunction}
+                                            />
+                                        ) : (
+                                            <Input.Placeholder>
+                                                Select function
+                                            </Input.Placeholder>
+                                        )}
+                                    </InputBase>
+                                </Combobox.Target>
+
+                                <Combobox.Dropdown>
+                                    <Combobox.Options>
+                                        {specificationFunctions.map(
+                                            (abiFunction) => {
+                                                const params =
+                                                    abiFunction.inputs
+                                                        .map(
+                                                            (input) =>
+                                                                `${input.type} ${input.name}`,
+                                                        )
+                                                        .join(", ");
+
+                                                return (
+                                                    <Combobox.Option
+                                                        key={`${abiFunction.name}-${params}`}
+                                                        value={abiFunction.name}
+                                                    >
+                                                        <FunctionSignature
+                                                            abiFunction={
+                                                                abiFunction
+                                                            }
+                                                        />
+                                                    </Combobox.Option>
+                                                );
+                                            },
+                                        )}
+                                    </Combobox.Options>
+                                </Combobox.Dropdown>
+                            </Combobox>
+                        ) : (
+                            <Alert
+                                variant="light"
+                                color="blue"
+                                icon={<TbAlertCircle />}
+                                data-testid="no-functions-alert"
+                            >
+                                No ABI functions available for this
+                                specification.
+                            </Alert>
+                        )}
+                    </>
+                )}
+        </>
+    );
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/AbiFunctionParams.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/AbiFunctionParams.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { Alert, Stack, Text, TextInput } from "@mantine/core";
+import { Fragment } from "react";
+import { TbAlertCircle } from "react-icons/tb";
+import { useFormContext } from "./context";
+import { InputLabel } from "./FunctionSignature";
+import { TupleComponents } from "./TupleComponents";
+import type { AbiInputParam } from "./types";
+
+export const AbiFunctionParams = () => {
+    const form = useFormContext();
+    const { abiFunction } = form.getTransformedValues();
+    const abiFunctionParams = form.getInputProps("abiFunctionParams");
+
+    return (
+        <>
+            {abiFunction ? (
+                <Stack>
+                    {abiFunction.inputs.length > 0 ? (
+                        <>
+                            {abiFunction.inputs.map((input) => {
+                                const inputIndex =
+                                    abiFunctionParams.value.findIndex(
+                                        (p: AbiInputParam) => p.id === input.id,
+                                    );
+
+                                return (
+                                    <Fragment key={input.id}>
+                                        {input.type === "tuple" ? (
+                                            <TupleComponents
+                                                input={input as AbiInputParam}
+                                            />
+                                        ) : (
+                                            <TextInput
+                                                label={
+                                                    <InputLabel input={input} />
+                                                }
+                                                placeholder={`Enter ${input.type} value`}
+                                                withAsterisk
+                                                {...form.getInputProps(
+                                                    `abiFunctionParams.${inputIndex}.value`,
+                                                )}
+                                            />
+                                        )}
+                                    </Fragment>
+                                );
+                            })}
+                        </>
+                    ) : (
+                        <Alert
+                            variant="light"
+                            color="blue"
+                            icon={<TbAlertCircle />}
+                            data-testid="empty-inputs-argments-alert"
+                        >
+                            No input arguments defined for{" "}
+                            <Text span fz="sm" fw="bold">
+                                {abiFunction.name}()
+                            </Text>
+                            .
+                        </Alert>
+                    )}
+                </Stack>
+            ) : null}
+        </>
+    );
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/AbiParameter.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/AbiParameter.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { Button, TextInput } from "@mantine/core";
+import { useCallback, useEffect, useRef } from "react";
+import type { AbiFunction } from "viem";
+import { useFormContext } from "./context";
+import type { AbiInputParam } from "./types";
+import {
+    generateAbiParamFormSpecification,
+    resetAbiFunctionParams,
+} from "./utils";
+
+export const AbiParameter = () => {
+    const form = useFormContext();
+    const { abiParam, savedAbiParam, specificationId, selectedSpecification } =
+        form.getTransformedValues();
+    const lastSpecificationId = useRef(specificationId);
+
+    const addABIParam = useCallback(() => {
+        form.setFieldValue("savedAbiParam", abiParam);
+        const selectedSpecification =
+            generateAbiParamFormSpecification(abiParam);
+
+        if (selectedSpecification) {
+            form.setFieldValue("specificationId", selectedSpecification.id);
+        }
+
+        const nextAbiFunction = (
+            selectedSpecification?.abi as AbiFunction[]
+        )[0];
+
+        if (nextAbiFunction) {
+            resetAbiFunctionParams(
+                form,
+                nextAbiFunction.inputs as AbiInputParam[],
+            );
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- 'form' is not added on purpose because it has unstable reference
+    }, [abiParam]);
+
+    useEffect(() => {
+        if (specificationId !== lastSpecificationId.current) {
+            lastSpecificationId.current = specificationId;
+
+            const nextAbiFunction = (
+                selectedSpecification?.abi as AbiFunction[]
+            )[0];
+
+            if (nextAbiFunction) {
+                resetAbiFunctionParams(
+                    form,
+                    nextAbiFunction.inputs as AbiInputParam[],
+                );
+            }
+        }
+    }, [form, selectedSpecification?.abi, specificationId]);
+
+    return (
+        <TextInput
+            label="ABI Parameter"
+            description="Human readable ABI format"
+            placeholder="address to, uint256 amount, bool succ"
+            rightSectionWidth="lg"
+            rightSection={
+                <Button
+                    data-testid="abi-parameter-add-button"
+                    onClick={addABIParam}
+                    disabled={
+                        !!form.errors.abiParam || abiParam === savedAbiParam
+                    }
+                >
+                    Save
+                </Button>
+            }
+            data-testid="abi-parameter-input"
+            {...form.getInputProps("abiParam")}
+            onChange={(event) => {
+                const nextValue = event.target.value;
+                form.setFieldValue("abiParam", nextValue);
+                form.validateField("abiParam");
+            }}
+        />
+    );
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/FunctionSignature.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/FunctionSignature.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { Box, Text } from "@mantine/core";
+import { type FC, Fragment } from "react";
+import type { AbiParameter } from "viem";
+import type { AbiInputParam, GenericFormAbiFunction } from "./types";
+
+interface FunctionParamLabelProps {
+    input: AbiParameter;
+}
+
+export const FunctionParamLabel: FC<FunctionParamLabelProps> = ({ input }) => {
+    return (
+        <Box display="inline">
+            <Text c="cyan" span fz="sm">
+                {input.type}
+            </Text>{" "}
+            <Text span fz="sm">
+                {input.name}
+            </Text>
+        </Box>
+    );
+};
+
+interface InputLabelProps {
+    input: AbiParameter | AbiInputParam;
+}
+
+export const InputLabel: FC<InputLabelProps> = ({ input }) => {
+    return (
+        <>
+            {input.name && input.type ? (
+                <FunctionParamLabel input={input} />
+            ) : (
+                input.name || input.type
+            )}
+        </>
+    );
+};
+
+interface FunctionSignatureProps {
+    abiFunction: GenericFormAbiFunction;
+}
+
+export const FunctionSignature: FC<FunctionSignatureProps> = ({
+    abiFunction,
+}) => {
+    return (
+        <>
+            <Text span fw="bold" fz="sm">
+                {abiFunction.name}
+            </Text>
+            (
+            {abiFunction.inputs.map((input, index) => (
+                <Fragment key={input.id}>
+                    <FunctionParamLabel input={input} />
+                    {index < abiFunction.inputs.length - 1 ? ", " : ""}
+                </Fragment>
+            ))}
+            )
+        </>
+    );
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/TupleComponents.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/TupleComponents.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { Fieldset, type FieldsetProps, TextInput } from "@mantine/core";
+import { type FC, Fragment } from "react";
+import { useFormContext } from "./context";
+import { InputLabel } from "./FunctionSignature";
+import type { AbiInputParam } from "./types";
+
+interface TupleComponentsProps extends FieldsetProps {
+    input: AbiInputParam;
+}
+
+export const TupleComponents: FC<TupleComponentsProps> = (props) => {
+    const { input, ...restProps } = props;
+    const form = useFormContext();
+    const abiFunctionParams = form.getInputProps("abiFunctionParams");
+    const firstStandardInput = input.components.find((c) => c.type !== "tuple");
+    const firstStandardInputIndex = input.components.findIndex(
+        (c) =>
+            c.name == firstStandardInput?.name &&
+            c.type === firstStandardInput?.type,
+    );
+
+    return (
+        <Fieldset {...restProps} legend={<InputLabel input={input} />}>
+            {input.components.map((component, componentIndex) => {
+                const isFirstStandardInput =
+                    componentIndex === firstStandardInputIndex;
+                const inputIndex = abiFunctionParams.value.findIndex(
+                    (p: AbiInputParam) => p.id === component.id,
+                );
+
+                return (
+                    <Fragment key={component.id}>
+                        {component.type === "tuple" ? (
+                            <TupleComponents
+                                input={component}
+                                mt={componentIndex > 0 ? 16 : 0}
+                                mb={
+                                    input.components[componentIndex + 1]
+                                        ? 16
+                                        : 0
+                                }
+                            />
+                        ) : (
+                            <TextInput
+                                label={<InputLabel input={component} />}
+                                placeholder={`Enter ${component.type} value`}
+                                mt={isFirstStandardInput ? 0 : 16}
+                                withAsterisk
+                                {...form.getInputProps(
+                                    `abiFunctionParams.${inputIndex}.value`,
+                                )}
+                            />
+                        )}
+                    </Fragment>
+                );
+            })}
+        </Fieldset>
+    );
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/context.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/context.tsx
@@ -1,0 +1,10 @@
+"use client";
+import { createFormContext } from "@mantine/form";
+import type { FormTransformedValues, FormValues } from "./types";
+
+type TransformValues = (a: FormValues) => FormTransformedValues;
+
+export const [FormProvider, useFormContext, useForm] = createFormContext<
+    FormValues,
+    TransformValues
+>();

--- a/apps/dave/src/components/transactions/GenericInputForm/hooks/useInputBoxAddInput.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/hooks/useInputBoxAddInput.tsx
@@ -1,0 +1,43 @@
+import {
+    useSimulateInputBoxAddInput,
+    useWriteInputBoxAddInput,
+} from "@cartesi/wagmi";
+import type { Hex } from "viem";
+import { useWaitForTransactionReceipt } from "wagmi";
+
+interface Props {
+    contractParams: {
+        args: [appAddress: Hex, payload: Hex];
+    };
+    isQueryEnabled: boolean;
+}
+
+/**
+ * Generate wagmi calls based on the parameters passed down.
+ * simulate contract call will not run until the query-enabled params is true
+ * @param {Props} props
+ * @returns
+ */
+export const useInputBoxAddInput = ({
+    contractParams,
+    isQueryEnabled,
+}: Props) => {
+    const prepare = useSimulateInputBoxAddInput({
+        args: contractParams.args,
+        query: {
+            enabled: isQueryEnabled,
+        },
+    });
+
+    const execute = useWriteInputBoxAddInput();
+
+    const wait = useWaitForTransactionReceipt({
+        hash: execute.data,
+    });
+
+    return {
+        prepare,
+        execute,
+        wait,
+    };
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/index.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/index.tsx
@@ -1,0 +1,250 @@
+"use client";
+import type { Application } from "@cartesi/viem";
+import { inputBoxAddress } from "@cartesi/wagmi";
+import {
+    Button,
+    Collapse,
+    Group,
+    SegmentedControl,
+    Stack,
+    Textarea,
+} from "@mantine/core";
+import { useDebouncedCallback } from "@mantine/hooks";
+import { type FC, useCallback, useEffect, useMemo } from "react";
+import { TbCheck } from "react-icons/tb";
+import {
+    type Abi,
+    type AbiFunction,
+    encodeAbiParameters,
+    encodeFunctionData,
+    stringToHex,
+} from "viem";
+import { type TransactionFormSuccessData } from "../DepositFormTypes";
+import TransactionDetails from "../TransactionDetails";
+import { TransactionProgress } from "../TransactionProgress";
+import { transactionState } from "../TransactionState";
+import { AbiFields } from "./AbiFields";
+import { FormProvider } from "./context";
+import { useInputBoxAddInput } from "./hooks/useInputBoxAddInput";
+import type {
+    AbiInputParam,
+    FormMode,
+    FormSpecification,
+    GenericFormAbiFunction,
+} from "./types";
+import { useGenericInputForm } from "./useGenericInputForm";
+import { generateFinalValues } from "./utils";
+
+export interface GenericInputFormSpecification {
+    id: string;
+    name: string;
+    abi: Abi;
+}
+
+export interface GenericInputFormProps {
+    application: Application;
+    specifications: GenericInputFormSpecification[];
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
+}
+
+const formModeSegmentData = [
+    { label: "Hex", value: "hex" },
+    {
+        label: "String to Hex",
+        value: "string",
+    },
+    { label: "ABI to Hex", value: "abi" },
+];
+
+export const GenericInputForm: FC<GenericInputFormProps> = (props) => {
+    const { application, specifications, onSuccess } = props;
+
+    const form = useGenericInputForm(specifications);
+    const {
+        address,
+        rawInput,
+        mode,
+        abiFunction,
+        selectedSpecification,
+        specificationMode,
+        abiFunctionName,
+    } = form.getTransformedValues();
+
+    const { prepare, execute, wait } = useInputBoxAddInput({
+        contractParams: {
+            args: [address, rawInput],
+        },
+        isQueryEnabled: form.isValid(),
+    });
+
+    const isFormValid = form.isValid();
+    const canSubmit = isFormValid && prepare.error === null;
+    const abiFunctionParams = form.getInputProps("abiFunctionParams");
+    const { disabled: sendDisabled, loading: sendLoading } = transactionState(
+        prepare,
+        execute,
+        wait,
+        true,
+    );
+
+    const details = useMemo(
+        () => [
+            {
+                legend: "Application Address",
+                text: application.applicationAddress,
+            },
+            { legend: "Input Box Address", text: inputBoxAddress },
+        ],
+        [application.applicationAddress],
+    );
+
+    const onChangeFormMode = useCallback(
+        (mode: string | null) => {
+            const application = form.getInputProps("application");
+            form.reset();
+            form.setFieldValue("mode", mode as FormMode);
+            form.setFieldValue("application", application.value);
+        },
+        [form],
+    );
+
+    const encodeFunctionParamsDebounced = useDebouncedCallback(
+        (params: AbiInputParam[]) => {
+            const abiFunctions =
+                (selectedSpecification?.abi as GenericFormAbiFunction[]) ?? [];
+            const nextAbiFunction = abiFunctions.find(
+                (f) => f.name === abiFunctionName,
+            );
+
+            if (nextAbiFunction) {
+                const finalValues = generateFinalValues(
+                    [...nextAbiFunction.inputs],
+                    params,
+                );
+
+                if (specificationMode === "json_abi") {
+                    const payload = encodeFunctionData({
+                        abi: (selectedSpecification as FormSpecification)?.abi,
+                        functionName: (abiFunction as AbiFunction)?.name,
+                        args: finalValues,
+                    });
+                    form.setFieldValue("rawInput", payload);
+                } else if (specificationMode === "abi_params") {
+                    const payload = encodeAbiParameters(
+                        nextAbiFunction.inputs,
+                        finalValues,
+                    );
+                    form.setFieldValue("rawInput", payload);
+                }
+            }
+        },
+        400,
+    );
+
+    useEffect(() => {
+        form.setFieldValue("application", application.applicationAddress);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [application.applicationAddress]);
+
+    useEffect(() => {
+        if (wait.isSuccess) {
+            onSuccess({ receipt: wait.data, type: "RAW" });
+            form.reset();
+            execute.reset();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [wait, onSuccess]);
+
+    useEffect(() => {
+        if (isFormValid) {
+            encodeFunctionParamsDebounced(abiFunctionParams.value);
+        }
+    }, [abiFunctionParams.value, isFormValid, encodeFunctionParamsDebounced]);
+
+    return (
+        <FormProvider form={form}>
+            <form data-testid="raw-input-form">
+                <Stack>
+                    <TransactionDetails details={details} />
+                    <SegmentedControl
+                        value={mode}
+                        onChange={onChangeFormMode}
+                        data={formModeSegmentData}
+                    />
+
+                    {mode === "hex" ? (
+                        <Textarea
+                            label="Hex input"
+                            description="Hex input for the application"
+                            withAsterisk
+                            data-testid="hex-textarea"
+                            {...form.getInputProps("rawInput")}
+                        />
+                    ) : mode === "string" ? (
+                        <>
+                            <Textarea
+                                label="String input"
+                                description="String input for the application"
+                                data-testid="string-to-hex-input"
+                                {...form.getInputProps("stringInput")}
+                                onChange={(event) => {
+                                    const nextValue = event.target.value;
+                                    form.setFieldValue(
+                                        "stringInput",
+                                        nextValue,
+                                    );
+
+                                    form.setFieldValue(
+                                        "rawInput",
+                                        stringToHex(nextValue),
+                                    );
+                                }}
+                            />
+
+                            <Textarea
+                                label="Hex value"
+                                description="Encoded hex value for the application"
+                                readOnly
+                                {...form.getInputProps("rawInput")}
+                            />
+                        </>
+                    ) : mode === "abi" ? (
+                        <AbiFields specifications={specifications} />
+                    ) : null}
+
+                    <Collapse
+                        in={
+                            execute.isPending ||
+                            wait.isLoading ||
+                            execute.isSuccess ||
+                            execute.isError
+                        }
+                    >
+                        <TransactionProgress
+                            prepare={prepare}
+                            execute={execute}
+                            wait={wait}
+                            confirmationMessage="Input sent successfully!"
+                            defaultErrorMessage={execute.error?.message}
+                        />
+                    </Collapse>
+
+                    <Group justify="right">
+                        <Button
+                            variant="filled"
+                            disabled={sendDisabled || !canSubmit}
+                            leftSection={<TbCheck />}
+                            loading={canSubmit && sendLoading}
+                            data-testid="generic-input-submit-button"
+                            onClick={() =>
+                                execute.writeContract(prepare.data!.request)
+                            }
+                        >
+                            Send
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </FormProvider>
+    );
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/initialValues.ts
+++ b/apps/dave/src/components/transactions/GenericInputForm/initialValues.ts
@@ -1,0 +1,16 @@
+import type { FormValues } from "./types";
+
+export const initialValues: FormValues = {
+    mode: "hex",
+    application: "",
+    rawInput: "0x",
+    stringInput: "",
+    abiMethod: "existing",
+    specificationMode: "json_abi",
+    humanAbi: "",
+    abiParam: "",
+    savedAbiParam: "",
+    specificationId: "",
+    abiFunctionName: "",
+    abiFunctionParams: [],
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/types.ts
+++ b/apps/dave/src/components/transactions/GenericInputForm/types.ts
@@ -1,0 +1,60 @@
+import type { Abi, AbiFunction, AbiParameter, Address, Hex } from "viem";
+
+export type FormMode = "hex" | "string" | "abi";
+
+export interface FormSpecification {
+    id: string;
+    name: string;
+    abi: Abi;
+}
+
+export type SpecificationMode = "json_abi" | "abi_params";
+
+export type FormAbiMethod = "new" | "existing";
+
+export type AbiValueParameter = Pick<AbiParameter, "type" | "name"> & {
+    value: string;
+    tupleName?: string;
+};
+
+export type AbiInputParam = AbiValueParameter & {
+    tupleName?: string;
+    id?: string;
+    components: AbiInputParam[];
+};
+
+export type GenericFormAbiFunction = Omit<AbiFunction, "inputs"> & {
+    inputs: AbiInputParam[];
+};
+
+export interface FormValues {
+    mode: FormMode;
+    application: string;
+    rawInput: Hex;
+    stringInput: string;
+    abiMethod: FormAbiMethod;
+    specificationMode: SpecificationMode;
+    humanAbi: string;
+    abiParam: string;
+    savedAbiParam: string;
+    specificationId: string;
+    abiFunctionName: string;
+    abiFunctionParams: AbiValueParameter[];
+}
+
+export interface FormTransformedValues {
+    mode: FormMode;
+    address: Address;
+    rawInput: Hex;
+    abiMethod: FormAbiMethod;
+    specificationMode: SpecificationMode;
+    humanAbi: string;
+    abiParam: string;
+    savedAbiParam: string;
+    specificationId: string;
+    abiFunctionName: string;
+    abiFunction: GenericFormAbiFunction | undefined;
+    selectedSpecification: FormSpecification | undefined;
+}
+
+export type FinalValues = (string | bigint | boolean | FinalValues)[];

--- a/apps/dave/src/components/transactions/GenericInputForm/useGenericInputForm.tsx
+++ b/apps/dave/src/components/transactions/GenericInputForm/useGenericInputForm.tsx
@@ -1,0 +1,140 @@
+"use client";
+import { equals, omit } from "ramda";
+import { useRef } from "react";
+import { v4 as uuidv4 } from "uuid";
+import {
+    type AbiFunction,
+    type Hex,
+    getAddress,
+    isAddress,
+    zeroAddress,
+} from "viem";
+import { useForm } from "./context";
+import { initialValues } from "./initialValues";
+import { type FormSpecification, type GenericFormAbiFunction } from "./types";
+import {
+    augmentInputsWithIds,
+    generateAbiParamFormSpecification,
+    generateHumanAbiFormSpecification,
+} from "./utils";
+import {
+    validateAbiFunctionName,
+    validateAbiFunctionParamValue,
+    validateAbiMethod,
+    validateAbiParam,
+    validateApplication,
+    validateHexInput,
+    validateHumanAbi,
+    validateSpecificationId,
+} from "./validations";
+
+export const useGenericInputForm = (specifications: FormSpecification[]) => {
+    const lastSelectedSpecification = useRef<FormSpecification | undefined>(
+        undefined,
+    );
+    const lastSelectedSpecificationWithIds = useRef<
+        FormSpecification | undefined
+    >(undefined);
+
+    return useForm({
+        validateInputOnBlur: true,
+        initialValues: {
+            ...initialValues,
+            abiMethod: specifications.length > 0 ? "existing" : "new",
+        },
+        validate: {
+            application: validateApplication,
+            rawInput: validateHexInput,
+            abiMethod: validateAbiMethod,
+            humanAbi: validateHumanAbi,
+            abiParam: validateAbiParam,
+            specificationId: validateSpecificationId,
+            abiFunctionName: validateAbiFunctionName,
+            abiFunctionParams: {
+                value: validateAbiFunctionParamValue,
+            },
+        },
+        transformValues: (values) => {
+            let selectedSpecification =
+                values.abiMethod === "existing"
+                    ? specifications.find(
+                          (s) => s.id === values.specificationId,
+                      )
+                    : values.specificationMode === "json_abi"
+                      ? generateHumanAbiFormSpecification(values.humanAbi)
+                      : generateAbiParamFormSpecification(values.savedAbiParam);
+
+            if (
+                selectedSpecification &&
+                !equals(
+                    omit(["id"], selectedSpecification),
+                    omit(
+                        ["id"],
+                        (lastSelectedSpecification.current ??
+                            {}) as FormSpecification,
+                    ),
+                )
+            ) {
+                lastSelectedSpecification.current = {
+                    ...selectedSpecification,
+                };
+
+                const selectedSpecificationWithIds = {
+                    ...selectedSpecification,
+                    abi: selectedSpecification.abi.map((abiFunction) => {
+                        const nextAbiFunction = {
+                            ...abiFunction,
+                        } as GenericFormAbiFunction;
+
+                        nextAbiFunction.inputs = nextAbiFunction.inputs.map(
+                            (input) => {
+                                const nextInput = { ...input, id: uuidv4() };
+
+                                if (nextInput.type === "tuple") {
+                                    nextInput.components =
+                                        augmentInputsWithIds(nextInput);
+                                }
+
+                                return nextInput;
+                            },
+                        );
+
+                        return nextAbiFunction;
+                    }),
+                };
+
+                selectedSpecification = { ...selectedSpecificationWithIds };
+                lastSelectedSpecificationWithIds.current = {
+                    ...selectedSpecificationWithIds,
+                };
+            } else if (lastSelectedSpecificationWithIds.current) {
+                selectedSpecification = {
+                    ...lastSelectedSpecificationWithIds.current,
+                };
+            }
+
+            const abiFunction = (
+                (selectedSpecification?.abi as AbiFunction[]) ?? []
+            ).find(
+                (abiFunction) => abiFunction.name === values.abiFunctionName,
+            ) as GenericFormAbiFunction;
+
+            return {
+                mode: values.mode,
+                address: isAddress(values.application)
+                    ? getAddress(values.application)
+                    : zeroAddress,
+                rawInput: values.rawInput as Hex,
+                abiMethod: values.abiMethod,
+                specificationMode: values.specificationMode,
+                humanAbi: values.humanAbi,
+                abiParam: values.abiParam,
+                savedAbiParam: values.savedAbiParam,
+                specificationId: values.specificationId,
+                abiFunctionName: values.abiFunctionName,
+                selectedSpecification,
+                abiFunction,
+            };
+        },
+    });
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/utils.ts
+++ b/apps/dave/src/components/transactions/GenericInputForm/utils.ts
@@ -1,0 +1,189 @@
+import { type UseFormReturnType } from "@mantine/form";
+import { isArray, isBlank, isObject } from "ramda-adjunct";
+import { v4 as uuidv4 } from "uuid";
+import { getAddress, parseAbi, parseAbiParameters } from "viem";
+import type {
+    AbiInputParam,
+    AbiValueParameter,
+    FinalValues,
+    FormSpecification,
+    FormTransformedValues,
+    FormValues,
+} from "./types";
+
+export const prepareSignatures = (multiline: string) =>
+    multiline.split("\n").map((signature) => signature?.trim());
+
+export const encodeFunctionParam = (param: AbiValueParameter) => {
+    switch (param.type) {
+        case "bool":
+            return param.value === "true";
+        case "address":
+            return getAddress(param.value);
+        case "uint":
+        case "uint8":
+        case "uint16":
+        case "uint32":
+        case "uint64":
+        case "uint128":
+        case "uint256":
+            return BigInt(param.value);
+        default:
+            return param.value;
+    }
+};
+
+export const generateHumanAbiFormSpecification = (humanAbi: string) => {
+    if (isBlank(humanAbi)) {
+        return undefined;
+    }
+
+    const readableList = prepareSignatures(humanAbi);
+    let generatedAbi;
+    try {
+        generatedAbi = parseAbi(readableList);
+    } catch (err) {
+        console.error(err);
+    }
+
+    return isObject(generatedAbi)
+        ? ({
+              id: uuidv4(),
+              name: "Generated specification",
+              abi: generatedAbi,
+          } as FormSpecification)
+        : undefined;
+};
+
+export const generateAbiParamFormSpecification = (abiParam: string) => {
+    let abiParameters;
+
+    try {
+        abiParameters = parseAbiParameters(abiParam);
+    } catch (err) {
+        console.error(err);
+    }
+
+    return isArray(abiParameters)
+        ? ({
+              id: uuidv4(),
+              name: "Generated specification",
+              abi: [
+                  {
+                      inputs: abiParameters,
+                      name: "",
+                      outputs: [],
+                      stateMutability: "view",
+                      type: "function",
+                  },
+              ],
+          } as FormSpecification)
+        : undefined;
+};
+
+export const generateInitialValues = (
+    parentInput: AbiInputParam,
+    flatInputs: AbiInputParam[],
+) => {
+    if (parentInput.components) {
+        parentInput.components.forEach((input: AbiInputParam) => {
+            if (input.type === "tuple") {
+                generateInitialValues(input, flatInputs);
+            } else {
+                const flatInput: AbiInputParam = {
+                    ...input,
+                    value: "",
+                };
+
+                flatInputs.push(flatInput);
+            }
+        });
+    } else {
+        flatInputs.push({
+            ...parentInput,
+            value: "",
+        });
+    }
+};
+
+export const augmentInputsWithIds = (
+    parentInput: AbiInputParam,
+): AbiInputParam[] => {
+    return parentInput.components.map((input: AbiInputParam) => {
+        const nextInput = { ...input, id: uuidv4() };
+
+        if (nextInput.type === "tuple") {
+            nextInput.components = augmentInputsWithIds(input);
+        }
+
+        return nextInput;
+    });
+};
+
+export const generateFinalValues = (
+    inputs: AbiInputParam[],
+    params: AbiInputParam[],
+) => {
+    const finalArr: FinalValues = [];
+
+    inputs.forEach((input) => {
+        if (input.type === "tuple") {
+            const currArr: FinalValues = [];
+            finalArr.push(currArr);
+
+            getTupleValues(input, params, finalArr, currArr);
+        } else {
+            const param = params.find((p) => {
+                return p.id === input.id;
+            }) as AbiValueParameter;
+            const value = encodeFunctionParam(param);
+            finalArr.push(value);
+        }
+    });
+
+    return finalArr;
+};
+
+const getTupleValues = (
+    tupleInput: AbiInputParam,
+    params: AbiInputParam[],
+    finalArr: FinalValues = [],
+    currentArr: FinalValues = [],
+) => {
+    tupleInput.components.forEach((input) => {
+        if (input.type === "tuple") {
+            const nextCurrentArr: FinalValues = [];
+            currentArr.push(nextCurrentArr);
+            getTupleValues(input, params, finalArr, nextCurrentArr);
+        } else {
+            const param = params.find((p) => {
+                return p.id === input.id;
+            }) as AbiValueParameter;
+            const value = encodeFunctionParam(param);
+            currentArr.push(value);
+        }
+    });
+};
+
+export const resetAbiFunctionParams = (
+    form: UseFormReturnType<
+        FormValues,
+        (values: FormValues) => FormTransformedValues
+    >,
+    inputs: AbiInputParam[],
+) => {
+    const emptyFunctionParams: AbiInputParam[] = [];
+    (inputs as AbiInputParam[]).forEach((input) => {
+        generateInitialValues(input, emptyFunctionParams);
+    });
+
+    const prevAbiFunctionParams = form.getInputProps("abiFunctionParams");
+
+    if (isArray(prevAbiFunctionParams.value)) {
+        prevAbiFunctionParams.value.forEach((_, index) => {
+            form.setFieldError(`abiFunctionParams.${index}.value`, null);
+        });
+    }
+
+    form.setFieldValue("abiFunctionParams", emptyFunctionParams);
+};

--- a/apps/dave/src/components/transactions/GenericInputForm/validations.ts
+++ b/apps/dave/src/components/transactions/GenericInputForm/validations.ts
@@ -1,0 +1,139 @@
+import { isBlank } from "ramda-adjunct";
+import { isAddress, isHex, parseAbi, parseAbiParameters } from "viem";
+import type { FormValues } from "./types";
+import { prepareSignatures } from "./utils";
+
+export const validateApplication = (value: string) =>
+    value !== "" && isAddress(value) ? null : "Invalid application";
+
+export const validateHexInput = (value: string) =>
+    isHex(value) ? null : "Invalid hex value";
+
+export const validateAbiMethod = (value: string, values: FormValues) =>
+    values.mode !== "abi" || value === "new" || value === "existing"
+        ? null
+        : "Invalid ABI method";
+
+export const validateSpecificationId = (value: string, values: FormValues) =>
+    values.mode !== "abi" ||
+    (values.abiMethod === "new" && values.specificationMode === "json_abi") ||
+    value !== ""
+        ? null
+        : "Invalid specification";
+
+export const validateAbiFunctionName = (value: string, values: FormValues) =>
+    values.mode !== "abi" ||
+    values.specificationMode !== "json_abi" ||
+    value !== ""
+        ? null
+        : "Invalid ABI function";
+
+export const validateAbiFunctionParamValue = (
+    value: string,
+    values: FormValues,
+    key: string,
+) => {
+    if (values.mode !== "abi") {
+        return null;
+    }
+
+    const [paramIndex] = key
+        .split(".")
+        .map((part) => parseInt(part))
+        .filter((n) => !isNaN(n));
+    const param = values.abiFunctionParams[paramIndex];
+
+    if (!param) {
+        return null;
+    }
+
+    const message = `Invalid ${param.type} value`;
+    let error: string | null = null;
+
+    // Validate the field for non-empty content
+    if (value === "") {
+        return message;
+    }
+
+    // Otherwise, if some content exists, validate it based on the type
+    switch (param.type) {
+        case "uint":
+        case "uint8":
+        case "uint16":
+        case "uint32":
+        case "uint64":
+        case "uint128":
+        case "uint256":
+            try {
+                BigInt(value);
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            } catch (e: unknown) {
+                error = message;
+            }
+            break;
+        case "bool":
+            error = value === "true" || value === "false" ? null : message;
+            break;
+        case "bytes":
+            error = isHex(value) ? null : message;
+            break;
+        case "address":
+            error = isAddress(value) ? null : message;
+            break;
+        // All other types like 'string' are handled in the non-empty content check above
+        default:
+            break;
+    }
+
+    return error;
+};
+
+export const validateHumanAbi = (value: string, values: FormValues) => {
+    if (values.mode !== "abi") {
+        return null;
+    }
+
+    if (
+        values.abiMethod === "existing" ||
+        values.specificationMode === "abi_params"
+    ) {
+        return null;
+    }
+
+    if (isBlank(value)) {
+        return "The ABI signature definition is required";
+    }
+
+    const items = prepareSignatures(value);
+    try {
+        parseAbi(items);
+    } catch (error: unknown) {
+        return (error as Error).message;
+    }
+
+    return null;
+};
+
+export const validateAbiParam = (value: string, values: FormValues) => {
+    if (values.mode !== "abi") {
+        return null;
+    }
+
+    if (
+        values.abiMethod === "existing" ||
+        values.specificationMode === "json_abi"
+    ) {
+        return null;
+    }
+
+    if (isBlank(value)) {
+        return "ABI parameter is required.";
+    }
+
+    try {
+        parseAbiParameters(value);
+        return null;
+    } catch (error: unknown) {
+        return (error as Error).message as string;
+    }
+};


### PR DESCRIPTION
# Summary
The code changes in this PR achieve feature parity in terms of a user be able to send transactions (i.e. deposits through portals and generic input through the input box). 

Even though the add-input is the simplest in terms of smart contract interface, it was the last to be added as it depends on the PR #434 (ABI encoding/decoding support), since we provide ways for the user to choose how they want to send the data i.e. using a raw hex value, or a string to be converted to hex, or ABI encoding to define the input to be sent. 

**PS:** _Currently I am skipping the CI step to publish the test reports to coveralls. It is having service outage for a couple of days at the moment of writing. They don't have an ETA, more details here: https://status.coveralls.io/_


closes: #435 