### PR TITLE
feat: Add foreclose capability for configured guardian applications

### DIFF
--- a/apps/explorer/next.config.ts
+++ b/apps/explorer/next.config.ts
@@ -6,12 +6,11 @@ const ContentSecurityPolicy = `
   font-src 'self' https:;
   style-src 'self' 'unsafe-inline' https:;
   img-src 'self' data: https:;
-  connect-src 'self' https: wss: http:;
+  connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;
   frame-ancestors 'self' https://app.safe.global https://verify.walletconnect.org;
   object-src 'none';
   base-uri 'self';
-  form-action 'self';  
-  upgrade-insecure-requests;
+  form-action 'self';
 `;
 
 const nextConfig: NextConfig = {

--- a/apps/explorer/src/components/ConfirmationModal.stories.tsx
+++ b/apps/explorer/src/components/ConfirmationModal.stories.tsx
@@ -1,0 +1,61 @@
+import { Button, Group, Stack, Text } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+import { action } from "storybook/actions";
+import { ConfirmationModal } from "./ConfirmationModal";
+
+const meta = {
+    title: "Components/General/ConfirmationModal",
+    component: ConfirmationModal,
+} satisfies Meta<typeof ConfirmationModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type Props = Parameters<typeof ConfirmationModal>[0];
+
+const Wrapper = (props: Props) => {
+    const [opened, handlers] = useDisclosure(false);
+    const [resultTxt, setResultTxt] = useState<string | null>(null);
+
+    return (
+        <Stack
+            align="center"
+            justify="center"
+            gap="md"
+            style={{ height: "100vh", width: "100vw" }}
+        >
+            <ConfirmationModal
+                {...props}
+                isOpened={opened}
+                onClose={() => {
+                    setResultTxt("Not confirmed");
+                    handlers.close();
+                }}
+                onConfirm={() => {
+                    setResultTxt("Confirmed");
+                    handlers.close();
+                }}
+            />
+            <Button onClick={handlers.open}>Open Confirmation Modal</Button>
+            <Group>
+                <Text>Result: {resultTxt ?? "No interaction yet"}</Text>
+            </Group>
+        </Stack>
+    );
+};
+
+/**
+ * The standard story for the ConfirmationModal component.
+ */
+export const Default: Story = {
+    args: {
+        isOpened: false,
+        title: "Confirmation before proceeding",
+        text: "Are you sure you want to proceed?",
+        onClose: action("Modal Closed"),
+        onConfirm: action("Confirmed"),
+    },
+    render: Wrapper,
+};

--- a/apps/explorer/src/components/ConfirmationModal.tsx
+++ b/apps/explorer/src/components/ConfirmationModal.tsx
@@ -1,0 +1,69 @@
+import { Button, Group, Modal, Notification, Stack, Text } from "@mantine/core";
+import { isValidElement, type FC, type ReactNode } from "react";
+import { content } from "../content";
+
+export interface ConfirmationModalProps {
+    isOpened: boolean;
+    title?: ReactNode;
+    text: ReactNode;
+    onClose: () => void;
+    onConfirm: () => void;
+}
+
+/**
+ *  A modal component that displays a confirmation dialog with customizable text and actions.
+ *  It can be used to confirm irreversible actions or any other user decisions.
+ * @param props
+ * @returns
+ */
+export const ConfirmationModal: FC<ConfirmationModalProps> = (props) => {
+    const { isOpened, text, onClose, onConfirm, title } = props;
+    const isElement = isValidElement(text);
+
+    return (
+        <Modal
+            opened={isOpened}
+            onClose={onClose}
+            onClick={(evt) => {
+                evt.stopPropagation();
+            }}
+            closeOnClickOutside
+            title={title ?? <Text fw="bold">Before you proceed...</Text>}
+            centered
+        >
+            <Stack gap="md">
+                {isElement ? (
+                    text
+                ) : (
+                    <Notification
+                        withCloseButton={false}
+                        color="red"
+                        style={{ boxShadow: "none" }}
+                    >
+                        {text}
+                    </Notification>
+                )}
+
+                <Group justify="flex-end">
+                    <Button
+                        variant="default"
+                        onClick={(evt) => {
+                            evt.stopPropagation();
+                            onClose();
+                        }}
+                    >
+                        {content.global.btn.cancel}
+                    </Button>
+                    <Button
+                        onClick={(evt) => {
+                            evt.stopPropagation();
+                            onConfirm();
+                        }}
+                    >
+                        {content.global.btn.confirm}
+                    </Button>
+                </Group>
+            </Stack>
+        </Modal>
+    );
+};

--- a/apps/explorer/src/components/application/utils.ts
+++ b/apps/explorer/src/components/application/utils.ts
@@ -1,6 +1,6 @@
 import type { Application } from "@cartesi/viem";
 import { isNil } from "ramda";
-import { zeroHash, type Hash } from "viem";
+import { isAddressEqual, zeroHash, type Address, type Hash } from "viem";
 
 /**
  *
@@ -22,4 +22,25 @@ const hasForecloseTransaction = (hash: Hash | null | undefined) => {
         return false;
     }
     return true;
+};
+
+/**
+ * Check if the given address is the guardian configured in the withdrawal setup of the application.
+ * @param application The application object containing the withdrawal configuration.
+ * @param address  The address to check against the guardian address in the application's withdrawal configuration.
+ * @returns {boolean} - Returns true if the address is the guardian, otherwise false.
+ */
+export const isGuardian = (application: Application, address?: Address) => {
+    if (!address || !application) return false;
+
+    if (
+        isNil(application.withdrawalConfig) ||
+        isNil(application.withdrawalConfig.guardian)
+    ) {
+        return false;
+    }
+
+    const guardian = application.withdrawalConfig.guardian;
+
+    return isAddressEqual(address, guardian);
 };

--- a/apps/explorer/src/components/output/OutputExecution.tsx
+++ b/apps/explorer/src/components/output/OutputExecution.tsx
@@ -24,6 +24,7 @@ import { TbExclamationCircle, TbInfoCircle, TbReceipt } from "react-icons/tb";
 import type { TransactionReceipt } from "viem";
 import { type Hex } from "viem";
 import { useAccount, useWaitForTransactionReceipt } from "wagmi";
+import { content } from "../../content";
 import TransactionHash from "../TransactionHash";
 import OutputExecutionError, {
     type WagmiActionError,
@@ -163,7 +164,7 @@ const OutputExecution: FC<OutputExecutionProps> = ({
                             leftSection={
                                 <Tooltip
                                     label={
-                                        "Once the epoch status become CLAIM_ACCEPTED the voucher will become executable."
+                                        content.output.epoch.nonAcceptedClaim
                                     }
                                 >
                                     <TbInfoCircle
@@ -187,7 +188,7 @@ const OutputExecution: FC<OutputExecutionProps> = ({
                     >
                         {isNotNil(output.executionTransactionHash) && (
                             <Group gap={3}>
-                                <Tooltip label="Execution transaction hash">
+                                <Tooltip label={content.output.txhash}>
                                     <TbReceipt size={theme.other.mdIconSize} />
                                 </Tooltip>
                                 <TransactionHash
@@ -221,12 +222,12 @@ const OutputExecution: FC<OutputExecutionProps> = ({
                             }}
                         >
                             {isExecuted
-                                ? "Executed"
+                                ? content.output.voucher.executed
                                 : checkingOutputExecuted
-                                  ? "Checking voucher..."
+                                  ? content.output.voucher.checking
                                   : prepare.isFetching
-                                    ? "Preparing voucher..."
-                                    : "Execute"}
+                                    ? content.output.voucher.preparing
+                                    : content.output.voucher.execute}
                         </Button>
                     </Group>
                 </Activity>

--- a/apps/explorer/src/components/output/OutputExecution.tsx
+++ b/apps/explorer/src/components/output/OutputExecution.tsx
@@ -1,4 +1,5 @@
 "use client";
+import type { EpochStatus } from "@cartesi/viem";
 import {
     useEpoch,
     useReadApplicationWasOutputExecuted,
@@ -21,8 +22,7 @@ import { isNil, isNotEmpty, isNotNil } from "ramda";
 import { isFunction, isNotNilOrEmpty } from "ramda-adjunct";
 import { Activity, useEffect, useMemo, type FC } from "react";
 import { TbExclamationCircle, TbInfoCircle, TbReceipt } from "react-icons/tb";
-import type { TransactionReceipt } from "viem";
-import { type Hex } from "viem";
+import { type Hex, type TransactionReceipt } from "viem";
 import { useAccount, useWaitForTransactionReceipt } from "wagmi";
 import { content } from "../../content";
 import TransactionHash from "../TransactionHash";
@@ -45,6 +45,27 @@ const buildProof = (output: VoucherOutput): Proof => ({
     outputHashesSiblings: output.outputHashesSiblings ?? [],
 });
 
+const buildFeedback = (epochStatus?: EpochStatus) => {
+    if (isNil(epochStatus)) return null;
+
+    switch (epochStatus) {
+        case "CLAIM_FORECLOSED":
+            return {
+                status: epochStatus,
+                tooltip: content.output.epoch.claimForeclosed,
+                body: content.output.epoch.executionForeclosed,
+            };
+        case "CLAIM_ACCEPTED":
+            return null;
+        default:
+            return {
+                status: epochStatus,
+                tooltip: content.output.epoch.nonAcceptedClaim,
+                body: content.output.epoch.waitingClaim,
+            };
+    }
+};
+
 const OutputExecution: FC<OutputExecutionProps> = ({
     application,
     output,
@@ -57,8 +78,10 @@ const OutputExecution: FC<OutputExecutionProps> = ({
     const chainModal = useChainModal();
     const epochQuery = useEpoch({ epochIndex: output.epochIndex, application });
     const queryClient = useQueryClient();
-    const isClaimAccepted = epochQuery.data?.status === "CLAIM_ACCEPTED";
+    const epochStatus = epochQuery.data?.status;
+    const isClaimAccepted = epochStatus === "CLAIM_ACCEPTED";
     const hasExecutionTransaction = isNotNil(output.executionTransactionHash);
+    const feedback = buildFeedback(epochStatus);
 
     const wasOutputExecutedQuery = useReadApplicationWasOutputExecuted({
         address: application,
@@ -156,27 +179,29 @@ const OutputExecution: FC<OutputExecutionProps> = ({
             <Stack>
                 <Divider mt="sm" />
 
-                <Activity mode={!isClaimAccepted ? "visible" : "hidden"}>
+                {isNotNil(feedback) ? (
                     <Group justify="flex-end">
                         <Badge
+                            color={
+                                feedback.status === "CLAIM_FORECLOSED"
+                                    ? "foreclosed"
+                                    : undefined
+                            }
+                            variant="filled"
                             radius="xs"
                             size="lg"
                             leftSection={
-                                <Tooltip
-                                    label={
-                                        content.output.epoch.nonAcceptedClaim
-                                    }
-                                >
+                                <Tooltip label={feedback.tooltip}>
                                     <TbInfoCircle
                                         size={theme.other.smIconSize}
                                     />
                                 </Tooltip>
                             }
                         >
-                            Waiting Claim
+                            {feedback.body}
                         </Badge>
                     </Group>
-                </Activity>
+                ) : null}
 
                 <Activity mode={isClaimAccepted ? "visible" : "hidden"}>
                     <Group

--- a/apps/explorer/src/components/output/OutputExecution.tsx
+++ b/apps/explorer/src/components/output/OutputExecution.tsx
@@ -17,22 +17,18 @@ import {
 } from "@mantine/core";
 import { useChainModal, useConnectModal } from "@rainbow-me/rainbowkit";
 import { useQueryClient } from "@tanstack/react-query";
-import { isNil, isNotEmpty, isNotNil, pathOr } from "ramda";
-import { isFunction, isNotNilOrEmpty, isObj, isString } from "ramda-adjunct";
+import { isNil, isNotEmpty, isNotNil } from "ramda";
+import { isFunction, isNotNilOrEmpty } from "ramda-adjunct";
 import { Activity, useEffect, useMemo, type FC } from "react";
 import { TbExclamationCircle, TbInfoCircle, TbReceipt } from "react-icons/tb";
 import type { TransactionReceipt } from "viem";
 import { type Hex } from "viem";
 import { useAccount, useWaitForTransactionReceipt } from "wagmi";
-import { useSelectedNodeConnection } from "../connection/hooks";
 import TransactionHash from "../TransactionHash";
 import OutputExecutionError, {
     type WagmiActionError,
 } from "./errors/OutputExecutionError";
 import type { VoucherOutput } from "./types";
-
-// xxx: Maybe should become an environment var.
-const POLLING_INTERVAL_MS = 8000 as const;
 
 type OutputExecutionProps = {
     output: VoucherOutput;
@@ -57,7 +53,6 @@ const OutputExecution: FC<OutputExecutionProps> = ({
     const theme = useMantineTheme();
     const userAccount = useAccount();
     const connectModal = useConnectModal();
-    const selectedNode = useSelectedNodeConnection();
     const chainModal = useChainModal();
     const epochQuery = useEpoch({ epochIndex: output.epochIndex, application });
     const queryClient = useQueryClient();
@@ -154,41 +149,6 @@ const OutputExecution: FC<OutputExecutionProps> = ({
             onError(errors);
         }
     }, [errors, onError]);
-
-    useEffect(() => {
-        let key: unknown;
-        // skip invalidation if there is no node-connected or the connected node is a mock.
-        if (
-            isNotNil(selectedNode) &&
-            selectedNode.type !== "system_mock" &&
-            !isClaimAccepted
-        ) {
-            key = setInterval(() => {
-                // Invalidation makes the targeted queries stale.
-                // It creates a Polling effect.
-                queryClient.invalidateQueries({
-                    predicate: (query) => {
-                        const [baseKey, paramsKey] = query.queryKey;
-                        const isEpochQuery =
-                            isString(baseKey) && baseKey.includes("epoch");
-                        const isMatchingEpochIndex =
-                            isObj(paramsKey) &&
-                            pathOr("", ["epochIndex"], paramsKey) ===
-                                output.epochIndex.toString();
-
-                        return isEpochQuery && isMatchingEpochIndex;
-                    },
-                });
-            }, POLLING_INTERVAL_MS);
-        }
-
-        return () => {
-            if (isNotNil(key)) {
-                console.info(`Clearing the polling.`);
-                clearInterval(key as number);
-            }
-        };
-    }, [queryClient, isClaimAccepted, selectedNode, output.epochIndex]);
 
     return (
         <>

--- a/apps/explorer/src/components/output/OutputView.tsx
+++ b/apps/explorer/src/components/output/OutputView.tsx
@@ -4,6 +4,7 @@ import { notifications } from "@mantine/notifications";
 import { isNotNil } from "ramda";
 import { type FC } from "react";
 import { formatUnits, isHex, type Hex } from "viem";
+import { content } from "../../content";
 import { useIsSmallDevice } from "../../hooks/useIsSmallDevice";
 import { getDecoder } from "../../lib/decoders";
 import Address from "../Address";
@@ -24,7 +25,7 @@ const NoticeContent: FC<NoticeContentProps> = ({
     const decoderFn = getDecoder(decoderType);
 
     return (
-        <Fieldset legend="Notice">
+        <Fieldset legend={content.output.noticeTxt}>
             <Spoiler>
                 <Text style={{ wordBreak: "break-all" }}>
                     {decoderFn(decodedData.payload)}
@@ -38,7 +39,7 @@ const VoucherContent: FC<VoucherContentProps> = ({
     decoderType,
     output,
     application,
-    title = "Voucher",
+    title = content.output.voucherTxt,
 }) => {
     const decoderFn = getDecoder(decoderType);
     const { isSmallDevice } = useIsSmallDevice();
@@ -95,8 +96,11 @@ const VoucherContent: FC<VoucherContentProps> = ({
                 output={output}
                 onSuccess={() => {
                     notifications.show({
-                        title: "Voucher execution status",
-                        message: "Executed successfully",
+                        title: content.output.voucher.feedback
+                            .executionStatusTxt,
+                        message:
+                            content.output.voucher.feedback
+                                .executionStatusSuccess,
                         color: "green",
                         withBorder: true,
                     });
@@ -128,7 +132,7 @@ export const OutputView: FC<OutputViewProps> = ({
             ) : outputType === "DelegateCallVoucher" ? (
                 <VoucherContent
                     application={application}
-                    title="Delegated Call Voucher"
+                    title={content.output.delegateCallVoucherTxt}
                     output={output as VoucherOutput}
                     decoderType={displayAs}
                 />

--- a/apps/explorer/src/components/send/SendContexts.tsx
+++ b/apps/explorer/src/components/send/SendContexts.tsx
@@ -3,8 +3,7 @@ import type { Application } from "@cartesi/viem";
 import { createContext, type ActionDispatch } from "react";
 import type { DbSpecification } from "../specification/types";
 
-// Actions
-type CloseModal = { type: "close_modal" };
+export type ForecloseType = "foreclose";
 export type InputType = "generic_input";
 export type DepositType =
     | "deposit_eth"
@@ -13,13 +12,15 @@ export type DepositType =
     | "deposit_erc1155Single"
     | "deposit_erc1155Batch";
 
-export type TransactionType = DepositType | InputType;
+export type TransactionType = DepositType | InputType | ForecloseType;
 
+type CloseModal = { type: "close_modal" };
 type Deposit = { type: DepositType; payload: { application: Application } };
 type GenericInput = {
     type: InputType;
     payload: { application: Application; specifications: DbSpecification[] };
 };
+type Foreclose = { type: ForecloseType; payload: { application: Application } };
 
 type SendState = {
     application: Application;
@@ -28,7 +29,7 @@ type SendState = {
     timestamp: number;
 } | null;
 
-export type SendAction = CloseModal | Deposit | GenericInput;
+export type SendAction = CloseModal | Deposit | GenericInput | Foreclose;
 export type SendReducer = (state: SendState, action: SendAction) => SendState;
 
 export const SendStateContext = createContext<SendState>(null);

--- a/apps/explorer/src/components/send/SendMenu.tsx
+++ b/apps/explorer/src/components/send/SendMenu.tsx
@@ -1,13 +1,28 @@
 "use client";
 import type { Application } from "@cartesi/viem";
-import { Button, Group, Menu, Text, Tooltip } from "@mantine/core";
+import {
+    Button,
+    Group,
+    Menu,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useChainModal, useConnectModal } from "@rainbow-me/rainbowkit";
-import { cond, filter, isNil } from "ramda";
-import type { FC } from "react";
-import { TbCoins, TbCurrencyEthereum, TbInbox, TbSend } from "react-icons/tb";
+import { cond, filter, isNil, isNotNil } from "ramda";
+import { useState, type FC, type ReactNode } from "react";
+import {
+    TbCoins,
+    TbCurrencyEthereum,
+    TbInbox,
+    TbLockFilled,
+    TbSend,
+} from "react-icons/tb";
 import { useAccount } from "wagmi";
-import { isForeclosed } from "../application/utils";
+import { content } from "../../content";
+import { isForeclosed, isGuardian } from "../application/utils";
+import { ConfirmationModal } from "../ConfirmationModal";
 import { useSelectedNodeConnection } from "../connection/hooks";
 import { useSpecification } from "../specification/hooks/useSpecification";
 import type { DbSpecification } from "../specification/types";
@@ -21,8 +36,7 @@ const getMenuState = cond([
     [
         isForeclosed,
         () => ({
-            tooltip:
-                "The application is foreclosed. You can no longer send transactions.",
+            tooltip: content.foreclose.sendTooltip,
             disabled: true,
         }),
     ],
@@ -33,7 +47,13 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
     const selectedConnection = useSelectedNodeConnection();
     const { listSpecifications } = useSpecification();
     const [opened, handlers] = useDisclosure(false);
+    const theme = useMantineTheme();
     const [openedTooltip, tooltipHandlers] = useDisclosure(false);
+    const [confirmationState, setConfirmationState] = useState<null | {
+        action: () => void;
+        title?: string;
+        text: ReactNode;
+    }>(null);
     const actions = useSendAction();
     const account = useAccount();
     const connectModal = useConnectModal();
@@ -41,6 +61,7 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
     const needSwitchNetwork = account.isConnected && isNil(account.chain);
     const canSend = !needSwitchNetwork && account.isConnected;
     const menuState = getMenuState(application);
+    const isAppGuardian = isGuardian(application, account.address);
 
     if (selectedConnection?.type === "system_mock") return null;
 
@@ -51,6 +72,19 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
             onClose={handlers.close}
             onDismiss={handlers.close}
         >
+            <ConfirmationModal
+                isOpened={isNotNil(confirmationState)}
+                title={confirmationState?.title}
+                text={confirmationState?.text ?? ""}
+                onClose={() => {
+                    setConfirmationState(null);
+                }}
+                onConfirm={() => {
+                    confirmationState?.action();
+                    setConfirmationState(null);
+                }}
+            />
+
             <Menu.Target>
                 <Tooltip
                     label={menuState.tooltip}
@@ -87,7 +121,7 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
 
             <Menu.Dropdown>
                 <Menu.Item
-                    leftSection={<TbInbox size={24} />}
+                    leftSection={<TbInbox size={theme.other.mdIconSize} />}
                     onClick={(evt) => {
                         evt.stopPropagation();
                         const specifications = filter(
@@ -103,12 +137,14 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                 <Menu.Divider />
                 <Menu.Label>
                     <Group gap={3}>
-                        <TbCoins size={21} />
+                        <TbCoins size={theme.other.smIconSize} />
                         <Text>Deposits</Text>
                     </Group>
                 </Menu.Label>
                 <Menu.Item
-                    leftSection={<TbCurrencyEthereum size={24} />}
+                    leftSection={
+                        <TbCurrencyEthereum size={theme.other.mdIconSize} />
+                    }
                     onClick={(evt) => {
                         evt.stopPropagation();
                         actions.depositEth(application);
@@ -118,7 +154,9 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                     <Text fw="500">Ether</Text>
                 </Menu.Item>
                 <Menu.Item
-                    leftSection={<TbCurrencyEthereum size={24} />}
+                    leftSection={
+                        <TbCurrencyEthereum size={theme.other.mdIconSize} />
+                    }
                     onClick={(evt) => {
                         evt.stopPropagation();
                         actions.depositErc20(application);
@@ -128,7 +166,9 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                     <Text fw="500">ERC-20</Text>
                 </Menu.Item>
                 <Menu.Item
-                    leftSection={<TbCurrencyEthereum size={24} />}
+                    leftSection={
+                        <TbCurrencyEthereum size={theme.other.mdIconSize} />
+                    }
                     onClick={(evt) => {
                         evt.stopPropagation();
                         actions.depositErc721(application);
@@ -138,7 +178,9 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                     <Text fw="500">ERC-721</Text>
                 </Menu.Item>
                 <Menu.Item
-                    leftSection={<TbCurrencyEthereum size={24} />}
+                    leftSection={
+                        <TbCurrencyEthereum size={theme.other.mdIconSize} />
+                    }
                     onClick={(evt) => {
                         evt.stopPropagation();
                         actions.depositErc1155Single(application);
@@ -148,7 +190,9 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                     <Text fw="500">ERC-1155 (Single)</Text>
                 </Menu.Item>
                 <Menu.Item
-                    leftSection={<TbCurrencyEthereum size={24} />}
+                    leftSection={
+                        <TbCurrencyEthereum size={theme.other.mdIconSize} />
+                    }
                     onClick={(evt) => {
                         evt.stopPropagation();
                         actions.depositErc1155Batch(application);
@@ -157,6 +201,34 @@ const SendMenu: FC<SendMenuProps> = ({ application }) => {
                 >
                     <Text fw="500">ERC-1155 (Batch)</Text>
                 </Menu.Item>
+
+                {isAppGuardian ? (
+                    <>
+                        <Menu.Divider />
+                        <Menu.Item
+                            leftSection={
+                                <TbLockFilled size={theme.other.mdIconSize} />
+                            }
+                            color="red"
+                            onClick={(evt) => {
+                                evt.stopPropagation();
+                                setConfirmationState({
+                                    title: content.foreclose.confirmation.title,
+                                    text: content.foreclose.confirmation
+                                        .description,
+                                    action: () => {
+                                        actions.foreclose(application);
+                                    },
+                                });
+                                handlers.close();
+                            }}
+                        >
+                            <Text fw="500">
+                                {content.foreclose.forecloseTxt}
+                            </Text>
+                        </Menu.Item>
+                    </>
+                ) : null}
             </Menu.Dropdown>
         </Menu>
     );

--- a/apps/explorer/src/components/send/SendModal.tsx
+++ b/apps/explorer/src/components/send/SendModal.tsx
@@ -11,6 +11,7 @@ import { ERC1155DepositForm } from "../transactions/ERC1155DepositForm";
 import { ERC20DepositForm } from "../transactions/ERC20DepositForm";
 import { ERC721DepositForm } from "../transactions/ERC721DepositForm";
 import { EtherDepositForm } from "../transactions/EtherDepositForm";
+import { ForecloseForm } from "../transactions/ForecloseForm";
 import {
     GenericInputForm,
     type GenericInputFormSpecification,
@@ -25,6 +26,7 @@ const wordingPrefix: Record<TransactionType, string> = {
     deposit_erc1155Single: "Send ERC-1155 to",
     deposit_erc20: "Send ERC-20 to",
     deposit_erc721: "Send ERC-721 to",
+    foreclose: "Foreclose application",
 };
 
 type SendModalTitleProps = {
@@ -57,7 +59,11 @@ const SendModal: FC = () => {
     const config = useConfig();
 
     const onSuccess = useCallback(
-        ({ receipt, type }: TransactionFormSuccessData) => {
+        ({
+            receipt,
+            type,
+            message: successMessage,
+        }: TransactionFormSuccessData) => {
             const message = receipt?.transactionHash
                 ? {
                       message: (
@@ -67,9 +73,12 @@ const SendModal: FC = () => {
                               chain={config.chains[0]}
                           />
                       ),
-                      title: `${type} transaction completed`,
+                      title: successMessage ?? `${type} transaction completed`,
                   }
-                : { message: `${type} transaction completed.` };
+                : {
+                      message:
+                          successMessage ?? `${type} transaction completed.`,
+                  };
 
             notifications.show({
                 withCloseButton: true,
@@ -128,6 +137,15 @@ const SendModal: FC = () => {
                         state.specifications as GenericInputFormSpecification[]
                     }
                     onSuccess={onSuccess}
+                />
+            ) : state.transactionType === "foreclose" ? (
+                <ForecloseForm
+                    application={state.application}
+                    onSuccess={(data) => {
+                        onSuccess(data);
+                        // Close the modal after foreclose is successful
+                        actions.closeModal();
+                    }}
                 />
             ) : null}
         </Modal>

--- a/apps/explorer/src/components/send/SendProvider.tsx
+++ b/apps/explorer/src/components/send/SendProvider.tsx
@@ -26,6 +26,13 @@ const sendReducer: SendReducer = (state, action) => {
                 specifications: action.payload.specifications,
                 timestamp: Date.now(),
             };
+        case "foreclose":
+            return {
+                transactionType: action.type,
+                application: action.payload.application,
+                specifications: [],
+                timestamp: Date.now(),
+            };
         case "close_modal":
             return null;
         default:

--- a/apps/explorer/src/components/send/hooks.tsx
+++ b/apps/explorer/src/components/send/hooks.tsx
@@ -28,6 +28,11 @@ export const useSendAction = () => {
                 type: "deposit_erc1155Batch",
                 payload: { application },
             }),
+        foreclose: (application: Application) =>
+            dispatch({
+                type: "foreclose",
+                payload: { application },
+            }),
         sendGenericInput: (
             application: Application,
             specifications: DbSpecification[],

--- a/apps/explorer/src/components/transactions/DepositFormTypes.ts
+++ b/apps/explorer/src/components/transactions/DepositFormTypes.ts
@@ -6,9 +6,11 @@ export type TRANSACTION_TYPE =
     | "ERC-721"
     | "ETHER"
     | "RAW"
-    | "ADDRESS-RELAY";
+    | "ADDRESS-RELAY"
+    | "FORECLOSE";
 
 export type TransactionFormSuccessData = {
     receipt: UseWaitForTransactionReceiptReturnType["data"];
     type: TRANSACTION_TYPE;
+    message?: string;
 };

--- a/apps/explorer/src/components/transactions/ForecloseForm/index.tsx
+++ b/apps/explorer/src/components/transactions/ForecloseForm/index.tsx
@@ -1,0 +1,169 @@
+import type { Application } from "@cartesi/viem";
+import {
+    useReadApplicationIsForeclosed,
+    useSimulateApplicationForeclose,
+    useWriteApplicationForeclose,
+} from "@cartesi/wagmi";
+import {
+    Button,
+    Collapse,
+    Group,
+    Notification,
+    Stack,
+    Text,
+} from "@mantine/core";
+import { isNil, isNotNil } from "ramda";
+import { useEffect, useMemo, type FC } from "react";
+import { TbLockFilled } from "react-icons/tb";
+import { useAccount, useWaitForTransactionReceipt } from "wagmi";
+import { content } from "../../../content";
+import type { TransactionFormSuccessData } from "../DepositFormTypes";
+import TransactionDetails from "../TransactionDetails";
+import { TransactionProgress } from "../TransactionProgress";
+
+interface ForecloseFormProps {
+    application: Application;
+    onSuccess: (receipt: TransactionFormSuccessData) => void;
+}
+
+export const ForecloseForm: FC<ForecloseFormProps> = (props) => {
+    const { application, onSuccess } = props;
+
+    // connected account
+    const { address } = useAccount();
+
+    const {
+        data: isApplicationForeclosed,
+        isLoading: isCheckingIfForeclosed,
+        refetch: recheckIfForeclosed,
+    } = useReadApplicationIsForeclosed({
+        address: application.applicationAddress,
+        query: {
+            enabled: isNotNil(application.applicationAddress),
+        },
+    });
+
+    const prepare = useSimulateApplicationForeclose({
+        address: application.applicationAddress,
+        query: {
+            enabled:
+                isNotNil(application.applicationAddress) &&
+                isNotNil(address) &&
+                isNotNil(isApplicationForeclosed) &&
+                isApplicationForeclosed === false,
+        },
+    });
+
+    const execute = useWriteApplicationForeclose();
+
+    const wait = useWaitForTransactionReceipt({
+        hash: execute.data,
+    });
+
+    const canSubmit =
+        !isCheckingIfForeclosed &&
+        isApplicationForeclosed === false &&
+        isNotNil(address) &&
+        !prepare.isLoading &&
+        isNotNil(prepare.data?.request) &&
+        isNil(prepare.error);
+    const loading = execute.isPending || wait.isLoading;
+
+    const details = useMemo(
+        () => [
+            {
+                legend: content.global.application.address,
+                text: application.applicationAddress,
+            },
+        ],
+        [application.applicationAddress],
+    );
+
+    const executeReset = execute.reset;
+
+    useEffect(() => {
+        if (wait.isSuccess) {
+            onSuccess({
+                receipt: wait.data,
+                type: "FORECLOSE",
+                message: content.foreclose.generic.txSuccess,
+            });
+            recheckIfForeclosed();
+            executeReset();
+        }
+    }, [
+        wait.isSuccess,
+        wait.data,
+        executeReset,
+        onSuccess,
+        recheckIfForeclosed,
+    ]);
+
+    return (
+        <form
+            onSubmit={(e) => {
+                e.preventDefault();
+                if (canSubmit) {
+                    execute.writeContract(prepare.data!.request);
+                }
+            }}
+            data-testid="foreclose-form"
+        >
+            <Stack>
+                <TransactionDetails details={details} defaultOpened={true} />
+
+                <Collapse
+                    in={
+                        !isCheckingIfForeclosed &&
+                        isApplicationForeclosed === false
+                    }
+                >
+                    <Notification
+                        color="info"
+                        title={content.global.alert.reminder}
+                        withCloseButton={false}
+                        style={{ boxShadow: "none" }}
+                    >
+                        {content.foreclose.foreclosingWarning}
+                    </Notification>
+                </Collapse>
+
+                <Collapse
+                    data-testid="foreclose-progress"
+                    in={
+                        execute.isPending ||
+                        wait.isLoading ||
+                        execute.isSuccess ||
+                        execute.isError ||
+                        prepare.isError
+                    }
+                >
+                    <TransactionProgress
+                        prepare={prepare}
+                        execute={execute}
+                        wait={wait}
+                        confirmationMessage={
+                            content.foreclose.generic.txSuccess
+                        }
+                        defaultErrorMessage={execute.error?.message}
+                    />
+                </Collapse>
+
+                <Group justify="right">
+                    <Button
+                        disabled={!canSubmit}
+                        leftSection={<TbLockFilled />}
+                        loading={loading}
+                        type="submit"
+                    >
+                        <Text>
+                            {isApplicationForeclosed
+                                ? content.foreclose.foreclosedTxt
+                                : content.foreclose.forecloseTxt}
+                        </Text>
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};

--- a/apps/explorer/src/components/transactions/TransactionDetails.tsx
+++ b/apps/explorer/src/components/transactions/TransactionDetails.tsx
@@ -15,10 +15,18 @@ type Detail = { text: ReactNode; legend: string };
 
 type TransactionDetailsProps = {
     details: Detail[];
+    /**
+     * Initial value for the details visibility. This is not a controlled prop.
+     * Follow mantine's convention for default values, using `default` prefix.
+     */
+    defaultOpened?: boolean;
 };
 
-const TransactionDetails: FC<TransactionDetailsProps> = ({ details }) => {
-    const [showDetails, handlers] = useDisclosure(false);
+const TransactionDetails: FC<TransactionDetailsProps> = ({
+    details,
+    defaultOpened,
+}) => {
+    const [showDetails, handlers] = useDisclosure(defaultOpened ?? false);
     return (
         <>
             <Switch

--- a/apps/explorer/src/components/transactions/TransactionProgress.tsx
+++ b/apps/explorer/src/components/transactions/TransactionProgress.tsx
@@ -1,5 +1,6 @@
 "use client";
 import {
+    ActionIcon,
     Center,
     Code,
     Collapse,
@@ -11,7 +12,7 @@ import {
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { hasPath, path } from "ramda";
-import { type FC } from "react";
+import { Activity, type FC } from "react";
 import {
     TbCheck,
     TbChevronDown,
@@ -104,18 +105,20 @@ export const TransactionProgress: FC<TransactionProgressProps> = ({
                         <Text size="xs" c={errorColor}>
                             {shortErrorMessage || defaultErrorMessage}
                         </Text>
-                        {errorMessage &&
-                            (showError ? (
-                                <TbChevronUp
-                                    color={errorColor}
-                                    onClick={toggleError}
-                                />
-                            ) : (
-                                <TbChevronDown
-                                    color={errorColor}
-                                    onClick={toggleError}
-                                />
-                            ))}
+
+                        <Activity mode={errorMessage ? "visible" : "hidden"}>
+                            <ActionIcon
+                                onClick={toggleError}
+                                variant="transparent"
+                                data-testid="transaction-progress-error-toggle"
+                            >
+                                {showError ? (
+                                    <TbChevronUp color={errorColor} />
+                                ) : (
+                                    <TbChevronDown color={errorColor} />
+                                )}
+                            </ActionIcon>
+                        </Activity>
                     </Group>
                 )}
             </Center>

--- a/apps/explorer/src/content/forecloseMessages.ts
+++ b/apps/explorer/src/content/forecloseMessages.ts
@@ -1,0 +1,23 @@
+/**
+ * Content/copy for foreclose related messages.
+ */
+export const forecloseMessages = {
+    confirmation: {
+        title: "Are you sure you want to foreclose?",
+        description:
+            "It is an irreversible action that prevents any further deposits or inputs to the application.",
+    },
+    sendTooltip:
+        "The application is foreclosed. You can no longer send transactions.",
+
+    foreclosingWarning: "Foreclosing an application is a permanent action.",
+    generic: {
+        txSuccess: "Application foreclosed successfully!",
+    },
+    feedback: {
+        applicationForeclosed:
+            "The application is already foreclosed. You cannot foreclose it again.",
+    },
+    forecloseTxt: "Foreclose",
+    foreclosedTxt: "Foreclosed",
+} as const;

--- a/apps/explorer/src/content/globalMessages.ts
+++ b/apps/explorer/src/content/globalMessages.ts
@@ -1,0 +1,25 @@
+/**
+ * Generic messages that can be used across the application.
+ */
+export const globalMessages = {
+    alert: {
+        error: "Error!",
+        success: "Success!",
+        warning: "Warning!",
+        info: "Info!",
+        reminder: "Remember!",
+    },
+    error: {
+        generic: "Something went wrong.",
+    },
+    btn: {
+        send: "Send",
+        cancel: "Cancel",
+        confirm: "Confirm",
+        close: "Close",
+        connectWallet: "Connect Wallet",
+    },
+    application: {
+        address: "Application Address",
+    },
+} as const;

--- a/apps/explorer/src/content/index.ts
+++ b/apps/explorer/src/content/index.ts
@@ -1,7 +1,9 @@
 import { forecloseMessages } from "./forecloseMessages";
 import { globalMessages } from "./globalMessages";
+import { outputMessages } from "./outputMessages";
 
 export const content = {
     foreclose: forecloseMessages,
     global: globalMessages,
+    output: outputMessages,
 } as const;

--- a/apps/explorer/src/content/index.ts
+++ b/apps/explorer/src/content/index.ts
@@ -1,0 +1,7 @@
+import { forecloseMessages } from "./forecloseMessages";
+import { globalMessages } from "./globalMessages";
+
+export const content = {
+    foreclose: forecloseMessages,
+    global: globalMessages,
+} as const;

--- a/apps/explorer/src/content/outputMessages.ts
+++ b/apps/explorer/src/content/outputMessages.ts
@@ -23,5 +23,7 @@ export const outputMessages = {
             "Once the epoch status become CLAIM_ACCEPTED the output will become executable.",
         claimForeclosed:
             "The epoch claim is foreclosed. The output cannot be executed.",
+        waitingClaim: "Waiting for claim.",
+        executionForeclosed: "Execution foreclosed.",
     },
 } as const;

--- a/apps/explorer/src/content/outputMessages.ts
+++ b/apps/explorer/src/content/outputMessages.ts
@@ -1,0 +1,27 @@
+/**
+ * This file contains the output messages used in the application.
+ */
+export const outputMessages = {
+    txhash: "Execution transaction hash",
+    delegateCallVoucherTxt: "Delegated Call Voucher",
+    voucherTxt: "Voucher",
+    noticeTxt: "Notice",
+    voucher: {
+        checking: "Checking voucher...",
+        preparing: "Preparing voucher...",
+        executed: "Executed",
+        execute: "Execute",
+        executionSuccess: "Voucher executed successfully!",
+        feedback: {
+            executionStatusTxt: "Voucher execution status",
+            executionStatusSuccess: "Executed successfully",
+            executionStatusError: "Execution failed",
+        },
+    },
+    epoch: {
+        nonAcceptedClaim:
+            "Once the epoch status become CLAIM_ACCEPTED the output will become executable.",
+        claimForeclosed:
+            "The epoch claim is foreclosed. The output cannot be executed.",
+    },
+} as const;

--- a/apps/explorer/test/components/output/OutputExecution.test.tsx
+++ b/apps/explorer/test/components/output/OutputExecution.test.tsx
@@ -1,0 +1,618 @@
+import type { EpochStatus } from "@cartesi/viem";
+import { type Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { foundry, mainnet } from "wagmi/chains";
+import OutputExecution from "../../../src/components/output/OutputExecution";
+import type { VoucherOutput } from "../../../src/components/output/types";
+import { content } from "../../../src/content";
+import { shortenHash } from "../../../src/lib/textUtils";
+import { fireEvent, render, screen, waitFor } from "../../test-utils";
+
+const mocks = vi.hoisted(() => ({
+    useEpoch: vi.fn(),
+    useReadApplicationWasOutputExecuted: vi.fn(),
+    useSimulateApplicationExecuteOutput: vi.fn(),
+    useWriteApplicationExecuteOutput: vi.fn(),
+    useConfig: vi.fn(),
+    useAccount: vi.fn(),
+    useWaitForTransactionReceipt: vi.fn(),
+    useChainModal: vi.fn(),
+    useConnectModal: vi.fn(),
+    useQueryClient: vi.fn(),
+}));
+
+vi.mock("@cartesi/wagmi", () => ({
+    useEpoch: mocks.useEpoch,
+    useReadApplicationWasOutputExecuted:
+        mocks.useReadApplicationWasOutputExecuted,
+    useSimulateApplicationExecuteOutput:
+        mocks.useSimulateApplicationExecuteOutput,
+    useWriteApplicationExecuteOutput: mocks.useWriteApplicationExecuteOutput,
+    useConfig: mocks.useConfig,
+}));
+
+vi.mock("wagmi", () => ({
+    useAccount: mocks.useAccount,
+    useConfig: mocks.useConfig,
+    useWaitForTransactionReceipt: mocks.useWaitForTransactionReceipt,
+}));
+
+vi.mock("@rainbow-me/rainbowkit", () => ({
+    useConnectModal: mocks.useConnectModal,
+    useChainModal: mocks.useChainModal,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+    useQueryClient: mocks.useQueryClient,
+}));
+
+const APPLICATION = "0x1234567890abcdef1234567890abcdef12345678" as const;
+const TX_HASH =
+    "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as const;
+
+const buildOutput = (overrides: Partial<VoucherOutput> = {}): VoucherOutput =>
+    ({
+        epochIndex: 2n,
+        inputIndex: 7n,
+        index: 14n,
+        rawData: "0x",
+        decodedData: {
+            type: "Voucher",
+            payload: "0x",
+            destination: "0x4A679253410272dd5232B3Ff7cF5dbB88f295319",
+            value: 0n,
+        },
+        hash: null,
+        outputHashesSiblings: [
+            "0x5a26e5a8c5b393796bb8ea278408a7278afee9a52a16a55f65839fe7a4689551",
+        ],
+        executionTransactionHash: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides,
+    }) as VoucherOutput;
+
+type SetupOptions = {
+    epochStatus?: EpochStatus;
+    wasOutputExecuted?: boolean | undefined;
+    checkingOutputExecuted?: boolean;
+    checkingOutputExecutedError?: Error | null;
+    simulateIsFetching?: boolean;
+    simulateError?: Error | null;
+    simulateData?: { request: unknown } | undefined;
+    isConnected?: boolean;
+    chain?: { id: number } | null;
+    waitIsSuccess?: boolean;
+    waitData?: unknown;
+    waitIsFetching?: boolean;
+    executeTxHash?: Hex | undefined;
+    executeIsPending?: boolean;
+};
+
+const setupMocks = ({
+    epochStatus,
+    wasOutputExecuted = false,
+    checkingOutputExecuted = false,
+    checkingOutputExecutedError = null,
+    simulateIsFetching = false,
+    simulateError = null,
+    simulateData = undefined,
+    isConnected = true,
+    chain = mainnet,
+    waitIsSuccess = false,
+    waitData = undefined,
+    waitIsFetching = false,
+    executeTxHash = undefined,
+    executeIsPending = false,
+}: SetupOptions = {}) => {
+    const refetch = vi.fn();
+    const reset = vi.fn();
+    const writeContract = vi.fn();
+    const openConnectModal = vi.fn();
+    const openChainModal = vi.fn();
+    const invalidateQueries = vi.fn();
+
+    mocks.useEpoch.mockReturnValue({
+        data: epochStatus !== undefined ? { status: epochStatus } : undefined,
+    });
+    mocks.useReadApplicationWasOutputExecuted.mockReturnValue({
+        data: wasOutputExecuted,
+        isFetching: checkingOutputExecuted,
+        error: checkingOutputExecutedError,
+        refetch,
+    });
+    mocks.useSimulateApplicationExecuteOutput.mockReturnValue({
+        data: simulateData,
+        error: simulateError,
+        isFetching: simulateIsFetching,
+    });
+    mocks.useWriteApplicationExecuteOutput.mockReturnValue({
+        data: executeTxHash,
+        isPending: executeIsPending,
+        reset,
+        writeContract,
+    });
+    mocks.useAccount.mockReturnValue({ isConnected, chain });
+    mocks.useConfig.mockReturnValue({ chains: chain ? [chain] : [] });
+    mocks.useWaitForTransactionReceipt.mockReturnValue({
+        data: waitData,
+        isFetching: waitIsFetching,
+        isSuccess: waitIsSuccess,
+    });
+    mocks.useConnectModal.mockReturnValue({ openConnectModal });
+    mocks.useChainModal.mockReturnValue({ openChainModal });
+    mocks.useQueryClient.mockReturnValue({ invalidateQueries });
+
+    return {
+        refetch,
+        reset,
+        writeContract,
+        openConnectModal,
+        openChainModal,
+        invalidateQueries,
+    };
+};
+
+describe("OutputExecution", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("feedback badge", () => {
+        it("shows no badge when epoch status is undefined", () => {
+            setupMocks({ epochStatus: undefined });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.queryByText(content.output.epoch.waitingClaim),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(content.output.epoch.executionForeclosed),
+            ).not.toBeInTheDocument();
+        });
+
+        it("shows no badge when epoch status is CLAIM_ACCEPTED", () => {
+            setupMocks({ epochStatus: "CLAIM_ACCEPTED" });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.queryByText(content.output.epoch.waitingClaim),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(content.output.epoch.executionForeclosed),
+            ).not.toBeInTheDocument();
+        });
+
+        it("shows waiting claim badge for non-accepted epoch statuses", () => {
+            setupMocks({ epochStatus: "OPEN" });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByText(content.output.epoch.waitingClaim),
+            ).toBeVisible();
+        });
+
+        it("shows foreclosed badge when epoch status is CLAIM_FORECLOSED", () => {
+            setupMocks({ epochStatus: "CLAIM_FORECLOSED" });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByText(content.output.epoch.executionForeclosed),
+            ).toBeVisible();
+        });
+    });
+
+    describe("Execute button labels", () => {
+        it('displays "Execute" when claim is accepted and output is pending execution', () => {
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByText(content.output.voucher.execute),
+            ).toBeVisible();
+        });
+
+        it('displays "Checking voucher..." while verifying on-chain execution status', () => {
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                checkingOutputExecuted: true,
+            });
+
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByText(content.output.voucher.checking),
+            ).toBeVisible();
+        });
+
+        it('displays "Preparing voucher..." while simulation is in progress', () => {
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+                simulateIsFetching: true,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByText(content.output.voucher.preparing),
+            ).toBeVisible();
+        });
+
+        it('displays "Executed" when the output was already executed on-chain', () => {
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: true,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByText(content.output.voucher.executed),
+            ).toBeVisible();
+        });
+
+        it('displays "Executed" when the output has an execution transaction hash', () => {
+            setupMocks({ epochStatus: "CLAIM_ACCEPTED" });
+            render(
+                <OutputExecution
+                    output={buildOutput({ executionTransactionHash: TX_HASH })}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByText(content.output.voucher.executed),
+            ).toBeVisible();
+        });
+    });
+
+    describe("execute button disabled state", () => {
+        it("is disabled when the output is already executed on-chain", () => {
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: true,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByRole("button", {
+                    name: content.output.voucher.executed,
+                }),
+            ).toBeDisabled();
+        });
+
+        it("is disabled when there are wagmi errors", () => {
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+                simulateError: Object.assign(new Error("Simulate failed"), {
+                    shortMessage: "Simulate failed",
+                }),
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByRole("button", {
+                    name: content.output.voucher.execute,
+                }),
+            ).toBeDisabled();
+        });
+
+        it("is disabled while simulation is fetching", () => {
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+                simulateIsFetching: true,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.getByRole("button", {
+                    name: content.output.voucher.preparing,
+                }),
+            ).toBeDisabled();
+        });
+    });
+
+    describe("execute button click", () => {
+        it("opens the connect modal when clicked by a disconnected user", () => {
+            const { openConnectModal } = setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                isConnected: false,
+                wasOutputExecuted: false,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            fireEvent.click(
+                screen.getByRole("button", {
+                    name: content.output.voucher.execute,
+                }),
+            );
+
+            expect(openConnectModal).toHaveBeenCalledTimes(1);
+        });
+
+        it("opens the chain modal when the connected user needs to switch networks", () => {
+            const { openChainModal } = setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                isConnected: true,
+                chain: null,
+                wasOutputExecuted: false,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            fireEvent.click(
+                screen.getByRole("button", {
+                    name: content.output.voucher.execute,
+                }),
+            );
+
+            expect(openChainModal).toHaveBeenCalledTimes(1);
+        });
+
+        it("calls writeContract when user is connected and simulation data is available", () => {
+            const request = { address: APPLICATION, data: "0x" as Hex };
+            const { writeContract } = setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                isConnected: true,
+                chain: mainnet,
+                wasOutputExecuted: false,
+                simulateData: { request },
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            fireEvent.click(
+                screen.getByRole("button", {
+                    name: content.output.voucher.execute,
+                }),
+            );
+
+            expect(writeContract).toHaveBeenCalledWith(request);
+        });
+    });
+
+    describe("execution transaction hash", () => {
+        it("displays the transaction hash when the output was executed via L2 (as text for devnet)", () => {
+            setupMocks({ epochStatus: "CLAIM_ACCEPTED", chain: foundry });
+            render(
+                <OutputExecution
+                    output={buildOutput({ executionTransactionHash: TX_HASH })}
+                    application={APPLICATION}
+                />,
+            );
+
+            const txHashElement = screen.getByText(shortenHash(TX_HASH));
+            expect(txHashElement).toBeVisible();
+            expect(txHashElement.closest("a")).toBeNull();
+        });
+
+        it("displays the transaction hash when the output was executed via L2 (as anchor for mainnet/testnet)", () => {
+            setupMocks({ epochStatus: "CLAIM_ACCEPTED", chain: mainnet });
+            render(
+                <OutputExecution
+                    output={buildOutput({ executionTransactionHash: TX_HASH })}
+                    application={APPLICATION}
+                />,
+            );
+
+            const txHashElement = screen.getByText(shortenHash(TX_HASH));
+            expect(txHashElement).toBeVisible();
+            expect(txHashElement.closest("a")).toHaveAttribute(
+                "href",
+                `https://etherscan.io/tx/${TX_HASH}`,
+            );
+        });
+
+        it("does not display a transaction hash when executionTransactionHash is null", () => {
+            setupMocks({ epochStatus: "CLAIM_ACCEPTED" });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(
+                screen.queryByText(shortenHash(TX_HASH)),
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    describe("error display", () => {
+        it("shows an alert when the simulation step fails", () => {
+            const errorMessage = "User rejected the request.";
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+                simulateError: Object.assign(new Error(errorMessage), {
+                    shortMessage: errorMessage,
+                }),
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(screen.getByText(errorMessage)).toBeVisible();
+        });
+
+        it("shows an alert when the on-chain execution check fails", () => {
+            const errorMessage = "Failed to read contract.";
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                checkingOutputExecutedError: Object.assign(
+                    new Error(errorMessage),
+                    { shortMessage: errorMessage },
+                ),
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            expect(screen.getByText(errorMessage)).toBeVisible();
+        });
+    });
+
+    describe("onError callback", () => {
+        it("is invoked with the list of errors when errors are present", () => {
+            const onError = vi.fn();
+            const errorMessage = "Contract simulation failed.";
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+                simulateError: Object.assign(new Error(errorMessage), {
+                    shortMessage: errorMessage,
+                }),
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                    onError={onError}
+                />,
+            );
+
+            expect(onError).toHaveBeenCalledTimes(1);
+            expect(onError.mock.calls[0][0]).toHaveLength(1);
+        });
+
+        it("is not invoked when there are no errors", () => {
+            const onError = vi.fn();
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                    onError={onError}
+                />,
+            );
+
+            expect(onError).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("onSuccess callback", () => {
+        it("is invoked with the transaction receipt after successful execution", async () => {
+            const onSuccess = vi.fn();
+            const txReceipt = { transactionHash: TX_HASH };
+            setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+                waitIsSuccess: true,
+                waitData: txReceipt,
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                    onSuccess={onSuccess}
+                />,
+            );
+
+            await waitFor(() =>
+                expect(onSuccess).toHaveBeenCalledWith(txReceipt),
+            );
+        });
+
+        it("invalidates the outputs query after successful execution", async () => {
+            const { invalidateQueries } = setupMocks({
+                epochStatus: "CLAIM_ACCEPTED",
+                wasOutputExecuted: false,
+                waitIsSuccess: true,
+                waitData: { transactionHash: TX_HASH },
+            });
+            render(
+                <OutputExecution
+                    output={buildOutput()}
+                    application={APPLICATION}
+                />,
+            );
+
+            await waitFor(() =>
+                expect(invalidateQueries).toHaveBeenCalledWith(
+                    expect.objectContaining({ queryKey: ["outputs"] }),
+                ),
+            );
+        });
+    });
+});

--- a/apps/explorer/test/components/send/SendMenu.test.tsx
+++ b/apps/explorer/test/components/send/SendMenu.test.tsx
@@ -1,30 +1,30 @@
-import type { Application } from "@cartesi/viem";
-import { useDisclosure } from "@mantine/hooks";
 import {
     useChainModal,
     useConnectModal,
     type Chain,
 } from "@rainbow-me/rainbowkit";
-import { zeroHash } from "viem";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Address } from "abitype";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAccount } from "wagmi";
 import { mainnet } from "wagmi/chains";
 import type { DbNodeConnectionConfig } from "../../../src/components/connection/types";
 import SendMenu from "../../../src/components/send/SendMenu";
-import { fireEvent, render, screen } from "../../test-utils";
+import { content } from "../../../src/content";
+import {
+    createApplication,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from "../../test-utils";
 
 const mocks = vi.hoisted(() => ({
-    useDisclosure: vi.fn(),
     useAccount: vi.fn(),
     useConnectModal: vi.fn(),
     useChainModal: vi.fn(),
     useSelectedNodeConnection: vi.fn(),
     useSpecification: vi.fn(),
     useSendAction: vi.fn(),
-}));
-
-vi.mock("@mantine/hooks", () => ({
-    useDisclosure: mocks.useDisclosure,
 }));
 
 vi.mock("wagmi", () => ({
@@ -48,67 +48,23 @@ vi.mock("../../../src/components/send/hooks", () => ({
     useSendAction: mocks.useSendAction,
 }));
 
-const mockUseDisclosure = vi.mocked(useDisclosure, { partial: true });
 const mockUseAccount = vi.mocked(useAccount, { partial: true });
 const mockUseConnectModal = vi.mocked(useConnectModal, { partial: true });
 const mockUseChainModal = vi.mocked(useChainModal, { partial: true });
 
-type ApplicationOverrides = Partial<
-    Pick<
-        Application,
-        | "applicationAddress"
-        | "forecloseBlock"
-        | "forecloseTransaction"
-        | "name"
-    >
->;
-
-const createApplication = (overrides?: ApplicationOverrides) =>
-    ({
-        name: "My App",
-        applicationAddress: "0x1234567890abcdef1234567890abcdef12345678",
-        forecloseBlock: 0n,
-        forecloseTransaction: zeroHash,
-        ...overrides,
-    }) as Application;
-
-const setupDisclosures = ({
-    menuOpened = false,
-    tooltipOpened = false,
-}: {
-    menuOpened?: boolean;
-    tooltipOpened?: boolean;
-}) => {
-    const menuHandlers = {
-        open: vi.fn(),
-        close: vi.fn(),
-        toggle: vi.fn(),
-    };
-    const tooltipHandlers = {
-        open: vi.fn(),
-        close: vi.fn(),
-        toggle: vi.fn(),
-    };
-
-    mockUseDisclosure.mockReset();
-    mockUseDisclosure
-        .mockImplementationOnce(() => [menuOpened, menuHandlers] as const)
-        .mockImplementationOnce(
-            () => [tooltipOpened, tooltipHandlers] as const,
-        );
-
-    return { menuHandlers, tooltipHandlers };
-};
+const guardianAddress = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as const;
 
 const setupCommonMocks = ({
     selectedConnection,
     isConnected,
     chain,
+    address,
     listSpecifications = () => [],
 }: {
     selectedConnection: { type: DbNodeConnectionConfig["type"] } | null;
     isConnected: boolean;
     chain?: Chain;
+    address?: Address;
     listSpecifications?: () => Array<{ id: string; mode: string }>;
 }) => {
     const connectModal = {
@@ -124,11 +80,13 @@ const setupCommonMocks = ({
         depositErc721: vi.fn(),
         depositErc1155Single: vi.fn(),
         depositErc1155Batch: vi.fn(),
+        foreclose: vi.fn(),
     };
 
     mockUseAccount.mockReturnValue({
         isConnected,
         chain,
+        address,
     });
 
     mockUseConnectModal.mockReturnValue(connectModal);
@@ -150,26 +108,22 @@ describe("SendMenu", () => {
         vi.clearAllMocks();
     });
 
-    test("should render nothing when the selected node is a system mock", () => {
+    it("should render nothing when the selected node is a system mock", () => {
         setupCommonMocks({
             selectedConnection: { type: "system_mock" },
             isConnected: false,
         });
-
-        setupDisclosures({});
 
         render(<SendMenu application={createApplication()} />);
 
         expect(screen.queryByText("Send")).not.toBeInTheDocument();
     });
 
-    test("should open the connect modal when the user is disconnected", () => {
+    it("should open the connect modal when the user is disconnected", () => {
         const { connectModal } = setupCommonMocks({
             selectedConnection: { type: "system" },
             isConnected: false,
         });
-
-        setupDisclosures({});
 
         render(<SendMenu application={createApplication()} />);
 
@@ -178,14 +132,12 @@ describe("SendMenu", () => {
         expect(connectModal.openConnectModal).toHaveBeenCalledTimes(1);
     });
 
-    test("should open the chain modal when the user needs to switch networks", () => {
+    it("should open the chain modal when the user needs to switch networks", () => {
         const { chainModal } = setupCommonMocks({
             selectedConnection: { type: "system" },
             isConnected: true,
             chain: undefined,
         });
-
-        setupDisclosures({});
 
         render(<SendMenu application={createApplication()} />);
 
@@ -194,9 +146,7 @@ describe("SendMenu", () => {
         expect(chainModal.openChainModal).toHaveBeenCalledTimes(1);
     });
 
-    test("Should toggle the tooltip for foreclosed applications", () => {
-        const { tooltipHandlers } = setupDisclosures({});
-
+    it("should show the foreclosure tooltip when clicking Send on a foreclosed application", () => {
         setupCommonMocks({
             selectedConnection: { type: "system" },
             isConnected: true,
@@ -215,11 +165,10 @@ describe("SendMenu", () => {
 
         fireEvent.click(screen.getByText("Send"));
 
-        expect(tooltipHandlers.toggle).toHaveBeenCalledTimes(1);
+        expect(screen.getByText(content.foreclose.sendTooltip)).toBeVisible();
     });
 
-    test("should toggle the menu when the user can send", () => {
-        const { menuHandlers } = setupDisclosures({});
+    it("should open the menu when the user can send", async () => {
         setupCommonMocks({
             selectedConnection: { type: "system" },
             isConnected: true,
@@ -230,11 +179,17 @@ describe("SendMenu", () => {
 
         fireEvent.click(screen.getByText("Send"));
 
-        expect(menuHandlers.toggle).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(screen.getByRole("menu")).toBeVisible());
+
+        expect(screen.getByText("Ether")).toBeVisible();
+        expect(screen.getByText("ERC-20")).toBeVisible();
+        expect(screen.getByText("ERC-721")).toBeVisible();
+        expect(screen.getByText("ERC-1155 (Single)")).toBeVisible();
+        expect(screen.getByText("ERC-1155 (Batch)")).toBeVisible();
+        expect(screen.getByText("Input")).toBeVisible();
     });
 
-    test("should dispatch the input action with json ABI specifications", () => {
-        const { menuHandlers } = setupDisclosures({ menuOpened: true });
+    it("should dispatch the input action with json ABI specifications", async () => {
         const listSpecifications = vi.fn(() => [
             { id: "1", mode: "json_abi" },
             { id: "2", mode: "abi_params" },
@@ -248,6 +203,13 @@ describe("SendMenu", () => {
         });
 
         render(<SendMenu application={createApplication()} />);
+
+        fireEvent.click(screen.getByText("Send"));
+
+        await waitFor(() => {
+            expect(screen.getByText("Input")).toBeVisible();
+        });
+
         fireEvent.click(screen.getByText("Input"));
 
         expect(actions.sendGenericInput).toHaveBeenCalledWith(
@@ -256,11 +218,10 @@ describe("SendMenu", () => {
             }),
             [{ id: "1", mode: "json_abi" }],
         );
-        expect(menuHandlers.close).toHaveBeenCalled();
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
 
-    test("should dispatch the deposit actions from the menu", () => {
-        const { menuHandlers } = setupDisclosures({ menuOpened: true });
+    it("should dispatch the deposit actions from the menu", async () => {
         const { actions } = setupCommonMocks({
             selectedConnection: { type: "system" },
             isConnected: true,
@@ -269,10 +230,28 @@ describe("SendMenu", () => {
 
         render(<SendMenu application={createApplication()} />);
 
+        fireEvent.click(screen.getByText("Send"));
+        await waitFor(() => expect(screen.getByText("Ether")).toBeVisible());
         fireEvent.click(screen.getByText("Ether"));
+
+        fireEvent.click(screen.getByText("Send"));
+        await waitFor(() => expect(screen.getByText("ERC-20")).toBeVisible());
         fireEvent.click(screen.getByText("ERC-20"));
+
+        fireEvent.click(screen.getByText("Send"));
+        await waitFor(() => expect(screen.getByText("ERC-721")).toBeVisible());
         fireEvent.click(screen.getByText("ERC-721"));
+
+        fireEvent.click(screen.getByText("Send"));
+        await waitFor(() =>
+            expect(screen.getByText("ERC-1155 (Single)")).toBeVisible(),
+        );
         fireEvent.click(screen.getByText("ERC-1155 (Single)"));
+
+        fireEvent.click(screen.getByText("Send"));
+        await waitFor(() =>
+            expect(screen.getByText("ERC-1155 (Batch)")).toBeVisible(),
+        );
         fireEvent.click(screen.getByText("ERC-1155 (Batch)"));
 
         expect(actions.depositEth).toHaveBeenCalledTimes(1);
@@ -280,6 +259,155 @@ describe("SendMenu", () => {
         expect(actions.depositErc721).toHaveBeenCalledTimes(1);
         expect(actions.depositErc1155Single).toHaveBeenCalledTimes(1);
         expect(actions.depositErc1155Batch).toHaveBeenCalledTimes(1);
-        expect(menuHandlers.close).toHaveBeenCalled();
+    });
+
+    describe("Foreclose workflow", () => {
+        const guardianApplication = createApplication({
+            withdrawalConfig: {
+                guardian: guardianAddress,
+                log2LeavesPerAccount: 0n,
+                log2MaxNumOfAccounts: 0n,
+                accountsDriveStartIndex: 0n,
+                withdrawalOutputBuilder:
+                    "0x0000000000000000000000000000000000000000",
+            },
+        });
+
+        it("should not show the Foreclose menu item for non-guardian users", async () => {
+            setupCommonMocks({
+                selectedConnection: { type: "system" },
+                isConnected: true,
+                chain: mainnet,
+                address: "0x1111111111111111111111111111111111111111",
+            });
+
+            render(<SendMenu application={guardianApplication} />);
+
+            fireEvent.click(screen.getByText("Send"));
+
+            await waitFor(() =>
+                expect(screen.getByText("Ether")).toBeVisible(),
+            );
+            expect(screen.queryByText("Foreclose")).not.toBeInTheDocument();
+        });
+
+        it("should show the Foreclose menu item for connected guardian account", async () => {
+            setupCommonMocks({
+                selectedConnection: { type: "system" },
+                isConnected: true,
+                chain: mainnet,
+                address: guardianAddress,
+            });
+
+            render(<SendMenu application={guardianApplication} />);
+
+            fireEvent.click(screen.getByText("Send"));
+
+            await waitFor(() =>
+                expect(screen.getByText("Foreclose")).toBeVisible(),
+            );
+        });
+
+        it("should open the confirmation modal when Foreclose is clicked", async () => {
+            setupCommonMocks({
+                selectedConnection: { type: "system" },
+                isConnected: true,
+                chain: mainnet,
+                address: guardianAddress,
+            });
+
+            render(<SendMenu application={guardianApplication} />);
+
+            fireEvent.click(screen.getByText("Send"));
+
+            await waitFor(() =>
+                expect(screen.getByText("Foreclose")).toBeVisible(),
+            );
+
+            fireEvent.click(screen.getByText("Foreclose"));
+
+            await waitFor(() =>
+                expect(
+                    screen.getByText("Are you sure you want to foreclose?"),
+                ).toBeVisible(),
+            );
+
+            expect(
+                screen.getByText(
+                    "It is an irreversible action that prevents any further deposits or inputs to the application.",
+                ),
+            ).toBeVisible();
+
+            expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+        });
+
+        it("should call foreclose action when the user confirms to proceed", async () => {
+            const { actions } = setupCommonMocks({
+                selectedConnection: { type: "system" },
+                isConnected: true,
+                chain: mainnet,
+                address: guardianAddress,
+            });
+
+            render(<SendMenu application={guardianApplication} />);
+
+            fireEvent.click(screen.getByText("Send"));
+            await waitFor(() =>
+                expect(screen.getByText("Foreclose")).toBeVisible(),
+            );
+
+            fireEvent.click(screen.getByText("Foreclose"));
+
+            await waitFor(() =>
+                expect(
+                    screen.getByText("Are you sure you want to foreclose?"),
+                ).toBeVisible(),
+            );
+
+            fireEvent.click(screen.getByText("Confirm"));
+
+            await waitFor(() =>
+                expect(
+                    screen.queryByText("Are you sure you want to foreclose?"),
+                ).not.toBeInTheDocument(),
+            );
+
+            expect(actions.foreclose).toHaveBeenCalledWith(guardianApplication);
+        });
+
+        it("should not call foreclose action when the confirmation modal is cancelled", async () => {
+            const { actions } = setupCommonMocks({
+                selectedConnection: { type: "system" },
+                isConnected: true,
+                chain: mainnet,
+                address: guardianAddress,
+            });
+
+            render(<SendMenu application={guardianApplication} />);
+
+            fireEvent.click(screen.getByText("Send"));
+
+            await waitFor(() =>
+                expect(screen.getByText("Foreclose")).toBeVisible(),
+            );
+
+            fireEvent.click(screen.getByText("Foreclose"));
+
+            await waitFor(() =>
+                expect(
+                    screen.getByText("Are you sure you want to foreclose?"),
+                ).toBeVisible(),
+            );
+
+            fireEvent.click(screen.getByText("Cancel"));
+
+            await waitFor(() =>
+                expect(
+                    screen.queryByText("Are you sure you want to foreclose?"),
+                ).not.toBeInTheDocument(),
+            );
+
+            expect(actions.foreclose).not.toHaveBeenCalled();
+        });
     });
 });

--- a/apps/explorer/test/components/transactions/ForecloseForm/index.test.tsx
+++ b/apps/explorer/test/components/transactions/ForecloseForm/index.test.tsx
@@ -1,0 +1,246 @@
+import {
+    useReadApplicationIsForeclosed,
+    useSimulateApplicationForeclose,
+    useWriteApplicationForeclose,
+} from "@cartesi/wagmi";
+import type { WriteContractErrorType } from "viem/actions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAccount, useWaitForTransactionReceipt } from "wagmi";
+import type { SimulateContractErrorType } from "wagmi/actions";
+import { ForecloseForm } from "../../../../src/components/transactions/ForecloseForm";
+import { content } from "../../../../src/content";
+import {
+    createApplication,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from "../../../test-utils";
+
+const mocks = vi.hoisted(() => ({
+    useReadApplicationIsForeclosed: vi.fn(),
+    useSimulateApplicationForeclose: vi.fn(),
+    useWriteApplicationForeclose: vi.fn(),
+    useAccount: vi.fn(),
+    useWaitForTransactionReceipt: vi.fn(),
+}));
+
+vi.mock("@cartesi/wagmi", () => ({
+    useReadApplicationIsForeclosed: mocks.useReadApplicationIsForeclosed,
+    useSimulateApplicationForeclose: mocks.useSimulateApplicationForeclose,
+    useWriteApplicationForeclose: mocks.useWriteApplicationForeclose,
+}));
+
+vi.mock("wagmi", () => ({
+    useAccount: mocks.useAccount,
+    useWaitForTransactionReceipt: mocks.useWaitForTransactionReceipt,
+}));
+
+const mockUseReadIsForeclosed = vi.mocked(useReadApplicationIsForeclosed, {
+    partial: true,
+});
+const mockUseSimulateForeclose = vi.mocked(useSimulateApplicationForeclose, {
+    partial: true,
+});
+const mockUseWriteForeclose = vi.mocked(useWriteApplicationForeclose, {
+    partial: true,
+});
+const mockUseAccount = vi.mocked(useAccount, { partial: true });
+const mockUseWaitForTx = vi.mocked(useWaitForTransactionReceipt, {
+    partial: true,
+});
+
+const mockApplication = createApplication();
+
+const setupCommonMocks = () => {
+    const refetch = vi.fn();
+    const writeContract = vi.fn();
+    const reset = vi.fn();
+
+    mockUseAccount.mockReturnValue({ address: "0xaddress" });
+
+    mockUseReadIsForeclosed.mockReturnValue({
+        data: false,
+        isLoading: false,
+        refetch,
+    });
+
+    mockUseSimulateForeclose.mockReturnValue({
+        data: { request: {} },
+        isLoading: false,
+        error: null,
+    });
+
+    mockUseWriteForeclose.mockReturnValue({
+        writeContract,
+        data: undefined,
+        isPending: false,
+        isSuccess: false,
+        isError: false,
+        reset,
+    });
+
+    mockUseWaitForTx.mockReturnValue({
+        isLoading: false,
+        isSuccess: false,
+    });
+
+    return { refetch, writeContract, reset };
+};
+
+describe("ForecloseForm", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("should disable the Foreclose button when the application is already foreclosed and change the button text to 'Foreclosed'", () => {
+        setupCommonMocks();
+        mockUseReadIsForeclosed.mockReturnValue({
+            data: true,
+            isLoading: false,
+            refetch: vi.fn(),
+        });
+
+        render(
+            <ForecloseForm application={mockApplication} onSuccess={vi.fn()} />,
+        );
+
+        expect(
+            screen.getByRole("button", {
+                name: content.foreclose.foreclosedTxt,
+            }),
+        ).toBeDisabled();
+    });
+
+    it("should disable the Foreclose button when the simulate call fails", async () => {
+        setupCommonMocks();
+        mockUseSimulateForeclose.mockReturnValue({
+            data: null,
+            isLoading: false,
+            isError: true,
+            error: new Error(
+                "Simulate error while foreclosing",
+            ) as SimulateContractErrorType,
+        });
+
+        render(
+            <ForecloseForm application={mockApplication} onSuccess={vi.fn()} />,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId("foreclose-progress")).toBeVisible(),
+        );
+
+        expect(screen.getByText("Transaction failed")).toBeVisible();
+
+        fireEvent.click(
+            screen.getByTestId("transaction-progress-error-toggle"),
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.getByText("Simulate error while foreclosing"),
+            ).toBeVisible(),
+        );
+
+        expect(
+            screen.getByRole("button", {
+                name: content.foreclose.forecloseTxt,
+            }),
+        ).toBeDisabled();
+    });
+
+    it("should display the error message when the execute call fails", () => {
+        const { writeContract } = setupCommonMocks();
+        mockUseWriteForeclose.mockReturnValue({
+            writeContract,
+            data: undefined,
+            isPending: false,
+            isSuccess: false,
+            isError: true,
+            error: {
+                message: "Execution reverted with message xpto",
+            } as WriteContractErrorType,
+            reset: vi.fn(),
+        });
+
+        render(
+            <ForecloseForm application={mockApplication} onSuccess={vi.fn()} />,
+        );
+
+        fireEvent.click(
+            screen.getByRole("button", {
+                name: content.foreclose.forecloseTxt,
+            }),
+        );
+
+        expect(writeContract).toHaveBeenCalled();
+        // TransactionProgress renders the error message in multiple places
+        expect(
+            screen.getAllByText("Execution reverted with message xpto")[0],
+        ).toBeInTheDocument();
+    });
+
+    it("should call onSuccess with the correct data when the foreclose transaction succeeds", () => {
+        const { refetch, reset } = setupCommonMocks();
+        const receipt = { status: "success" };
+
+        mockUseWriteForeclose.mockReturnValue({
+            writeContract: vi.fn(),
+            data: "0x12345678901234567890123456789012345678901234567890123456789012345",
+            isPending: false,
+            isSuccess: true,
+            isError: false,
+            reset,
+        });
+
+        mockUseWaitForTx.mockReturnValue({
+            data: receipt,
+            isLoading: false,
+            isSuccess: true,
+        });
+
+        const onSuccess = vi.fn();
+
+        render(
+            <ForecloseForm
+                application={mockApplication}
+                onSuccess={onSuccess}
+            />,
+        );
+
+        expect(onSuccess).toHaveBeenCalledWith({
+            receipt,
+            type: "FORECLOSE",
+            message: content.foreclose.generic.txSuccess,
+        });
+        expect(refetch).toHaveBeenCalled();
+        expect(reset).toHaveBeenCalled();
+    });
+
+    it("should display the application address upon opening the form", () => {
+        setupCommonMocks();
+
+        render(
+            <ForecloseForm application={mockApplication} onSuccess={vi.fn()} />,
+        );
+
+        expect(screen.getByText("Application Address")).toBeVisible();
+        expect(
+            screen.getByText(mockApplication.applicationAddress),
+        ).toBeVisible();
+    });
+
+    it("should display the foreclosure info warning message", () => {
+        setupCommonMocks();
+
+        render(
+            <ForecloseForm application={mockApplication} onSuccess={vi.fn()} />,
+        );
+
+        expect(screen.getByText(content.global.alert.reminder)).toBeVisible();
+        expect(
+            screen.getByText(content.foreclose.foreclosingWarning),
+        ).toBeVisible();
+    });
+});

--- a/apps/explorer/test/test-utils.tsx
+++ b/apps/explorer/test/test-utils.tsx
@@ -1,10 +1,16 @@
 /* eslint-disable react-refresh/only-export-components */
+import type { Application } from "@cartesi/viem";
 import { MantineProvider } from "@mantine/core";
 import { render, type RenderOptions } from "@testing-library/react";
+import { zeroHash } from "viem";
 import theme from "../src/providers/theme";
 
 const WithProviders = ({ children }: { children: React.ReactNode }) => {
-    return <MantineProvider theme={theme}>{children}</MantineProvider>;
+    return (
+        <MantineProvider theme={theme} env="test">
+            {children}
+        </MantineProvider>
+    );
 };
 
 const customRender = (
@@ -14,3 +20,23 @@ const customRender = (
 
 export * from "@testing-library/react";
 export { customRender as render };
+
+type ApplicationOverrides = Partial<
+    Pick<
+        Application,
+        | "applicationAddress"
+        | "forecloseBlock"
+        | "forecloseTransaction"
+        | "name"
+        | "withdrawalConfig"
+    >
+>;
+
+export const createApplication = (overrides?: ApplicationOverrides) =>
+    ({
+        name: "My App",
+        applicationAddress: "0x1234567890abcdef1234567890abcdef12345678",
+        forecloseBlock: 0n,
+        forecloseTransaction: zeroHash,
+        ...overrides,
+    }) as Application;


### PR DESCRIPTION
# Summary 
The Cartesi rollups contracts expose a foreclosure operation meant for guardian-configured applications. This PR brings that capability into the explorer UI with appropriate safeguards (confirmation modal, irreversible-action warnings). Also, refactored the output execution component to correctly reflect all possible epoch states and to provide information about its execution for epochs that have status `claim_foreclosed`. 


PS: For the lookback test the reviewer can use the following deployed instances. 

**Current**: https://dave-demo.cartesi.io/
**Preview**: https://dave-git-feat-add-foreclose-capability-for-confi-af9017-cartesi.vercel.app/

Tip: use `cartesi/cli`, as it already has CORS configured at the proxy level for ease of testing.


## What changed

### Foreclose action
- Added a **Foreclose** option to the `Send Menu` (located in the home page in the application card), allowing a configured guardian to foreclose an application directly from the UI.
- Introduced a `ForecloseForm` component that handles the full transaction flow (simulate → write → wait for receipt).
- Added a `ConfirmationModal` component to gate irreversible actions behind an explicit user confirmation step, used by the foreclose flow.

### Output execution improvements
- Refactored `OutputExecution` to surface richer epoch-status feedback: a badge is shown while the claim is pending, and a distinct **foreclosed** state is shown when execution is no longer possible.
- Removed the epoch-status polling loop from `OutputExecution` — epoch state is now driven reactively without a client-side interval. 

### Content / copy consolidation

- Extracted UI strings into a structured `content` object (`forecloseMessages`, `globalMessages`, `outputMessages`) so copy lives in one place and components stay free of hardcoded strings. **_PS: This is a continuing effort._**

### CSP fix
- Removed `upgrade-insecure-requests` from the Content Security Policy and replaced the broad `http:` scheme source with explicit loopback origins (`http://localhost:*`, `http://127.0.0.1:*`, `ws://localhost:*`, `ws://127.0.0.1:*`). This allows users on deployed HTTPS instances to connect a local node without the browser silently rewriting their `http://localhost` URL to `https://localhost` and failing the TLS handshake.

### Tests
- Added OutputExecution.test.tsx covering feedback badges, button states, wallet interactions, error display, and success/error callbacks.
- Extended SendMenu.test.tsx to cover the new foreclose path and confirmation modal integration.
- Added test cases for the new `ForecloseForm`.
