### PR TITLE
refactor: improve data fetch error and connectivity problems

### DIFF
--- a/apps/explorer/src/components/connection/ConnectionProvider.tsx
+++ b/apps/explorer/src/components/connection/ConnectionProvider.tsx
@@ -2,7 +2,7 @@
 import { Button, Group, Stack, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { isEmpty, isNotNil } from "ramda";
-import { useEffect, useReducer, useRef, type FC, type ReactNode } from "react";
+import { useEffect, useReducer, type FC, type ReactNode } from "react";
 import {
     ConnectionActionContext,
     ConnectionStateContext,
@@ -61,8 +61,6 @@ export const ConnectionProvider: FC<ConnectionProviderProps> = ({
     repository = indexedDbRepository,
 }) => {
     const [state, dispatch] = useReducer(reducer, repository, initState);
-
-    const prev = useRef(state.selectedConnection);
     const selectedConfig = getSelectedConfig(state);
     const [result] = useCheckNodeConnection(selectedConfig);
 
@@ -113,8 +111,8 @@ export const ConnectionProvider: FC<ConnectionProviderProps> = ({
     }, [repository]);
 
     useEffect(() => {
-        if (null !== prev.current && result.status === "error") {
-            const notificationId = prev.current.toString();
+        if (isNotNil(selectedConfig?.id) && result.status === "error") {
+            const notificationId = selectedConfig.id.toString();
             notifications.show({
                 id: notificationId,
                 color: "red",
@@ -133,7 +131,7 @@ export const ConnectionProvider: FC<ConnectionProviderProps> = ({
                 ),
             });
         }
-    }, [result]);
+    }, [result, selectedConfig]);
 
     useEffect(() => {
         // the state starts with fetching. After startup if a connection is not selected;

--- a/apps/explorer/src/containers/ApplicationSummaryContainer.tsx
+++ b/apps/explorer/src/containers/ApplicationSummaryContainer.tsx
@@ -17,6 +17,7 @@ import { ApplicationSummaryPage } from "../page/ApplicationSummaryPage";
 import { pathBuilder } from "../routes/routePathBuilder";
 import { ContainerSkeleton } from "./ContainerSkeleton";
 import ContainerStack from "./ContainerStack";
+import DisplayContainerError from "./DisplayContainerError";
 
 interface ApplicationSummaryContainerProps {
     application: string;
@@ -30,10 +31,13 @@ const defaultParams = {
 export const ApplicationSummaryContainer: FC<
     ApplicationSummaryContainerProps
 > = (props) => {
-    const { data: application, isLoading: isLoadingApplication } =
-        useApplication({
-            application: props.application,
-        });
+    const {
+        data: application,
+        isLoading: isLoadingApplication,
+        error: applicationError,
+    } = useApplication({
+        application: props.application,
+    });
     const epochsResult = useEpochs({
         application: props.application,
         ...defaultParams,
@@ -99,8 +103,14 @@ export const ApplicationSummaryContainer: FC<
     return (
         <ContainerStack>
             <Hierarchy hierarchyConfig={hierarchyConfig} />
-            {isLoading && <ContainerSkeleton />}
-            {showPage && (
+            {isLoading ? (
+                <ContainerSkeleton />
+            ) : applicationError ? (
+                <DisplayContainerError
+                    title={`Something went wrong while fetching data for application ${props.application}`}
+                    subtitle={"Check your node connection and try again."}
+                />
+            ) : showPage ? (
                 <ApplicationSummaryPage
                     application={props.application}
                     applicationConsensusType={application.consensusType}
@@ -109,6 +119,10 @@ export const ApplicationSummaryContainer: FC<
                     outputs={outputs}
                     reports={reports}
                     tournaments={tournaments}
+                />
+            ) : (
+                <DisplayContainerError
+                    title={`An unexpected error occurred while fetching the application data.`}
                 />
             )}
         </ContainerStack>

--- a/apps/explorer/src/containers/DisplayContainerError.tsx
+++ b/apps/explorer/src/containers/DisplayContainerError.tsx
@@ -1,0 +1,37 @@
+import { Stack, Title, type StackProps, type TitleProps } from "@mantine/core";
+import { isNotNilOrEmpty } from "ramda-adjunct";
+import type { FC, ReactNode } from "react";
+
+interface DisplayContainerErrorProps {
+    title: ReactNode;
+    subtitle?: ReactNode;
+    stackProps?: StackProps;
+    titleProps?: TitleProps;
+    subtitleProps?: TitleProps;
+    children?: ReactNode;
+}
+
+const DisplayContainerError: FC<DisplayContainerErrorProps> = ({
+    title,
+    subtitle,
+    stackProps,
+    titleProps,
+    subtitleProps,
+    children,
+}) => {
+    return (
+        <Stack align="center" justify="center" pt="xl" {...stackProps}>
+            <Title order={2} {...titleProps}>
+                {title}
+            </Title>
+            {isNotNilOrEmpty(subtitle) && (
+                <Title order={4} c="dimmed" {...subtitleProps}>
+                    {subtitle}
+                </Title>
+            )}
+            {isNotNilOrEmpty(children) && children}
+        </Stack>
+    );
+};
+
+export default DisplayContainerError;

--- a/apps/explorer/src/containers/EpochsContainer.tsx
+++ b/apps/explorer/src/containers/EpochsContainer.tsx
@@ -9,6 +9,7 @@ import { EpochsPage } from "../page/EpochsPage";
 import { pathBuilder } from "../routes/routePathBuilder";
 import { ContainerSkeleton } from "./ContainerSkeleton";
 import ContainerStack from "./ContainerStack";
+import DisplayContainerError from "./DisplayContainerError";
 
 export type EpochsContainerProps = {
     application: string;
@@ -18,7 +19,7 @@ export type EpochsContainerProps = {
 };
 
 export const EpochsContainer: FC<EpochsContainerProps> = (props) => {
-    const { isLoading, data } = useEpochs(props);
+    const { isLoading, data, error: epochsError } = useEpochs(props);
     const hierarchyConfig: HierarchyConfig[] = [
         { title: "Home", href: "/" },
         {
@@ -36,9 +37,20 @@ export const EpochsContainer: FC<EpochsContainerProps> = (props) => {
     return (
         <ContainerStack>
             <Hierarchy hierarchyConfig={hierarchyConfig} />
-            {isLoading && <ContainerSkeleton />}
-            {props.application && (
+            {isLoading ? (
+                <ContainerSkeleton />
+            ) : epochsError ? (
+                <DisplayContainerError
+                    title={`Something went wrong while fetching data for application ${props.application}`}
+                    subtitle={"Check your node connection and try again."}
+                />
+            ) : props.application ? (
                 <EpochsPage epochs={epochs} pagination={data?.pagination} />
+            ) : (
+                <DisplayContainerError
+                    title={"An unexpected error occurred."}
+                    subtitle="Check your node connection."
+                />
             )}
         </ContainerStack>
     );

--- a/apps/explorer/src/containers/OutputsContainer.tsx
+++ b/apps/explorer/src/containers/OutputsContainer.tsx
@@ -1,10 +1,8 @@
 "use client";
 import type { Pagination } from "@cartesi/viem";
 import { useApplication, useOutputs } from "@cartesi/wagmi";
-import { Anchor, Stack, Title } from "@mantine/core";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { isNil, isNotNil, pathOr } from "ramda";
+import { isNil, isNotNil } from "ramda";
 import { useEffect, useMemo, useRef, type FC } from "react";
 import {
     Hierarchy,
@@ -21,24 +19,10 @@ import { OutputsPage } from "../page/OutputsPage";
 import { pathBuilder } from "../routes/routePathBuilder";
 import { ContainerSkeleton } from "./ContainerSkeleton";
 import ContainerStack from "./ContainerStack";
+import DisplayContainerError from "./DisplayContainerError";
 
 export type OutputsContainerProps = {
     application: string;
-};
-
-const HomeLink = () => (
-    <Anchor component={Link} href={pathBuilder.home()}>
-        Go back to Home
-    </Anchor>
-);
-
-const DisplayError: FC<{ message: string }> = ({ message }) => {
-    return (
-        <Stack align="center" justify="center" pt="xl">
-            <Title order={2}>{message}</Title>
-            <HomeLink />
-        </Stack>
-    );
 };
 
 export const OutputsContainer: FC<OutputsContainerProps> = (props) => {
@@ -124,23 +108,20 @@ export const OutputsContainer: FC<OutputsContainerProps> = (props) => {
                     sort={queryParams.sort}
                 />
             ) : isNotNil(applicationError) ? (
-                <DisplayError
-                    message={pathOr(
-                        `Application ${props.application} not found`,
-                        ["details"],
-                        applicationError,
-                    )}
+                <DisplayContainerError
+                    title={`Something went wrong while fetching data for application ${props.application}`}
+                    subtitle="Check your node connection and try again."
                 />
             ) : isNotNil(outputError) ? (
-                <DisplayError
-                    message={pathOr(
-                        `Outputs for application ${props.application} not found`,
-                        ["details"],
-                        outputError,
-                    )}
+                <DisplayContainerError
+                    title={`Something went wrong while fetching the outputs for application ${props.application}`}
+                    subtitle="Check your node connection and try again."
                 />
             ) : (
-                <DisplayError message="Unexpected error occurred" />
+                <DisplayContainerError
+                    title="An unexpected error occurred."
+                    subtitle="Check your node connection."
+                />
             )}
         </ContainerStack>
     );


### PR DESCRIPTION
## Summary
The first set of changes are to improve the handling of data fetching errors (mostly when the connection with the node is offline) to avoid blank pages without any feedback on what is happening.

Affected pages:
* Application summary page.
* Epochs list page.
* Small refactoring on outputs-page as now there is an extracted `DisplayContainerError` UI component.

The second concerns the notification to be displayed when there is a connectivity issue, so the user can "manage" and check their node connection configuration. As per the last change, it was no longer displaying.

Below are short clips regarding the changes. 

## Short clips


<details>
<summary>Data fetching error handling before changes</summary>

![before-container-updates](https://github.com/user-attachments/assets/5658b870-d6b4-4d56-9dea-a2736c9f5050)

</details>


<details>
<summary>Data fetching error handling after changes</summary>

![after-container-updates](https://github.com/user-attachments/assets/a5fdd45b-3e36-4b17-9da0-1c72e17384ba)

</details>


<details>
<summary>Connectivity issue notification after changes</summary>

![after-connectivity-check-changes](https://github.com/user-attachments/assets/5bb95626-02fa-4b21-8ad2-337866c24eba)

</details>