### PR TITLE
feat: better handling of apps that uses Authority consensus.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
         "source.fixAll": "explicit",
         "source.organizeImports": "explicit"
     },
-    "typescript.tsdk": "node_modules/typescript/lib",
+    "js/ts.tsdk.path": "node_modules/typescript/lib",
     "[terraform]": {
         "editor.defaultFormatter": "hashicorp.terraform"
     },

--- a/apps/explorer/src/components/send/SendMenu.tsx
+++ b/apps/explorer/src/components/send/SendMenu.tsx
@@ -87,7 +87,7 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                         handlers.close();
                     }}
                 >
-                    <Text fw="500">Ethereum</Text>
+                    <Text fw="500">Ether</Text>
                 </Menu.Item>
                 <Menu.Item
                     leftSection={<TbCurrencyEthereum size={24} />}

--- a/apps/explorer/src/containers/ApplicationSummaryContainer.tsx
+++ b/apps/explorer/src/containers/ApplicationSummaryContainer.tsx
@@ -1,11 +1,13 @@
 "use client";
 import {
+    useApplication,
     useEpochs,
     useInputs,
     useOutputs,
     useReports,
     useTournaments,
 } from "@cartesi/wagmi";
+import { isNotNil } from "ramda";
 import type { FC } from "react";
 import {
     Hierarchy,
@@ -13,6 +15,7 @@ import {
 } from "../components/navigation/Hierarchy";
 import { ApplicationSummaryPage } from "../page/ApplicationSummaryPage";
 import { pathBuilder } from "../routes/routePathBuilder";
+import { ContainerSkeleton } from "./ContainerSkeleton";
 import ContainerStack from "./ContainerStack";
 
 interface ApplicationSummaryContainerProps {
@@ -27,6 +30,10 @@ const defaultParams = {
 export const ApplicationSummaryContainer: FC<
     ApplicationSummaryContainerProps
 > = (props) => {
+    const { data: application, isLoading: isLoadingApplication } =
+        useApplication({
+            application: props.application,
+        });
     const epochsResult = useEpochs({
         application: props.application,
         ...defaultParams,
@@ -86,17 +93,24 @@ export const ApplicationSummaryContainer: FC<
         },
     ];
 
+    const isLoading = isLoadingApplication;
+    const showPage = isNotNil(application);
+
     return (
         <ContainerStack>
             <Hierarchy hierarchyConfig={hierarchyConfig} />
-            <ApplicationSummaryPage
-                application={props.application}
-                epochs={epochs}
-                inputs={inputs}
-                outputs={outputs}
-                reports={reports}
-                tournaments={tournaments}
-            />
+            {isLoading && <ContainerSkeleton />}
+            {showPage && (
+                <ApplicationSummaryPage
+                    application={props.application}
+                    applicationConsensusType={application.consensusType}
+                    epochs={epochs}
+                    inputs={inputs}
+                    outputs={outputs}
+                    reports={reports}
+                    tournaments={tournaments}
+                />
+            )}
         </ContainerStack>
     );
 };

--- a/apps/explorer/src/containers/EpochContainer.tsx
+++ b/apps/explorer/src/containers/EpochContainer.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { useEpoch, useInputs } from "@cartesi/wagmi";
+import { useApplication, useEpoch, useInputs } from "@cartesi/wagmi";
 import { notFound } from "next/navigation";
+import { isNotNil } from "ramda";
 import { type FC } from "react";
 import {
     Hierarchy,
@@ -22,8 +23,11 @@ export type EpochContainerProps = {
 export const EpochContainer: FC<EpochContainerProps> = (props) => {
     const { data: epoch, isLoading: isEpochLoading } = useEpoch(props);
     const { data: inputs, isLoading: isInputsLoading } = useInputs(props);
+    const { data: application, isLoading: isApplicationLoading } =
+        useApplication({ application: props.application });
 
-    const isLoading = isEpochLoading || isInputsLoading;
+    const isLoading = isEpochLoading || isInputsLoading || isApplicationLoading;
+    const showPage = isNotNil(epoch) && isNotNil(application);
 
     const hierarchyConfig: HierarchyConfig[] = [
         { title: "Home", href: "/" },
@@ -49,9 +53,10 @@ export const EpochContainer: FC<EpochContainerProps> = (props) => {
         <ContainerStack>
             <Hierarchy hierarchyConfig={hierarchyConfig} />
             {isLoading && <ContainerSkeleton />}
-            {!!epoch && (
+            {showPage && (
                 <EpochPage
                     epoch={epoch}
+                    application={application}
                     inputs={inputs?.data ?? []}
                     pagination={inputs?.pagination}
                 />

--- a/apps/explorer/src/page/ApplicationSummaryPage.stories.tsx
+++ b/apps/explorer/src/page/ApplicationSummaryPage.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import { getUnixTime, subHours } from "date-fns";
 import { ApplicationSummaryPage } from "./ApplicationSummaryPage";
 
 const meta = {
@@ -14,6 +15,7 @@ const date = new Date();
 
 const params: Parameters<typeof ApplicationSummaryPage>[0] = {
     application: "aeron",
+    applicationConsensusType: "PRT",
     inputs: {
         data: [
             {
@@ -28,7 +30,7 @@ const params: Parameters<typeof ApplicationSummaryPage>[0] = {
                         "0x40a7C73a6a592D8697bE97254E273E6f3FB46000",
                     sender: "0xA632c5c05812c6a6149B7af5C56117d1D2603828",
                     blockNumber: 10830n,
-                    blockTimestamp: 1770313035n,
+                    blockTimestamp: BigInt(getUnixTime(subHours(date, 10))),
                     prevRandao:
                         32087405413018063438212660768862326033482889634384336760477959572643178016995n,
                     index: 0n,
@@ -142,6 +144,106 @@ const params: Parameters<typeof ApplicationSummaryPage>[0] = {
     },
 };
 
-export const Default: Story = {
+export const PRTApplication: Story = {
     args: params,
+};
+
+export const AuthorityApplication: Story = {
+    args: {
+        application: "NewApp",
+        applicationConsensusType: "AUTHORITY",
+        inputs: {
+            data: [
+                {
+                    epochIndex: 36n,
+                    index: 0n,
+                    blockNumber: 10830n,
+                    rawData:
+                        "0x415bf3630000000000000000000000000000000000000000000000000000000000007a6900000000000000000000000040a7c73a6a592d8697be97254e273e6f3fb46000000000000000000000000000a632c5c05812c6a6149b7af5c56117d1d26038280000000000000000000000000000000000000000000000000000000000002a4e000000000000000000000000000000000000000000000000000000006984d54b46f0d3ef2cf902a71ed5d4f180ff2aa8cd21851eb9cff5425199d023c522f0e3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000034a074683b5be015f053b5dceb064c41fc9d11b6e50000000000000000000000000000000000000000000000001bc16d674ec80000000000000000000000000000",
+                    decodedData: {
+                        chainId: 31337n,
+                        applicationContract:
+                            "0x40a7C73a6a592D8697bE97254E273E6f3FB46000",
+                        sender: "0xA632c5c05812c6a6149B7af5C56117d1D2603828",
+                        blockNumber: 10830n,
+                        blockTimestamp: BigInt(getUnixTime(subHours(date, 4))),
+                        prevRandao:
+                            32087405413018063438212660768862326033482889634384336760477959572643178016995n,
+                        index: 0n,
+                        payload:
+                            "0xa074683b5be015f053b5dceb064c41fc9d11b6e50000000000000000000000000000000000000000000000001bc16d674ec80000",
+                    },
+                    status: "ACCEPTED",
+                    machineHash:
+                        "0x227d685f612568ed2d5b34fb8e3c19eef80097430498fd2b4a60e73c59e75e8a",
+                    outputsHash:
+                        "0x97a8872d473a093269f65e4e14170fcf5d1383cd105d7215688f5e8c55f00553",
+                    transactionReference:
+                        "0x75e1a936e92309ce05d3592905fb08637e64dab4131440c59ff053880ffde098",
+                    createdAt: date,
+                    updatedAt: date,
+                },
+            ],
+            totalCount: 1,
+            isLoading: false,
+        },
+        outputs: {
+            totalCount: 2,
+            isLoading: false,
+        },
+        reports: {
+            totalCount: 0,
+            isLoading: false,
+        },
+        tournaments: {
+            data: [],
+            totalCount: 0,
+            isLoading: false,
+        },
+
+        epochs: {
+            data: [
+                {
+                    index: 52n,
+                    firstBlock: 15391n,
+                    lastBlock: 15498n,
+                    inputIndexLowerBound: 1n,
+                    inputIndexUpperBound: 1n,
+                    tournamentAddress: null,
+                    machineHash: null,
+                    commitment: null,
+                    claimTransactionHash: null,
+                    status: "OPEN",
+                    virtualIndex: 52n,
+                    createdAt: date,
+                    updatedAt: date,
+                    commitmentProof: null,
+                    outputsMerkleProof: null,
+                    outputsMerkleRoot: null,
+                },
+                {
+                    index: 51n,
+                    firstBlock: 15090n,
+                    lastBlock: 15391n,
+                    inputIndexLowerBound: 1n,
+                    inputIndexUpperBound: 1n,
+                    tournamentAddress: null,
+                    machineHash:
+                        "0x227d685f612568ed2d5b34fb8e3c19eef80097430498fd2b4a60e73c59e75e8a",
+                    commitment:
+                        "0x725e9d3febbdd79841345f187aacf343ee497214277f3cb330aca90319cbdd92",
+                    claimTransactionHash: null,
+                    status: "CLAIM_ACCEPTED",
+                    virtualIndex: 51n,
+                    createdAt: date,
+                    updatedAt: date,
+                    commitmentProof: null,
+                    outputsMerkleProof: null,
+                    outputsMerkleRoot: null,
+                },
+            ],
+            totalCount: 53,
+            isLoading: false,
+        },
+    },
 };

--- a/apps/explorer/src/page/ApplicationSummaryPage.tsx
+++ b/apps/explorer/src/page/ApplicationSummaryPage.tsx
@@ -1,4 +1,5 @@
 import type {
+    Application,
     GetEpochReturnType,
     GetInputReturnType,
     GetTournamentReturnType,
@@ -7,7 +8,7 @@ import { Anchor, Card, Grid, Group, Stack, Text, Title } from "@mantine/core";
 import Link from "next/link";
 import { head } from "ramda";
 import { isNilOrEmpty } from "ramda-adjunct";
-import type { FC } from "react";
+import { Activity, type FC } from "react";
 import {
     TbClock,
     TbInbox,
@@ -34,6 +35,7 @@ type Meta<T> = OmitNever<{
 
 interface Props {
     application: string;
+    applicationConsensusType: Application["consensusType"];
     inputs: Meta<GetInputReturnType[]>;
     epochs: Meta<GetEpochReturnType[]>;
     outputs: Meta<never>;
@@ -41,7 +43,14 @@ interface Props {
     tournaments: Meta<GetTournamentReturnType[]>;
 }
 
-const gridSpan = { base: 12, xs: 6, sm: 4 };
+const getGridSpan = (consensusType: Application["consensusType"]) => {
+    switch (consensusType) {
+        case "PRT":
+            return { base: 12, xs: 6, sm: 4 };
+        default:
+            return { base: 12, xs: 6 };
+    }
+};
 
 export const ApplicationSummaryPage: FC<Props> = ({
     application,
@@ -50,9 +59,12 @@ export const ApplicationSummaryPage: FC<Props> = ({
     outputs,
     reports,
     tournaments,
+    applicationConsensusType,
 }) => {
     const latestTournament = head(tournaments.data);
     const epochsUrls = pathBuilder.epochs({ application });
+
+    const gridSpan = getGridSpan(applicationConsensusType);
 
     const tournamentUrl =
         latestTournament !== undefined
@@ -100,14 +112,22 @@ export const ApplicationSummaryPage: FC<Props> = ({
                     />
                 </Grid.Col>
 
-                <Grid.Col span={gridSpan} mb="sm">
-                    <SummaryCard
-                        title="Tournaments"
-                        value={tournaments.totalCount}
-                        icon={TbTrophy}
-                        displaySkeleton={tournaments.isLoading}
-                    />
-                </Grid.Col>
+                <Activity
+                    mode={
+                        applicationConsensusType === "PRT"
+                            ? "visible"
+                            : "hidden"
+                    }
+                >
+                    <Grid.Col span={gridSpan} mb="sm">
+                        <SummaryCard
+                            title="Tournaments"
+                            value={tournaments.totalCount}
+                            icon={TbTrophy}
+                            displaySkeleton={tournaments.isLoading}
+                        />
+                    </Grid.Col>
+                </Activity>
             </Grid>
 
             {tournamentUrl && (

--- a/apps/explorer/src/page/EpochPage.stories.tsx
+++ b/apps/explorer/src/page/EpochPage.stories.tsx
@@ -1,5 +1,6 @@
 import { Stack } from "@mantine/core";
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import { getUnixTime, subMinutes, subSeconds } from "date-fns";
 import { keccak256 } from "viem";
 import { Hierarchy } from "../components/navigation/Hierarchy";
 import { applications } from "../stories/data";
@@ -17,7 +18,7 @@ type Story = StoryObj<typeof meta>;
 type Props = Parameters<typeof EpochPage>[0];
 
 const WithBreadcrumb = (props: Props) => {
-    const app = applications[0];
+    const app = props.application;
     return (
         <Stack gap="lg">
             <Hierarchy
@@ -32,9 +33,12 @@ const WithBreadcrumb = (props: Props) => {
     );
 };
 
+const currentDatetime = new Date();
+
 export const Open: Story = {
     render: WithBreadcrumb,
     args: {
+        application: applications[0],
         epoch: applications[0].epochs[4],
         inputs: [
             {
@@ -52,7 +56,9 @@ export const Open: Story = {
                     applicationContract:
                         "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
                     blockNumber: 1n,
-                    blockTimestamp: 1n,
+                    blockTimestamp: BigInt(
+                        getUnixTime(subSeconds(currentDatetime, 20)),
+                    ),
                     chainId: 13370n,
                     index: 0n,
                     prevRandao: 1n,
@@ -78,7 +84,9 @@ export const Open: Story = {
                     applicationContract:
                         "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
                     blockNumber: 1n,
-                    blockTimestamp: 1n,
+                    blockTimestamp: BigInt(
+                        getUnixTime(subMinutes(currentDatetime, 10)),
+                    ),
                     chainId: 13370n,
                     index: 0n,
                     prevRandao: 1n,
@@ -104,7 +112,9 @@ export const Open: Story = {
                     applicationContract:
                         "0x7d6bcf9b5bb5bfb0ae793082c271931ec333e35d",
                     blockNumber: 1n,
-                    blockTimestamp: 1n,
+                    blockTimestamp: BigInt(
+                        getUnixTime(subMinutes(currentDatetime, 12)),
+                    ),
                     chainId: 13370n,
                     index: 0n,
                     prevRandao: 1n,
@@ -122,6 +132,7 @@ export const Open: Story = {
 export const ClosedInDispute: Story = {
     render: WithBreadcrumb,
     args: {
+        application: applications[0],
         epoch: applications[0].epochs[3],
         inputs: [
             {
@@ -135,7 +146,9 @@ export const ClosedInDispute: Story = {
                 decodedData: {
                     applicationContract: applications[0].applicationAddress,
                     blockNumber: 1n,
-                    blockTimestamp: 1n,
+                    blockTimestamp: BigInt(
+                        getUnixTime(subSeconds(currentDatetime, 10)),
+                    ),
                     chainId: 13370n,
                     index: 2n,
                     prevRandao: 1n,
@@ -163,7 +176,9 @@ export const ClosedInDispute: Story = {
                     sender: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
                     applicationContract: applications[0].applicationAddress,
                     blockNumber: 1n,
-                    blockTimestamp: 1n,
+                    blockTimestamp: BigInt(
+                        getUnixTime(subMinutes(currentDatetime, 5)),
+                    ),
                     chainId: 13370n,
                     index: 1n,
                     prevRandao: 1n,
@@ -185,7 +200,9 @@ export const ClosedInDispute: Story = {
                 decodedData: {
                     applicationContract: applications[0].applicationAddress,
                     blockNumber: 1n,
-                    blockTimestamp: 1n,
+                    blockTimestamp: BigInt(
+                        getUnixTime(subMinutes(currentDatetime, 8)),
+                    ),
                     chainId: 13370n,
                     index: 0n,
                     prevRandao: 1n,
@@ -196,6 +213,63 @@ export const ClosedInDispute: Story = {
                 blockNumber: 1n,
                 createdAt: new Date(),
                 updatedAt: new Date(),
+                rawData: "0x",
+                transactionReference: keccak256("0x1"),
+            },
+        ],
+    },
+};
+
+const authorityApp = applications[1];
+
+export const AuthorityOpenEpoch: Story = {
+    render: WithBreadcrumb,
+    args: {
+        application: authorityApp,
+        epoch: {
+            index: 0n,
+            claimTransactionHash: null,
+            commitment: null,
+            commitmentProof: null,
+            createdAt: currentDatetime,
+            firstBlock: 0n,
+            inputIndexLowerBound: 0n,
+            inputIndexUpperBound: 1n,
+            lastBlock: 0n,
+            machineHash:
+                "0x9ffb262ceb9b337cc4472dcaf27766b0395c63a23c3705968d0578a24b272890",
+            status: "OPEN",
+            tournamentAddress: null,
+            updatedAt: currentDatetime,
+            virtualIndex: 0n,
+            outputsMerkleProof: null,
+            outputsMerkleRoot: null,
+        },
+        inputs: [
+            {
+                index: 3n,
+                status: "ACCEPTED",
+                epochIndex: 0n,
+                machineHash:
+                    "0xd721e60f83c8fc277b2d2e23a24e77a4035ee1f482b64486a78dd5598f11364b",
+                outputsHash:
+                    "0x0a162946e56158bac0673e6dd3bdfdc1e4a0e7744a120fdb640050c8d7abe1c6",
+                decodedData: {
+                    applicationContract: authorityApp.applicationAddress,
+                    blockNumber: 1n,
+                    blockTimestamp: BigInt(
+                        getUnixTime(subSeconds(currentDatetime, 10)),
+                    ),
+                    chainId: 13370n,
+                    index: 2n,
+                    prevRandao: 1n,
+                    payload:
+                        "0x7b22616374696f6e223a226a616d2e7365744e465441646472657373222c2261646472657373223a22307865376631373235453737333443453238384638333637653142623134334539306262334630353132227d",
+                    sender: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                },
+                blockNumber: 1n,
+                createdAt: currentDatetime,
+                updatedAt: currentDatetime,
                 rawData: "0x",
                 transactionReference: keccak256("0x1"),
             },

--- a/apps/explorer/src/page/EpochPage.tsx
+++ b/apps/explorer/src/page/EpochPage.tsx
@@ -11,7 +11,7 @@ import {
     useMantineTheme,
 } from "@mantine/core";
 import Link from "next/link";
-import { isEmpty, isNil, isNotNil } from "ramda";
+import { isEmpty, isNotNil } from "ramda";
 import { Activity, type FC } from "react";
 import { TbClockFilled, TbInbox, TbTrophy } from "react-icons/tb";
 import { isAddress } from "viem";
@@ -73,7 +73,7 @@ export const EpochPage: FC<Props> = ({
                     application.consensusType === "PRT" ? "visible" : "hidden"
                 }
             >
-                <Activity mode={isNotNil(tournamentUrl) ? "visible" : "hidden"}>
+                {isNotNil(tournamentUrl) ? (
                     <Anchor
                         component={Link}
                         href={tournamentUrl!}
@@ -94,14 +94,12 @@ export const EpochPage: FC<Props> = ({
                             />
                         </Group>
                     </Anchor>
-                </Activity>
-
-                <Activity mode={isNil(tournamentUrl) ? "visible" : "hidden"}>
+                ) : (
                     <Group gap="sm">
                         <TbTrophy size={theme.other.mdIconSize} />
                         <Text>No Tournament Yet</Text>
                     </Group>
-                </Activity>
+                )}
             </Activity>
 
             <Group gap="xs">

--- a/apps/explorer/src/page/EpochPage.tsx
+++ b/apps/explorer/src/page/EpochPage.tsx
@@ -1,4 +1,4 @@
-import type { Epoch, Input, Pagination } from "@cartesi/viem";
+import type { Application, Epoch, Input, Pagination } from "@cartesi/viem";
 import {
     Anchor,
     Badge,
@@ -22,6 +22,7 @@ import PageTitle from "../components/layout/PageTitle";
 import { NextPagination } from "../components/navigation/NextPagination";
 
 type Props = {
+    application: Application;
     epoch: Epoch;
     inputs: Input[];
     pagination?: Pagination;
@@ -37,7 +38,12 @@ const NoInputs = () => (
     </Card>
 );
 
-export const EpochPage: FC<Props> = ({ epoch, inputs, pagination }) => {
+export const EpochPage: FC<Props> = ({
+    epoch,
+    inputs,
+    pagination,
+    application,
+}) => {
     const theme = useMantineTheme();
     const epochStatusColor = useEpochStatusColor(epoch);
     const tournamentAddress = epoch.tournamentAddress;
@@ -62,34 +68,40 @@ export const EpochPage: FC<Props> = ({ epoch, inputs, pagination }) => {
                 )}
             </Group>
 
-            <Activity mode={isNotNil(tournamentUrl) ? "visible" : "hidden"}>
-                <Anchor
-                    component={Link}
-                    href={tournamentUrl!}
-                    variant="text"
-                    c={tournamentColor}
-                >
-                    <Group gap="xs">
-                        <Group gap="sm">
-                            <TbTrophy
-                                size={theme.other.mdIconSize}
-                                color={tournamentColor}
+            <Activity
+                mode={
+                    application.consensusType === "PRT" ? "visible" : "hidden"
+                }
+            >
+                <Activity mode={isNotNil(tournamentUrl) ? "visible" : "hidden"}>
+                    <Anchor
+                        component={Link}
+                        href={tournamentUrl!}
+                        variant="text"
+                        c={tournamentColor}
+                    >
+                        <Group gap="xs">
+                            <Group gap="sm">
+                                <TbTrophy
+                                    size={theme.other.mdIconSize}
+                                    color={tournamentColor}
+                                />
+                                <Text c={tournamentColor}>Tournament</Text>
+                            </Group>
+                            <CycleRangeFormatted
+                                size="md"
+                                range={[startCycle, endCycle]}
                             />
-                            <Text c={tournamentColor}>Tournament</Text>
                         </Group>
-                        <CycleRangeFormatted
-                            size="md"
-                            range={[startCycle, endCycle]}
-                        />
-                    </Group>
-                </Anchor>
-            </Activity>
+                    </Anchor>
+                </Activity>
 
-            <Activity mode={isNil(tournamentUrl) ? "visible" : "hidden"}>
-                <Group gap="sm">
-                    <TbTrophy size={theme.other.mdIconSize} />
-                    <Text>No Tournament Yet</Text>
-                </Group>
+                <Activity mode={isNil(tournamentUrl) ? "visible" : "hidden"}>
+                    <Group gap="sm">
+                        <TbTrophy size={theme.other.mdIconSize} />
+                        <Text>No Tournament Yet</Text>
+                    </Group>
+                </Activity>
             </Activity>
 
             <Group gap="xs">


### PR DESCRIPTION
# Summary
Code changes to improve the handling logic of applications that use authority consensus. The initial implementation was highly focused on PRT and its tournaments. Some of this information makes no sense when reading data from an Application using Authority consensus. 

**Changes:**
* For an application that uses Authority upon entering the application summary page, the Tournament summary card is not visible. 
* For an application that uses Authority, when looking into an Epoch page, the link to the tournament or tournament temporary message while waiting for the tournament to be created is not visible.
* Also, update the wording for sending a deposit using the Ether Portal. Before it was `Ethereum`, now it is `Ether`.

# Test Steps
The changes were made using the latest cartesi-cli `v2.0.0-alpha.33` for ease of use. 

To run an application with Authority consensus
```shell
cartesi create --template=<template_name> <project_name>
cd <project_name>
cartesi build
cartesi run 
```
or to use the PRT consensus:
```shell
cartesi run --prt 
```


* There is a live deployed version on Vercel [here is the link](https://dave-git-feat-hide-tournament-information-for-au-afc669-cartesi.vercel.app/). Access the web page and create a connection to the rollups-node RPC and blockchain node (e.g. http://127.0.0.1:6751/anvil) 
* Alternatively, check out the base code of this branch and follow the README information.
* For PRT:
  * Click the application to access its summary page.
  * Verify the top of the page. It should display 5 cards, including the total number of Tournaments.
  * Right below the summary cards, it should display information and link to the active tournament for quick access.
  * Go back to the summary page or click the `epoch #{number}` in the breadcrumb to access the epoch's details page.
  * For a Epoch with status `CLAIM_COMPUTED`, you should see a link to the tournament right below the status information. 
  * For an Epoch with status `Open`, you should see a text stating `No tournament yet`
* For Authority:
  * _Disclaimer: To start seeing epochs, you need to send at least one input._
  * Click the application to access its summary page. 
  * You should see only 4 summary cards at the top. 
  * You should not see any `Active tournament`  link right below. 
  * Click one of the epochs available to see its details,
  * You should not see  a *link to a tournament* 
  * Nor any *wording related to a tournament*
