### PR TITLE
feat: add output execution capability

### DIFF
--- a/apps/dave/src/components/output/OutputContainer.tsx
+++ b/apps/dave/src/components/output/OutputContainer.tsx
@@ -72,6 +72,7 @@ export const OutputContainer: FC<OutputContainerProps> = ({
 
     return (
         <OutputList
+            application={application}
             outputs={result.data}
             pagination={result.pagination}
             decoderType={decoderType}

--- a/apps/dave/src/components/output/OutputExecution.tsx
+++ b/apps/dave/src/components/output/OutputExecution.tsx
@@ -1,0 +1,293 @@
+"use client";
+import {
+    useEpoch,
+    useReadApplicationWasOutputExecuted,
+    useSimulateApplicationExecuteOutput,
+    useWriteApplicationExecuteOutput,
+} from "@cartesi/wagmi";
+import {
+    Alert,
+    Badge,
+    Button,
+    Divider,
+    Group,
+    Stack,
+    Tooltip,
+    useMantineTheme,
+} from "@mantine/core";
+import { useChainModal, useConnectModal } from "@rainbow-me/rainbowkit";
+import { useQueryClient } from "@tanstack/react-query";
+import { isNil, isNotEmpty, isNotNil, pathOr } from "ramda";
+import { isFunction, isNotNilOrEmpty, isObj, isString } from "ramda-adjunct";
+import { Activity, useEffect, useMemo, type FC } from "react";
+import { TbExclamationCircle, TbInfoCircle, TbReceipt } from "react-icons/tb";
+import type { TransactionReceipt } from "viem";
+import { type Hex } from "viem";
+import { useAccount, useWaitForTransactionReceipt } from "wagmi";
+import { useSelectedNodeConnection } from "../connection/hooks";
+import TransactionHash from "../TransactionHash";
+import OutputExecutionError, {
+    type WagmiActionError,
+} from "./errors/OutputExecutionError";
+import type { VoucherOutput } from "./types";
+
+// xxx: Maybe should become an environment var.
+const POLLING_INTERVAL_MS = 8000 as const;
+
+type OutputExecutionProps = {
+    output: VoucherOutput;
+    application: Hex;
+    onSuccess?: (txReceipt: TransactionReceipt) => void;
+    onError?: (errors: OutputExecutionError[]) => void;
+};
+
+type Proof = { outputIndex: bigint; outputHashesSiblings: Hex[] };
+
+const buildProof = (output: VoucherOutput): Proof => ({
+    outputIndex: output.index,
+    outputHashesSiblings: output.outputHashesSiblings ?? [],
+});
+
+const OutputExecution: FC<OutputExecutionProps> = ({
+    application,
+    output,
+    onSuccess,
+    onError,
+}) => {
+    const theme = useMantineTheme();
+    const userAccount = useAccount();
+    const connectModal = useConnectModal();
+    const selectedNode = useSelectedNodeConnection();
+    const chainModal = useChainModal();
+    const epochQuery = useEpoch({ epochIndex: output.epochIndex, application });
+    const queryClient = useQueryClient();
+    const isClaimAccepted = epochQuery.data?.status === "CLAIM_ACCEPTED";
+    const hasExecutionTransaction = isNotNil(output.executionTransactionHash);
+
+    const wasOutputExecutedQuery = useReadApplicationWasOutputExecuted({
+        address: application,
+        args: [output.index],
+        query: {
+            enabled: !hasExecutionTransaction && isNotNil(output.index),
+        },
+    });
+
+    const {
+        data: wasOutputExecuted,
+        isFetching: checkingOutputExecuted,
+        error: checkingOutputExecutedError,
+        refetch: recheckOutputExecuted,
+    } = wasOutputExecutedQuery;
+
+    const proof = buildProof(output);
+
+    const hasHashes = isNotEmpty(proof.outputHashesSiblings);
+    const canSimulate =
+        userAccount.isConnected &&
+        !checkingOutputExecuted &&
+        wasOutputExecuted === false &&
+        hasHashes &&
+        isClaimAccepted;
+
+    const prepare = useSimulateApplicationExecuteOutput({
+        address: application,
+        args: [output.rawData, proof],
+        query: {
+            enabled: canSimulate,
+        },
+    });
+
+    const execute = useWriteApplicationExecuteOutput();
+    const wait = useWaitForTransactionReceipt({
+        hash: execute.data,
+    });
+
+    const isExecutingVoucher = execute.isPending || wait.isFetching;
+
+    const errors = useMemo(() => {
+        return [checkingOutputExecutedError, prepare.error]
+            .filter(isNotNilOrEmpty)
+            .map(
+                (wagmiError) =>
+                    new OutputExecutionError({
+                        type: "wagmi-error",
+                        error: wagmiError as WagmiActionError,
+                    }),
+            );
+    }, [checkingOutputExecutedError, prepare.error]);
+
+    const hasErrors = errors.length > 0;
+
+    const isExecuteDisabled =
+        !isClaimAccepted ||
+        checkingOutputExecuted ||
+        wasOutputExecuted ||
+        prepare.isFetching ||
+        hasErrors;
+
+    useEffect(() => {
+        if (wait.isSuccess) {
+            if (isFunction(onSuccess)) {
+                onSuccess(wait.data);
+            }
+            execute.reset();
+            recheckOutputExecuted();
+            // mark outputs as stale to get latest values from rollups-node.
+            queryClient.invalidateQueries({ queryKey: ["outputs"] });
+        }
+    }, [
+        wait.isSuccess,
+        wait.data,
+        recheckOutputExecuted,
+        execute,
+        queryClient,
+        onSuccess,
+    ]);
+
+    useEffect(() => {
+        if (!isFunction(onError)) return;
+
+        if (errors.length > 0) {
+            onError(errors);
+        }
+    }, [errors, onError]);
+
+    useEffect(() => {
+        let key: unknown;
+        // skip invalidation if there is no node-connected or the connected node is a mock.
+        if (
+            isNotNil(selectedNode) &&
+            selectedNode.type !== "system_mock" &&
+            !isClaimAccepted
+        ) {
+            key = setInterval(() => {
+                // Invalidation makes the targeted queries stale.
+                // It creates a Polling effect.
+                queryClient.invalidateQueries({
+                    predicate: (query) => {
+                        const [baseKey, paramsKey] = query.queryKey;
+                        const isEpochQuery =
+                            isString(baseKey) && baseKey.includes("epoch");
+                        const isMatchingEpochIndex =
+                            isObj(paramsKey) &&
+                            pathOr("", ["epochIndex"], paramsKey) ===
+                                output.epochIndex.toString();
+
+                        return isEpochQuery && isMatchingEpochIndex;
+                    },
+                });
+            }, POLLING_INTERVAL_MS);
+        }
+
+        return () => {
+            if (isNotNil(key)) {
+                console.info(`Clearing the polling.`);
+                clearInterval(key as number);
+            }
+        };
+    }, [queryClient, isClaimAccepted, selectedNode, output.epochIndex]);
+
+    return (
+        <>
+            <Stack>
+                <Divider mt="sm" />
+
+                <Activity mode={!isClaimAccepted ? "visible" : "hidden"}>
+                    <Group justify="flex-end">
+                        <Badge
+                            radius="xs"
+                            size="lg"
+                            leftSection={
+                                <Tooltip
+                                    label={
+                                        "Once the epoch status become CLAIM_ACCEPTED the voucher will become executable."
+                                    }
+                                >
+                                    <TbInfoCircle
+                                        size={theme.other.smIconSize}
+                                    />
+                                </Tooltip>
+                            }
+                        >
+                            Waiting Claim
+                        </Badge>
+                    </Group>
+                </Activity>
+
+                <Activity mode={isClaimAccepted ? "visible" : "hidden"}>
+                    <Group
+                        justify={
+                            hasExecutionTransaction
+                                ? "space-between"
+                                : "flex-end"
+                        }
+                    >
+                        {isNotNil(output.executionTransactionHash) && (
+                            <Group gap={3}>
+                                <Tooltip label="Transaction hash">
+                                    <TbReceipt size={theme.other.mdIconSize} />
+                                </Tooltip>
+                                <TransactionHash
+                                    transactionHash={
+                                        output.executionTransactionHash
+                                    }
+                                />
+                            </Group>
+                        )}
+                        <Button
+                            disabled={isExecuteDisabled}
+                            loading={isExecutingVoucher}
+                            onClick={() => {
+                                const needSwitchNetwork =
+                                    userAccount.isConnected &&
+                                    isNil(userAccount.chain);
+                                const canSend =
+                                    !needSwitchNetwork &&
+                                    userAccount.isConnected;
+
+                                if (needSwitchNetwork)
+                                    return chainModal.openChainModal?.();
+
+                                if (canSend) {
+                                    execute.writeContract(
+                                        prepare.data!.request,
+                                    );
+                                } else {
+                                    connectModal.openConnectModal?.();
+                                }
+                            }}
+                        >
+                            {wasOutputExecuted
+                                ? "Executed"
+                                : checkingOutputExecuted
+                                  ? "Checking voucher..."
+                                  : prepare.isFetching
+                                    ? "Preparing voucher..."
+                                    : "Execute"}
+                        </Button>
+                    </Group>
+                </Activity>
+            </Stack>
+            {hasErrors && (
+                <Stack py="sm">
+                    {errors.map((error) => (
+                        <Alert
+                            key={error.message}
+                            color="red"
+                            title={error.message}
+                            icon={
+                                <TbExclamationCircle
+                                    size={theme.other.mdIconSize}
+                                />
+                            }
+                        >
+                            {error.shortMessage}
+                        </Alert>
+                    ))}
+                </Stack>
+            )}
+        </>
+    );
+};
+
+export default OutputExecution;

--- a/apps/dave/src/components/output/OutputList.tsx
+++ b/apps/dave/src/components/output/OutputList.tsx
@@ -9,6 +9,7 @@ type OutputListProps = {
     decoderType?: DecoderType;
     outputs: Output[];
     pagination: Pagination;
+    application: string;
     onPaginationChange?: (newOffset: number) => void;
 };
 
@@ -17,6 +18,7 @@ export const OutputList: FC<OutputListProps> = ({
     pagination,
     decoderType = "raw",
     onPaginationChange,
+    application,
 }) => {
     return (
         <Stack id="output-list" gap={0}>
@@ -26,6 +28,7 @@ export const OutputList: FC<OutputListProps> = ({
             />
             {outputs.map((output) => (
                 <OutputView
+                    application={application}
                     key={`${output.epochIndex}-${output.inputIndex}-${output.index}`}
                     output={output}
                     displayAs={decoderType}

--- a/apps/dave/src/components/output/OutputView.tsx
+++ b/apps/dave/src/components/output/OutputView.tsx
@@ -1,57 +1,26 @@
 "use client";
-import type {
-    DelegateCallVoucher,
-    GetOutputReturnType,
-    Notice,
-    Output,
-    Voucher,
-} from "@cartesi/viem";
-import {
-    useEpoch,
-    useReadApplicationWasOutputExecuted,
-    useSimulateApplicationExecuteOutput,
-    useWriteApplicationExecuteOutput,
-} from "@cartesi/wagmi";
-import {
-    Alert,
-    Badge,
-    Button,
-    Divider,
-    Fieldset,
-    Group,
-    Spoiler,
-    Stack,
-    Text,
-    Tooltip,
-    useMantineTheme,
-} from "@mantine/core";
+import { Divider, Fieldset, Group, Spoiler, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
-import { useChainModal, useConnectModal } from "@rainbow-me/rainbowkit";
-import { useQueryClient } from "@tanstack/react-query";
-import { isNil, isNotEmpty, isNotNil, pathOr } from "ramda";
-import { isNotNilOrEmpty, isObj, isString } from "ramda-adjunct";
-import { Activity, useEffect, useMemo, type FC } from "react";
-import { TbExclamationCircle, TbInfoCircle, TbReceipt } from "react-icons/tb";
+import { isNotNil } from "ramda";
+import { type FC } from "react";
 import { formatUnits, isHex, type Hex } from "viem";
-import { useAccount, useWaitForTransactionReceipt } from "wagmi";
 import { useIsSmallDevice } from "../../hooks/useIsSmallDevice";
 import { getDecoder } from "../../lib/decoders";
 import Address from "../Address";
-import { useSelectedNodeConnection } from "../connection/hooks";
 import JSONViewer from "../JSONViewer";
 import useVoucherDecoder from "../specification/hooks/useVoucherDecoder";
-import TransactionHash from "../TransactionHash";
-import type { DecoderType } from "../types";
+import OutputExecution from "./OutputExecution";
+import type {
+    NoticeContentProps,
+    OutputViewProps,
+    VoucherContentProps,
+    VoucherOutput,
+} from "./types";
 
-interface OutputViewProps {
-    displayAs?: DecoderType;
-    output: GetOutputReturnType;
-    application: string;
-}
-
-type NoticeProps = { decodedData: Notice; decoderType: DecoderType };
-
-const NoticeContent: FC<NoticeProps> = ({ decodedData, decoderType }) => {
+const NoticeContent: FC<NoticeContentProps> = ({
+    decodedData,
+    decoderType,
+}) => {
     const decoderFn = getDecoder(decoderType);
 
     return (
@@ -65,28 +34,7 @@ const NoticeContent: FC<NoticeProps> = ({ decodedData, decoderType }) => {
     );
 };
 
-type VoucherOutput = Omit<Output, "decodedData"> & {
-    decodedData: Voucher | DelegateCallVoucher;
-};
-
-type VoucherProps = {
-    output: VoucherOutput;
-    application: string;
-    decoderType: DecoderType;
-    title?: string;
-};
-
-type Proof = { outputIndex: bigint; outputHashesSiblings: Hex[] };
-
-const buildProof = (output: VoucherOutput): Proof => ({
-    outputIndex: output.index,
-    outputHashesSiblings: output.outputHashesSiblings ?? [],
-});
-
-// xxx: Maybe should become an environment var.
-const POLLING_INTERVAL_MS = 8000 as const;
-
-const VoucherContent: FC<VoucherProps> = ({
+const VoucherContent: FC<VoucherContentProps> = ({
     decoderType,
     output,
     application,
@@ -94,16 +42,7 @@ const VoucherContent: FC<VoucherProps> = ({
 }) => {
     const decoderFn = getDecoder(decoderType);
     const { isSmallDevice } = useIsSmallDevice();
-    const userAccount = useAccount();
-    const connectModal = useConnectModal();
-    const selectedNode = useSelectedNodeConnection();
-    const chainModal = useChainModal();
-    const queryClient = useQueryClient();
-
-    const { decodedData, epochIndex } = output;
-
-    const theme = useMantineTheme();
-    const epochQuery = useEpoch({ epochIndex, application });
+    const { decodedData } = output;
     const hasPayload =
         isHex(decodedData.payload) && decodedData.payload !== "0x";
     const amount = decodedData.type === "Voucher" ? decodedData.value : 0n;
@@ -111,115 +50,6 @@ const VoucherContent: FC<VoucherProps> = ({
     const voucherDecodingRes = useVoucherDecoder({ voucher: decodedData });
     const hasDecodedData = isNotNil(voucherDecodingRes.data);
     const isDecodedSelected = decoderType === "decoded";
-    const appAddress = application as Hex;
-
-    const isClaimAccepted = epochQuery.data?.status === "CLAIM_ACCEPTED";
-    const hasExecutionTransaction = isNotNil(output.executionTransactionHash);
-
-    const wasOutputExecutedQuery = useReadApplicationWasOutputExecuted({
-        address: appAddress,
-        args: [output.index],
-        query: {
-            enabled: !hasExecutionTransaction && isNotNil(output.index),
-        },
-    });
-
-    const {
-        data: wasOutputExecuted,
-        isFetching: checkingOutputExecuted,
-        error: checkingOutputExecutedError,
-        refetch: recheckOutputExecuted,
-    } = wasOutputExecutedQuery;
-
-    const proof = buildProof(output);
-
-    const hasHashes = isNotEmpty(proof.outputHashesSiblings);
-    const canSimulate =
-        userAccount.isConnected &&
-        !checkingOutputExecuted &&
-        wasOutputExecuted === false &&
-        hasHashes &&
-        isClaimAccepted;
-
-    const prepare = useSimulateApplicationExecuteOutput({
-        address: appAddress,
-        args: [output.rawData, proof],
-        query: {
-            enabled: canSimulate,
-        },
-    });
-
-    const execute = useWriteApplicationExecuteOutput();
-    const wait = useWaitForTransactionReceipt({
-        hash: execute.data,
-    });
-
-    const isExecutingVoucher = execute.isPending || wait.isFetching;
-
-    const errors = useMemo(() => {
-        return [checkingOutputExecutedError, prepare.error].filter(
-            isNotNilOrEmpty,
-        );
-    }, [checkingOutputExecutedError, prepare.error]);
-
-    const hasErrors = errors.length > 0;
-
-    const isExecuteDisabled =
-        !isClaimAccepted ||
-        checkingOutputExecuted ||
-        wasOutputExecuted ||
-        prepare.isFetching ||
-        hasErrors;
-
-    useEffect(() => {
-        if (wait.isSuccess) {
-            notifications.show({
-                title: "Voucher execution status",
-                message: "Executed successfully",
-                color: "green",
-                withBorder: true,
-            });
-            execute.reset();
-            recheckOutputExecuted();
-            // mark outputs as stale to get latest values from rollups-node.
-            queryClient.invalidateQueries({ queryKey: ["outputs"] });
-        }
-    }, [wait.isSuccess, recheckOutputExecuted, execute, queryClient]);
-
-    useEffect(() => {
-        let key: unknown;
-        // skip invalidation if there is no node-connected or the connected node is a mock.
-        if (
-            isNotNil(selectedNode) &&
-            selectedNode.type !== "system_mock" &&
-            !isClaimAccepted
-        ) {
-            key = setInterval(() => {
-                // Invalidation makes the targeted queries stale.
-                // It creates a Polling effect.
-                queryClient.invalidateQueries({
-                    predicate: (query) => {
-                        const [baseKey, paramsKey] = query.queryKey;
-                        const isEpochQuery =
-                            isString(baseKey) && baseKey.includes("epoch");
-                        const isMatchingEpochIndex =
-                            isObj(paramsKey) &&
-                            pathOr("", ["epochIndex"], paramsKey) ===
-                                output.epochIndex.toString();
-
-                        return isEpochQuery && isMatchingEpochIndex;
-                    },
-                });
-            }, POLLING_INTERVAL_MS);
-        }
-
-        return () => {
-            if (isNotNil(key)) {
-                console.info(`Clearing the polling.`);
-                clearInterval(key as number);
-            }
-        };
-    }, [queryClient, isClaimAccepted, selectedNode, output.epochIndex]);
 
     return (
         <Fieldset legend={title}>
@@ -259,107 +89,19 @@ const VoucherContent: FC<VoucherProps> = ({
                     </Spoiler>
                 </>
             )}
-            <Stack>
-                <Divider mt="sm" />
 
-                <Activity mode={!isClaimAccepted ? "visible" : "hidden"}>
-                    <Group justify="flex-end">
-                        <Badge
-                            radius="xs"
-                            size="lg"
-                            leftSection={
-                                <Tooltip
-                                    label={
-                                        "Once the epoch status become CLAIM_ACCEPTED the voucher will become executable."
-                                    }
-                                >
-                                    <TbInfoCircle
-                                        size={theme.other.smIconSize}
-                                    />
-                                </Tooltip>
-                            }
-                        >
-                            Waiting Claim
-                        </Badge>
-                    </Group>
-                </Activity>
-
-                <Activity mode={isClaimAccepted ? "visible" : "hidden"}>
-                    <Group
-                        justify={
-                            hasExecutionTransaction
-                                ? "space-between"
-                                : "flex-end"
-                        }
-                    >
-                        {isNotNil(output.executionTransactionHash) && (
-                            <Group gap={3}>
-                                <Tooltip label="Transaction hash">
-                                    <TbReceipt size={theme.other.mdIconSize} />
-                                </Tooltip>
-                                <TransactionHash
-                                    transactionHash={
-                                        output.executionTransactionHash
-                                    }
-                                />
-                            </Group>
-                        )}
-                        <Button
-                            disabled={isExecuteDisabled}
-                            loading={isExecutingVoucher}
-                            onClick={() => {
-                                const needSwitchNetwork =
-                                    userAccount.isConnected &&
-                                    isNil(userAccount.chain);
-                                const canSend =
-                                    !needSwitchNetwork &&
-                                    userAccount.isConnected;
-
-                                if (needSwitchNetwork)
-                                    return chainModal.openChainModal?.();
-
-                                if (canSend) {
-                                    execute.writeContract(
-                                        prepare.data!.request,
-                                    );
-                                } else {
-                                    connectModal.openConnectModal?.();
-                                }
-                            }}
-                        >
-                            {wasOutputExecuted
-                                ? "Executed"
-                                : checkingOutputExecuted
-                                  ? "Checking voucher..."
-                                  : prepare.isFetching
-                                    ? "Preparing voucher..."
-                                    : "Execute"}
-                        </Button>
-                    </Group>
-                </Activity>
-            </Stack>
-            {hasErrors && (
-                <Stack py="sm">
-                    {errors.map((error) => (
-                        <Alert
-                            key={error?.message}
-                            color="red"
-                            title={pathOr("", ["shortMessage"], error)}
-                            icon={
-                                <TbExclamationCircle
-                                    size={theme.other.mdIconSize}
-                                />
-                            }
-                        >
-                            {pathOr(
-                                "Something went wrong!",
-                                ["cause", "data", "errorName"],
-                                error,
-                            )}
-                        </Alert>
-                    ))}
-                </Stack>
-            )}
+            <OutputExecution
+                application={application as Hex}
+                output={output}
+                onSuccess={() => {
+                    notifications.show({
+                        title: "Voucher execution status",
+                        message: "Executed successfully",
+                        color: "green",
+                        withBorder: true,
+                    });
+                }}
+            />
         </Fieldset>
     );
 };

--- a/apps/dave/src/components/output/OutputView.tsx
+++ b/apps/dave/src/components/output/OutputView.tsx
@@ -1,22 +1,52 @@
+"use client";
 import type {
     DelegateCallVoucher,
     GetOutputReturnType,
     Notice,
+    Output,
     Voucher,
 } from "@cartesi/viem";
-import { Divider, Fieldset, Group, Spoiler, Text } from "@mantine/core";
-import { isNotNil } from "ramda";
-import type { FC } from "react";
-import { formatUnits, isHex } from "viem";
+import {
+    useEpoch,
+    useReadApplicationWasOutputExecuted,
+    useSimulateApplicationExecuteOutput,
+    useWriteApplicationExecuteOutput,
+} from "@cartesi/wagmi";
+import {
+    Alert,
+    Badge,
+    Button,
+    Divider,
+    Fieldset,
+    Group,
+    Spoiler,
+    Stack,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { useChainModal, useConnectModal } from "@rainbow-me/rainbowkit";
+import { useQueryClient } from "@tanstack/react-query";
+import { isNil, isNotEmpty, isNotNil, pathOr } from "ramda";
+import { isNotNilOrEmpty, isObj, isString } from "ramda-adjunct";
+import { Activity, useEffect, useMemo, type FC } from "react";
+import { TbExclamationCircle, TbInfoCircle, TbReceipt } from "react-icons/tb";
+import { formatUnits, isHex, type Hex } from "viem";
+import { useAccount, useWaitForTransactionReceipt } from "wagmi";
+import { useIsSmallDevice } from "../../hooks/useIsSmallDevice";
 import { getDecoder } from "../../lib/decoders";
 import Address from "../Address";
+import { useSelectedNodeConnection } from "../connection/hooks";
 import JSONViewer from "../JSONViewer";
 import useVoucherDecoder from "../specification/hooks/useVoucherDecoder";
+import TransactionHash from "../TransactionHash";
 import type { DecoderType } from "../types";
 
 interface OutputViewProps {
     displayAs?: DecoderType;
     output: GetOutputReturnType;
+    application: string;
 }
 
 type NoticeProps = { decodedData: Notice; decoderType: DecoderType };
@@ -35,18 +65,45 @@ const NoticeContent: FC<NoticeProps> = ({ decodedData, decoderType }) => {
     );
 };
 
-type VoucherProps = {
+type VoucherOutput = Omit<Output, "decodedData"> & {
     decodedData: Voucher | DelegateCallVoucher;
+};
+
+type VoucherProps = {
+    output: VoucherOutput;
+    application: string;
     decoderType: DecoderType;
     title?: string;
 };
 
+type Proof = { outputIndex: bigint; outputHashesSiblings: Hex[] };
+
+const buildProof = (output: VoucherOutput): Proof => ({
+    outputIndex: output.index,
+    outputHashesSiblings: output.outputHashesSiblings ?? [],
+});
+
+// xxx: Maybe should become an environment var.
+const POLLING_INTERVAL_MS = 8000 as const;
+
 const VoucherContent: FC<VoucherProps> = ({
-    decodedData,
     decoderType,
+    output,
+    application,
     title = "Voucher",
 }) => {
     const decoderFn = getDecoder(decoderType);
+    const { isSmallDevice } = useIsSmallDevice();
+    const userAccount = useAccount();
+    const connectModal = useConnectModal();
+    const selectedNode = useSelectedNodeConnection();
+    const chainModal = useChainModal();
+    const queryClient = useQueryClient();
+
+    const { decodedData, epochIndex } = output;
+
+    const theme = useMantineTheme();
+    const epochQuery = useEpoch({ epochIndex, application });
     const hasPayload =
         isHex(decodedData.payload) && decodedData.payload !== "0x";
     const amount = decodedData.type === "Voucher" ? decodedData.value : 0n;
@@ -54,13 +111,127 @@ const VoucherContent: FC<VoucherProps> = ({
     const voucherDecodingRes = useVoucherDecoder({ voucher: decodedData });
     const hasDecodedData = isNotNil(voucherDecodingRes.data);
     const isDecodedSelected = decoderType === "decoded";
+    const appAddress = application as Hex;
+
+    const isClaimAccepted = epochQuery.data?.status === "CLAIM_ACCEPTED";
+    const hasExecutionTransaction = isNotNil(output.executionTransactionHash);
+
+    const wasOutputExecutedQuery = useReadApplicationWasOutputExecuted({
+        address: appAddress,
+        args: [output.index],
+        query: {
+            enabled: !hasExecutionTransaction && isNotNil(output.index),
+        },
+    });
+
+    const {
+        data: wasOutputExecuted,
+        isFetching: checkingOutputExecuted,
+        error: checkingOutputExecutedError,
+        refetch: recheckOutputExecuted,
+    } = wasOutputExecutedQuery;
+
+    const proof = buildProof(output);
+
+    const hasHashes = isNotEmpty(proof.outputHashesSiblings);
+    const canSimulate =
+        userAccount.isConnected &&
+        !checkingOutputExecuted &&
+        wasOutputExecuted === false &&
+        hasHashes &&
+        isClaimAccepted;
+
+    const prepare = useSimulateApplicationExecuteOutput({
+        address: appAddress,
+        args: [output.rawData, proof],
+        query: {
+            enabled: canSimulate,
+        },
+    });
+
+    const execute = useWriteApplicationExecuteOutput();
+    const wait = useWaitForTransactionReceipt({
+        hash: execute.data,
+    });
+
+    const isExecutingVoucher = execute.isPending || wait.isFetching;
+
+    const errors = useMemo(() => {
+        return [checkingOutputExecutedError, prepare.error].filter(
+            isNotNilOrEmpty,
+        );
+    }, [checkingOutputExecutedError, prepare.error]);
+
+    const hasErrors = errors.length > 0;
+
+    const isExecuteDisabled =
+        !isClaimAccepted ||
+        checkingOutputExecuted ||
+        wasOutputExecuted ||
+        prepare.isFetching ||
+        hasErrors;
+
+    useEffect(() => {
+        if (wait.isSuccess) {
+            notifications.show({
+                title: "Voucher execution status",
+                message: "Executed successfully",
+                color: "green",
+                withBorder: true,
+            });
+            execute.reset();
+            recheckOutputExecuted();
+            // mark outputs as stale to get latest values from rollups-node.
+            queryClient.invalidateQueries({ queryKey: ["outputs"] });
+        }
+    }, [wait.isSuccess, recheckOutputExecuted, execute, queryClient]);
+
+    useEffect(() => {
+        let key: unknown;
+        // skip invalidation if there is no node-connected or the connected node is a mock.
+        if (
+            isNotNil(selectedNode) &&
+            selectedNode.type !== "system_mock" &&
+            !isClaimAccepted
+        ) {
+            key = setInterval(() => {
+                // Invalidation makes the targeted queries stale.
+                // It creates a Polling effect.
+                queryClient.invalidateQueries({
+                    predicate: (query) => {
+                        const [baseKey, paramsKey] = query.queryKey;
+                        const isEpochQuery =
+                            isString(baseKey) && baseKey.includes("epoch");
+                        const isMatchingEpochIndex =
+                            isObj(paramsKey) &&
+                            pathOr("", ["epochIndex"], paramsKey) ===
+                                output.epochIndex.toString();
+
+                        return isEpochQuery && isMatchingEpochIndex;
+                    },
+                });
+            }, POLLING_INTERVAL_MS);
+        }
+
+        return () => {
+            if (isNotNil(key)) {
+                console.info(`Clearing the polling.`);
+                clearInterval(key as number);
+            }
+        };
+    }, [queryClient, isClaimAccepted, selectedNode, output.epochIndex]);
 
     return (
         <Fieldset legend={title}>
             <Group gap="xs">
                 <Text c="blue">Destination</Text>
-                <Address value={decodedData.destination} wrap="nowrap" />
+                <Address
+                    value={decodedData.destination}
+                    wrap="nowrap"
+                    shorten={isSmallDevice}
+                />
             </Group>
+
             {hasAmount && (
                 <Group>
                     <Text c="blue">Amount</Text>
@@ -78,7 +249,7 @@ const VoucherContent: FC<VoucherProps> = ({
                         {hasDecodedData && isDecodedSelected ? (
                             <JSONViewer
                                 content={voucherDecodingRes.data ?? ""}
-                                key={`decoded-view-${decodedData.destination}`}
+                                key={`decoded-view-${output.index}-${decodedData.destination}`}
                             />
                         ) : (
                             <Text style={{ wordBreak: "break-all" }}>
@@ -88,6 +259,107 @@ const VoucherContent: FC<VoucherProps> = ({
                     </Spoiler>
                 </>
             )}
+            <Stack>
+                <Divider mt="sm" />
+
+                <Activity mode={!isClaimAccepted ? "visible" : "hidden"}>
+                    <Group justify="flex-end">
+                        <Badge
+                            radius="xs"
+                            size="lg"
+                            leftSection={
+                                <Tooltip
+                                    label={
+                                        "Once the epoch status become CLAIM_ACCEPTED the voucher will become executable."
+                                    }
+                                >
+                                    <TbInfoCircle
+                                        size={theme.other.smIconSize}
+                                    />
+                                </Tooltip>
+                            }
+                        >
+                            Waiting Claim
+                        </Badge>
+                    </Group>
+                </Activity>
+
+                <Activity mode={isClaimAccepted ? "visible" : "hidden"}>
+                    <Group
+                        justify={
+                            hasExecutionTransaction
+                                ? "space-between"
+                                : "flex-end"
+                        }
+                    >
+                        {isNotNil(output.executionTransactionHash) && (
+                            <Group gap={3}>
+                                <Tooltip label="Transaction hash">
+                                    <TbReceipt size={theme.other.mdIconSize} />
+                                </Tooltip>
+                                <TransactionHash
+                                    transactionHash={
+                                        output.executionTransactionHash
+                                    }
+                                />
+                            </Group>
+                        )}
+                        <Button
+                            disabled={isExecuteDisabled}
+                            loading={isExecutingVoucher}
+                            onClick={() => {
+                                const needSwitchNetwork =
+                                    userAccount.isConnected &&
+                                    isNil(userAccount.chain);
+                                const canSend =
+                                    !needSwitchNetwork &&
+                                    userAccount.isConnected;
+
+                                if (needSwitchNetwork)
+                                    return chainModal.openChainModal?.();
+
+                                if (canSend) {
+                                    execute.writeContract(
+                                        prepare.data!.request,
+                                    );
+                                } else {
+                                    connectModal.openConnectModal?.();
+                                }
+                            }}
+                        >
+                            {wasOutputExecuted
+                                ? "Executed"
+                                : checkingOutputExecuted
+                                  ? "Checking voucher..."
+                                  : prepare.isFetching
+                                    ? "Preparing voucher..."
+                                    : "Execute"}
+                        </Button>
+                    </Group>
+                </Activity>
+            </Stack>
+            {hasErrors && (
+                <Stack py="sm">
+                    {errors.map((error) => (
+                        <Alert
+                            key={error?.message}
+                            color="red"
+                            title={pathOr("", ["shortMessage"], error)}
+                            icon={
+                                <TbExclamationCircle
+                                    size={theme.other.mdIconSize}
+                                />
+                            }
+                        >
+                            {pathOr(
+                                "Something went wrong!",
+                                ["cause", "data", "errorName"],
+                                error,
+                            )}
+                        </Alert>
+                    ))}
+                </Stack>
+            )}
         </Fieldset>
     );
 };
@@ -95,6 +367,7 @@ const VoucherContent: FC<VoucherProps> = ({
 export const OutputView: FC<OutputViewProps> = ({
     displayAs = "raw",
     output,
+    application,
 }) => {
     const outputType = output.decodedData.type;
     return (
@@ -106,13 +379,15 @@ export const OutputView: FC<OutputViewProps> = ({
                 />
             ) : outputType === "Voucher" ? (
                 <VoucherContent
-                    decodedData={output.decodedData}
+                    application={application}
+                    output={output as VoucherOutput}
                     decoderType={displayAs}
                 />
             ) : outputType === "DelegateCallVoucher" ? (
                 <VoucherContent
+                    application={application}
                     title="Delegated Call Voucher"
-                    decodedData={output.decodedData}
+                    output={output as VoucherOutput}
                     decoderType={displayAs}
                 />
             ) : null}

--- a/apps/dave/src/components/output/errors/OutputExecutionError.ts
+++ b/apps/dave/src/components/output/errors/OutputExecutionError.ts
@@ -1,0 +1,58 @@
+import { pathOr } from "ramda";
+import type {
+    ReadContractErrorType,
+    SimulateContractErrorType,
+} from "wagmi/actions";
+
+export type WagmiActionError =
+    | ReadContractErrorType
+    | SimulateContractErrorType;
+
+type WagmiError = {
+    type: "wagmi-error";
+    error: WagmiActionError;
+};
+
+type SimpleError = {
+    type: "error";
+    message: string;
+    shortMessage?: string;
+};
+
+type Params = WagmiError | SimpleError;
+
+class OutputExecutionError {
+    shortMessage: string = "";
+    message: string = "Output execution failed!";
+
+    constructor(params: Params) {
+        switch (params.type) {
+            case "error":
+                this.setError(params.message, params.shortMessage);
+                break;
+            case "wagmi-error":
+                this.setWagmiError(params.error);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private setWagmiError(error: WagmiActionError) {
+        const message = pathOr(this.message, ["shortMessage"], error);
+        const shortMessage = pathOr(
+            this.shortMessage,
+            ["cause", "data", "errorName"],
+            error,
+        );
+
+        this.setError(message, shortMessage);
+    }
+
+    private setError(message: string, shortMessage?: string) {
+        this.message = message;
+        this.shortMessage = shortMessage ?? "Something is not right!";
+    }
+}
+
+export default OutputExecutionError;

--- a/apps/dave/src/components/output/types.ts
+++ b/apps/dave/src/components/output/types.ts
@@ -1,0 +1,31 @@
+"use client";
+import type {
+    DelegateCallVoucher,
+    GetOutputReturnType,
+    Notice,
+    Output,
+    Voucher,
+} from "@cartesi/viem";
+import type { DecoderType } from "../types";
+
+export type VoucherOutput = Omit<Output, "decodedData"> & {
+    decodedData: Voucher | DelegateCallVoucher;
+};
+
+export type VoucherContentProps = {
+    output: VoucherOutput;
+    application: string;
+    decoderType: DecoderType;
+    title?: string;
+};
+
+export type OutputViewProps = {
+    displayAs?: DecoderType;
+    output: GetOutputReturnType;
+    application: string;
+};
+
+export type NoticeContentProps = {
+    decodedData: Notice;
+    decoderType: DecoderType;
+};


### PR DESCRIPTION
# Summary

Code changes to add support for output execution. [issue #427](https://github.com/cartesi/rollups-explorer/issues/427)
I want to draw attention to one "business logic" here: If the epoch's status where the output(s) you are looking at was generated is not yet set as `CLAIM_ACCEPTED`, the application will present a wording `waiting claim` with a info icon with a tooltip with more details if you hover on it, and will actively observe the epoch until its status moves to the expected status (i.e. `CLAIM_ACCEPTED`). The execution itself follows the usual workflow: `click the execute button` -> `confirm transaction in the wallet` -> `wait transaction confirmation`. 


A Deployed version of this branch/PR: https://dave-git-feat-add-output-execution-capability-cartesi.vercel.app/

### Testing Steps
It is expected that a Cartesi Application is available to generate voucher outputs.

* Create a voucher output so you can check receiving it back (e.g. Ether Deposit).
* On the home page, click the application, and it will navigate to the application summary page.
* In the application summary page, scroll down to the latest inputs and click the `Outputs` option in the input of interest.
* If the epoch is not `CLAIM_ACCEPTED`, you shall see a blue square at the bottom right of the output content saying `WAITING CLAIM` ℹ (the square icon here is just for reference)
* If the epoch has status `CLAIM_ACCEPTED`, you shall see a button with text `Execute` if the output is not yet executed.
  * Just click and follow the flow to execute the voucher output. 
* If the output is executed, the button is permanently grey with text `Executed`, and on the right side, the Tx hash will appear. PS: _The transaction hash becomes a link only for testnets and mainnets. For devnets, it is only text you can copy_
* Any errors that occur during the execution will display right below the Execute button area as a red Alert. 



closes #427 
